### PR TITLE
fix: publish only the web project to prevent deployment failure

### DIFF
--- a/.github/workflows/main_paceletics.yml
+++ b/.github/workflows/main_paceletics.yml
@@ -27,7 +27,7 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish PaceLetics.Web/PaceLetics.Web.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The dotnet publish command ran without specifying a project, causing all solution projects to publish into the same output directory. The last project to write overwrote the web app entry point, so Azure App Service showed the default placeholder page instead of the app.