### PR TITLE
Add Cosmos-backed courses

### DIFF
--- a/AthleteDataAccessLibrary/AthleteDataOptions.cs
+++ b/AthleteDataAccessLibrary/AthleteDataOptions.cs
@@ -8,6 +8,8 @@ public sealed class AthleteDataOptions
 
     public string AthleteContainerName { get; set; } = "athletedata";
 
+    public string CourseContainerName { get; set; } = "courses";
+
     public void Validate()
     {
         if (string.IsNullOrWhiteSpace(DatabaseName))
@@ -15,6 +17,9 @@ public sealed class AthleteDataOptions
 
         if (string.IsNullOrWhiteSpace(AthleteContainerName))
             throw new InvalidOperationException("AthleteData:AthleteContainerName must be configured.");
+
+        if (string.IsNullOrWhiteSpace(CourseContainerName))
+            throw new InvalidOperationException("AthleteData:CourseContainerName must be configured.");
 
     }
 }

--- a/AthleteDataAccessLibrary/Contracts/IDataAccess.cs
+++ b/AthleteDataAccessLibrary/Contracts/IDataAccess.cs
@@ -14,6 +14,10 @@ namespace AthleteDataAccessLibrary.Contracts
         /// <returns></returns>
         Task<List<T>> LoadData<T>(string cosmosDb, string container);
 
+        Task<List<T>> LoadData<T>(string cosmosDb, string container, string documentType);
+
+        Task<List<T>> LoadPartitionData<T>(string cosmosDb, string container, string partitionKeyValue, string documentType);
+
         /// <summary>
         /// 
         /// </summary>
@@ -25,6 +29,8 @@ namespace AthleteDataAccessLibrary.Contracts
         /// <returns></returns>
         Task<T?> LoadItem<T>(string cosmosDb, string container, string id) where T : IQueryItem;
 
+        Task<T?> LoadItem<T>(string cosmosDb, string container, string id, string partitionKeyValue) where T : IQueryItem;
+
 
         /// <summary>
         /// 
@@ -34,6 +40,8 @@ namespace AthleteDataAccessLibrary.Contracts
         /// <param name="id"></param>
         /// <returns></returns>
         Task DeleteItem<T>(string cosmosDb, string container, string id);
+
+        Task DeleteItem<T>(string cosmosDb, string container, string id, string partitionKeyValue);
 
 
         /// <summary>
@@ -45,6 +53,8 @@ namespace AthleteDataAccessLibrary.Contracts
         /// <param name="parameter"></param>
         /// <returns></returns>
         Task UpsertItem<T>(string cosmosDb, string containerId, T parameter);
+
+        Task UpsertItem<T>(string cosmosDb, string containerId, T parameter, string partitionKeyValue);
 
 
         /// <summary>

--- a/AthleteDataAccessLibrary/DataAccess.cs
+++ b/AthleteDataAccessLibrary/DataAccess.cs
@@ -43,6 +43,26 @@ namespace AthleteDataAccessLibrary
 			return results;
 		}
 
+		public Task<List<T>> LoadData<T>(string cosmosDb, string container, string documentType)
+		{
+			var query = new QueryDefinition("SELECT * FROM c WHERE c.documentType = @documentType")
+				.WithParameter("@documentType", documentType);
+
+			return QueryItems<T>(cosmosDb, container, query);
+		}
+
+		public Task<List<T>> LoadPartitionData<T>(string cosmosDb, string container, string partitionKeyValue, string documentType)
+		{
+			var query = new QueryDefinition("SELECT * FROM c WHERE c.documentType = @documentType")
+				.WithParameter("@documentType", documentType);
+
+			return QueryItems<T>(
+				cosmosDb,
+				container,
+				query,
+				new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKeyValue) });
+		}
+
 		public async Task<T?> LoadItem<T>(string cosmosDb, string container, string id) where T : IQueryItem
 		{
             var containerAccess =  _client.GetContainer(cosmosDb, container);
@@ -52,12 +72,33 @@ namespace AthleteDataAccessLibrary
 			return result.FirstOrDefault();
         }
 
+		public async Task<T?> LoadItem<T>(string cosmosDb, string container, string id, string partitionKeyValue) where T : IQueryItem
+		{
+			var containerAccess = _client.GetContainer(cosmosDb, container);
+
+			try
+			{
+				var response = await containerAccess.ReadItemAsync<T>(id, new PartitionKey(partitionKeyValue));
+				return response.Resource;
+			}
+			catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+			{
+				return default;
+			}
+		}
+
 
 		public async Task DeleteItem<T>(string cosmosDb, string container, string id) 
 		{
             var containerAccess = _client.GetContainer(cosmosDb, container);
             await containerAccess.DeleteItemAsync<T>(id, PartitionKey.None);
         }
+
+		public async Task DeleteItem<T>(string cosmosDb, string container, string id, string partitionKeyValue)
+		{
+			var containerAccess = _client.GetContainer(cosmosDb, container);
+			await containerAccess.DeleteItemAsync<T>(id, new PartitionKey(partitionKeyValue));
+		}
 
 
 		public async Task SaveData<T>(string comsosDb, string container, T parameter)
@@ -72,5 +113,32 @@ namespace AthleteDataAccessLibrary
             var containerAccess = _client.GetContainer(cosmosDb, container);
             await containerAccess.UpsertItemAsync(parameter);
         }
+
+		public async Task UpsertItem<T>(string cosmosDb, string container, T parameter, string partitionKeyValue)
+		{
+			var containerAccess = _client.GetContainer(cosmosDb, container);
+			await containerAccess.UpsertItemAsync(parameter, new PartitionKey(partitionKeyValue));
+		}
+
+		private async Task<List<T>> QueryItems<T>(
+			string cosmosDb,
+			string container,
+			QueryDefinition query,
+			QueryRequestOptions? options = null)
+		{
+			var containerAccess = _client.GetContainer(cosmosDb, container);
+			var iterator = containerAccess.GetItemQueryIterator<T>(query, requestOptions: options);
+			var results = new List<T>();
+
+			while (iterator.HasMoreResults)
+			{
+				foreach (var item in await iterator.ReadNextAsync())
+				{
+					results.Add(item);
+				}
+			}
+
+			return results;
+		}
     }
 }

--- a/PaceLetics.Tests/CourseServiceTests.cs
+++ b/PaceLetics.Tests/CourseServiceTests.cs
@@ -1,0 +1,172 @@
+using PaceLetics.Web.Services.Courses;
+
+namespace PaceLetics.Tests;
+
+public sealed class CourseServiceTests
+{
+    [Fact]
+    public async Task JoinCourse_CreatesActiveEnrollment()
+    {
+        var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
+        var service = new CourseService(repository);
+
+        var enrollment = await service.JoinCourseAsync("course-1", "athlete-1");
+
+        Assert.Equal("course-1", enrollment.CourseId);
+        Assert.Equal("athlete-1", enrollment.AthleteUserId);
+        Assert.Equal(CourseEnrollmentStatus.Active, enrollment.Status);
+    }
+
+    [Fact]
+    public async Task GetPublishedTrainingPlanIdsForAthlete_ReturnsPlansFromJoinedCourses()
+    {
+        var repository = new InMemoryCourseRepository(
+            CreateCourse("course-1", "plan-1"),
+            CreateCourse("course-2", "plan-2"));
+        var service = new CourseService(repository);
+        await service.JoinCourseAsync("course-2", "athlete-1");
+
+        var planIds = await service.GetPublishedTrainingPlanIdsForAthleteAsync("athlete-1");
+
+        Assert.Equal(new[] { "plan-2" }, planIds);
+    }
+
+    [Fact]
+    public async Task RegisterForEvent_RequiresCourseEnrollment()
+    {
+        var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
+        repository.Events.Add(new CourseEventDocument
+        {
+            Id = "event-1",
+            CourseId = "course-1",
+            Title = "Startanalyse",
+            StartsAt = DateTime.UtcNow.AddDays(1),
+            EndsAt = DateTime.UtcNow.AddDays(1).AddHours(1)
+        });
+        var service = new CourseService(repository);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.RegisterForEventAsync("course-1", "event-1", "athlete-1"));
+    }
+
+    private static CourseDocument CreateCourse(string courseId, string planId)
+    {
+        return new CourseDocument
+        {
+            Id = courseId,
+            CourseId = courseId,
+            Name = courseId,
+            Slug = courseId,
+            IsPublished = true,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow.AddDays(30),
+            TrainingPlanPublications = new List<CourseTrainingPlanPublicationDocument>
+            {
+                new()
+                {
+                    TrainingPlanId = planId,
+                    PublishedAt = DateTime.UtcNow.AddDays(-1)
+                }
+            }
+        };
+    }
+
+    private sealed class InMemoryCourseRepository : ICourseRepository
+    {
+        private readonly List<CourseDocument> _courses;
+        private readonly List<CourseEnrollmentDocument> _enrollments = new();
+        private readonly List<CourseEventRegistrationDocument> _registrations = new();
+
+        public InMemoryCourseRepository(params CourseDocument[] courses)
+        {
+            _courses = courses.ToList();
+        }
+
+        public List<CourseEventDocument> Events { get; } = new();
+
+        public Task<IReadOnlyList<CourseDocument>> GetCoursesAsync()
+        {
+            return Task.FromResult<IReadOnlyList<CourseDocument>>(_courses);
+        }
+
+        public Task<CourseDocument?> GetCourseAsync(string courseId)
+        {
+            return Task.FromResult(_courses.FirstOrDefault(course => course.Id == courseId));
+        }
+
+        public Task UpsertCourseAsync(CourseDocument course)
+        {
+            _courses.RemoveAll(existing => existing.Id == course.Id);
+            _courses.Add(course);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForAthleteAsync(string athleteUserId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEnrollmentDocument>>(
+                _enrollments.Where(enrollment => enrollment.AthleteUserId == athleteUserId).ToList());
+        }
+
+        public Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForCourseAsync(string courseId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEnrollmentDocument>>(
+                _enrollments.Where(enrollment => enrollment.CourseId == courseId).ToList());
+        }
+
+        public Task<CourseEnrollmentDocument?> GetEnrollmentAsync(string courseId, string athleteUserId)
+        {
+            return Task.FromResult(_enrollments.FirstOrDefault(enrollment =>
+                enrollment.CourseId == courseId && enrollment.AthleteUserId == athleteUserId));
+        }
+
+        public Task UpsertEnrollmentAsync(CourseEnrollmentDocument enrollment)
+        {
+            _enrollments.RemoveAll(existing =>
+                existing.CourseId == enrollment.CourseId && existing.AthleteUserId == enrollment.AthleteUserId);
+            _enrollments.Add(enrollment);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEventDocument>>(
+                Events.Where(courseEvent => courseEvent.CourseId == courseId).ToList());
+        }
+
+        public Task<CourseEventDocument?> GetEventAsync(string courseId, string eventId)
+        {
+            return Task.FromResult(Events.FirstOrDefault(courseEvent =>
+                courseEvent.CourseId == courseId && courseEvent.Id == eventId));
+        }
+
+        public Task UpsertEventAsync(CourseEventDocument courseEvent)
+        {
+            Events.RemoveAll(existing => existing.Id == courseEvent.Id);
+            Events.Add(courseEvent);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsAsync(string courseId, string eventId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEventRegistrationDocument>>(
+                _registrations.Where(registration =>
+                    registration.CourseId == courseId && registration.EventId == eventId).ToList());
+        }
+
+        public Task<CourseEventRegistrationDocument?> GetEventRegistrationAsync(string courseId, string eventId, string athleteUserId)
+        {
+            return Task.FromResult(_registrations.FirstOrDefault(registration =>
+                registration.CourseId == courseId
+                && registration.EventId == eventId
+                && registration.AthleteUserId == athleteUserId));
+        }
+
+        public Task UpsertEventRegistrationAsync(CourseEventRegistrationDocument registration)
+        {
+            _registrations.RemoveAll(existing =>
+                existing.EventId == registration.EventId && existing.AthleteUserId == registration.AthleteUserId);
+            _registrations.Add(registration);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/PaceLetics.Tests/DashboardMessageFeedServiceTests.cs
+++ b/PaceLetics.Tests/DashboardMessageFeedServiceTests.cs
@@ -147,6 +147,11 @@ public sealed class DashboardMessageFeedServiceTests
             return _plans;
         }
 
+        public Task<IReadOnlyList<TrainingPlan>> LoadTrainingPlansForUserAsync(string? userId)
+        {
+            return Task.FromResult(_plans);
+        }
+
         public IReadOnlyList<RunningSession> LoadLegacySessions()
         {
             return Array.Empty<RunningSession>();

--- a/PaceLetics.Web/Pages/Athletes/Dashboard.razor
+++ b/PaceLetics.Web/Pages/Athletes/Dashboard.razor
@@ -100,7 +100,14 @@
         _name = string.IsNullOrWhiteSpace(Athlete?.Name)
             ? user.Identity?.Name ?? string.Empty
             : Athlete.Name;
-        _trainingPlans = TrainingPlanService.LoadTrainingPlans();
+        try
+        {
+            _trainingPlans = await TrainingPlanService.LoadTrainingPlansForUserAsync(id);
+        }
+        catch
+        {
+            _trainingPlans = Array.Empty<TrainingPlan>();
+        }
         _activePlan = ResolveActivePlan(_trainingPlans, Athlete);
         _nextSession = ResolveNextSession(_activePlan, _trainingPlans);
         _referenceResult = Athlete?.ActiveReferenceResult;

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -1,0 +1,233 @@
+@page "/Athletes/courses"
+@attribute [Authorize]
+@using PaceLetics.Web.Services.Courses
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ICourseService CourseService
+@inject ISnackbar Snackbar
+
+<PageTitle>Meine Kurse</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
+    @if (_isLoading)
+    {
+        <LoadingScreen Label="Kurse werden geladen" />
+    }
+    else
+    {
+        <PageHeader Title="Meine Kurse" Subtitle="Kursbeitritte, Termine und Events" />
+
+        <MudDivider Class="my-4" />
+
+        @if (!string.IsNullOrWhiteSpace(_errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">@_errorMessage</MudAlert>
+        }
+
+        @if (_courses.Count == 0)
+        {
+            <MudText Typo="Typo.body2" Color="Color.Secondary">Aktuell sind keine Kurse veröffentlicht.</MudText>
+        }
+        else
+        {
+            <MudStack Spacing="3">
+                @foreach (var overview in _courses)
+                {
+                    var course = overview.Course;
+                    var upcomingDates = GetUpcomingDates(course).Take(4).ToList();
+                    var courseEvents = GetEvents(course.Id).ToList();
+
+                    <MudPaper Elevation="1" Class="pa-4">
+                        <MudStack Spacing="3">
+                            <MudStack Row="true" AlignItems="AlignItems.Start" Justify="Justify.SpaceBetween" Style="width:100%; gap:12px;">
+                                <MudStack Spacing="1" Style="min-width:0;">
+                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="flex-wrap:wrap;">
+                                        <MudText Typo="Typo.h6">@course.Name</MudText>
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@course.Level</MudChip>
+                                        @if (overview.IsJoined)
+                                        {
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">Beigetreten</MudChip>
+                                        }
+                                    </MudStack>
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@course.Description</MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatPeriod(course)</MudText>
+                                </MudStack>
+
+                                <MudButton Color="Color.Primary"
+                                           Variant="Variant.Filled"
+                                           StartIcon="@Icons.Material.Filled.HowToReg"
+                                           Disabled="@overview.IsJoined"
+                                           OnClick="@(() => JoinCourseAsync(course.Id))">
+                                    @(overview.IsJoined ? "Dabei" : "Beitreten")
+                                </MudButton>
+                            </MudStack>
+
+                            <MudExpansionPanels Elevation="0" MultiExpansion="true">
+                                <MudExpansionPanel Text="Termine">
+                                    @if (upcomingDates.Count == 0)
+                                    {
+                                        <MudText Typo="Typo.body2" Color="Color.Secondary">Keine kommenden Termine.</MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudStack Spacing="1">
+                                            @foreach (var date in upcomingDates)
+                                            {
+                                                <div style="display:grid; grid-template-columns:96px 1fr; gap:12px; align-items:start;">
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@date.StartsAt.ToString("dd.MM.")</MudText>
+                                                    <div>
+                                                        <MudText Typo="Typo.body2">@date.Title</MudText>
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatTimeRange(date)</MudText>
+                                                    </div>
+                                                </div>
+                                            }
+                                        </MudStack>
+                                    }
+                                </MudExpansionPanel>
+
+                                <MudExpansionPanel Text="Trainingspläne">
+                                    @if (course.TrainingPlanPublications.Count == 0)
+                                    {
+                                        <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Trainingspläne veröffentlicht.</MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudStack Spacing="1">
+                                            @foreach (var publication in course.TrainingPlanPublications)
+                                            {
+                                                <MudText Typo="Typo.body2">@publication.TrainingPlanId</MudText>
+                                            }
+                                        </MudStack>
+                                    }
+                                </MudExpansionPanel>
+
+                                <MudExpansionPanel Text="Events">
+                                    @if (!overview.IsJoined)
+                                    {
+                                        <MudText Typo="Typo.body2" Color="Color.Secondary">Events werden nach dem Kursbeitritt verfügbar.</MudText>
+                                    }
+                                    else if (courseEvents.Count == 0)
+                                    {
+                                        <MudText Typo="Typo.body2" Color="Color.Secondary">Aktuell sind keine Events eingestellt.</MudText>
+                                    }
+                                    else
+                                    {
+                                        <MudStack Spacing="2">
+                                            @foreach (var courseEvent in courseEvents)
+                                            {
+                                                <div style="display:grid; grid-template-columns:1fr auto; gap:12px; align-items:center;">
+                                                    <div>
+                                                        <MudText Typo="Typo.body2">@courseEvent.Title</MudText>
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatEventDate(courseEvent)</MudText>
+                                                    </div>
+                                                    <MudIconButton Icon="@Icons.Material.Filled.EventAvailable"
+                                                                   Color="Color.Primary"
+                                                                   OnClick="@(() => RegisterForEventAsync(course.Id, courseEvent.Id))" />
+                                                </div>
+                                            }
+                                        </MudStack>
+                                    }
+                                </MudExpansionPanel>
+                            </MudExpansionPanels>
+                        </MudStack>
+                    </MudPaper>
+                }
+            </MudStack>
+        }
+    }
+</MudContainer>
+
+@code {
+    private bool _isLoading = true;
+    private string? _userId;
+    private string? _errorMessage;
+    private IReadOnlyList<CourseOverview> _courses = Array.Empty<CourseOverview>();
+    private Dictionary<string, IReadOnlyList<CourseEventDocument>> _eventsByCourse = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        _userId = authState.User.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
+        await LoadCoursesAsync();
+    }
+
+    private async Task LoadCoursesAsync()
+    {
+        try
+        {
+            _isLoading = true;
+            _errorMessage = null;
+            _courses = await CourseService.GetCoursesForAthleteAsync(_userId ?? string.Empty);
+            _eventsByCourse = new Dictionary<string, IReadOnlyList<CourseEventDocument>>();
+
+            foreach (var course in _courses.Where(course => course.IsJoined).Select(course => course.Course))
+            {
+                _eventsByCourse[course.Id] = await CourseService.GetEventsAsync(course.Id);
+            }
+        }
+        catch
+        {
+            _errorMessage = "Die Kurse konnten nicht aus Cosmos DB geladen werden.";
+            _courses = Array.Empty<CourseOverview>();
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task JoinCourseAsync(string courseId)
+    {
+        try
+        {
+            await CourseService.JoinCourseAsync(courseId, _userId ?? string.Empty);
+            Snackbar.Add("Du bist dem Kurs beigetreten.", Severity.Success);
+            await LoadCoursesAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task RegisterForEventAsync(string courseId, string eventId)
+    {
+        try
+        {
+            await CourseService.RegisterForEventAsync(courseId, eventId, _userId ?? string.Empty);
+            Snackbar.Add("Du bist für das Event angemeldet.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private static IEnumerable<CourseDateDocument> GetUpcomingDates(CourseDocument course)
+    {
+        return course.Dates
+            .Where(date => date.StartsAt.Date >= DateTime.Today)
+            .OrderBy(date => date.StartsAt);
+    }
+
+    private IEnumerable<CourseEventDocument> GetEvents(string courseId)
+    {
+        return _eventsByCourse.TryGetValue(courseId, out var events)
+            ? events.OrderBy(courseEvent => courseEvent.StartsAt)
+            : Array.Empty<CourseEventDocument>();
+    }
+
+    private static string FormatPeriod(CourseDocument course)
+    {
+        return $"{course.StartDate:dd.MM.yyyy} bis {course.EndDate:dd.MM.yyyy}";
+    }
+
+    private static string FormatTimeRange(CourseDateDocument date)
+    {
+        return $"{date.StartsAt:HH:mm} bis {date.EndsAt:HH:mm} Uhr";
+    }
+
+    private static string FormatEventDate(CourseEventDocument courseEvent)
+    {
+        return $"{courseEvent.StartsAt:dd.MM.yyyy HH:mm} bis {courseEvent.EndsAt:HH:mm} Uhr";
+    }
+}

--- a/PaceLetics.Web/Pages/Athletes/TrainingPlanPage.razor
+++ b/PaceLetics.Web/Pages/Athletes/TrainingPlanPage.razor
@@ -205,8 +205,6 @@
     {
         try
         {
-            _plans = TrainingPlanService.LoadTrainingPlans().ToList();
-
             // athlete laden
             var authState = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
             var userID = authState.User.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
@@ -219,6 +217,8 @@
                 if (_athlete?.PaceModel is not null)
                     _paceModel = _athlete.PaceModel;
             }
+
+            _plans = (await TrainingPlanService.LoadTrainingPlansForUserAsync(userID)).ToList();
 
             // Auswahl: gespeicherter Plan wenn vorhanden (Server-Athlete.SelectedTrainingPlanId), sonst Browser localStorage, sonst nächster oder erster Plan
             string? storedPlan = null;

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -23,6 +23,7 @@ using PaceLetics.WorkoutModule.CodeBase.Repositories;
 using PaceLetics.Web.ViewModels.Workouts;
 using PaceLetics.Web.Services.DashboardMessages;
 using PaceLetics.CoreModule.Infrastructure.Services;
+using PaceLetics.Web.Services.Courses;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -93,6 +94,8 @@ builder.Services.Configure<TrainerVerificationOptions>(options =>
     }
 });
 builder.Services.AddTransient<IEmailSender, SmtpEmailSender>();
+builder.Services.AddScoped<ICourseRepository, CosmosCourseRepository>();
+builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddScoped<ITrainingPlanService, TrainingPlanService>();
 builder.Services.AddSingleton<DashboardMessageFeedOptions>();
 builder.Services.AddScoped<IAthleteMessageProvider, ReferenceRunDashboardMessageProvider>();

--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -35,6 +35,7 @@
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Laufdaten</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pacebereiche</value></data>
+  <data name="Nav_Courses" xml:space="preserve"><value>Meine Kurse</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Trainingsplanung</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profile</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -35,6 +35,7 @@
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
+  <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/PaceLetics.Web/Services/Courses/CosmosCourseRepository.cs
+++ b/PaceLetics.Web/Services/Courses/CosmosCourseRepository.cs
@@ -1,0 +1,219 @@
+using AthleteDataAccessLibrary;
+using AthleteDataAccessLibrary.Contracts;
+
+namespace PaceLetics.Web.Services.Courses;
+
+public sealed class CosmosCourseRepository : ICourseRepository
+{
+    private readonly IDataAccess _db;
+    private readonly AthleteDataOptions _options;
+
+    public CosmosCourseRepository(IDataAccess db, AthleteDataOptions options)
+    {
+        _db = db;
+        _options = options;
+        _options.Validate();
+    }
+
+    public async Task<IReadOnlyList<CourseDocument>> GetCoursesAsync()
+    {
+        await EnsureDefaultCoursesAsync();
+        var courses = await _db.LoadData<CourseDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            CourseDocumentTypes.Course);
+
+        return courses
+            .Where(course => !string.IsNullOrWhiteSpace(course.Id))
+            .OrderBy(course => course.StartDate)
+            .ThenBy(course => course.Name)
+            .ToList();
+    }
+
+    public async Task<CourseDocument?> GetCourseAsync(string courseId)
+    {
+        await EnsureDefaultCoursesAsync();
+        return await _db.LoadItem<CourseDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            courseId,
+            courseId);
+    }
+
+    public Task UpsertCourseAsync(CourseDocument course)
+    {
+        NormalizeCourse(course);
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            course,
+            course.CourseId);
+    }
+
+    public async Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForAthleteAsync(string athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return Array.Empty<CourseEnrollmentDocument>();
+
+        var enrollments = await _db.LoadData<CourseEnrollmentDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            CourseDocumentTypes.Enrollment);
+
+        return enrollments
+            .Where(enrollment => enrollment.AthleteUserId == athleteUserId)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForCourseAsync(string courseId)
+    {
+        if (string.IsNullOrWhiteSpace(courseId))
+            return Array.Empty<CourseEnrollmentDocument>();
+
+        var enrollments = await _db.LoadPartitionData<CourseEnrollmentDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            courseId,
+            CourseDocumentTypes.Enrollment);
+
+        return enrollments
+            .Where(enrollment => enrollment.CourseId == courseId)
+            .ToList();
+    }
+
+    public Task<CourseEnrollmentDocument?> GetEnrollmentAsync(string courseId, string athleteUserId)
+    {
+        return _db.LoadItem<CourseEnrollmentDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            CourseDocumentIds.Enrollment(courseId, athleteUserId),
+            courseId);
+    }
+
+    public Task UpsertEnrollmentAsync(CourseEnrollmentDocument enrollment)
+    {
+        enrollment.DocumentType = CourseDocumentTypes.Enrollment;
+        enrollment.Id = CourseDocumentIds.Enrollment(enrollment.CourseId, enrollment.AthleteUserId);
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            enrollment,
+            enrollment.CourseId);
+    }
+
+    public Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId)
+    {
+        return LoadPartitionItems<CourseEventDocument>(courseId, CourseDocumentTypes.Event);
+    }
+
+    public Task<CourseEventDocument?> GetEventAsync(string courseId, string eventId)
+    {
+        return _db.LoadItem<CourseEventDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            eventId,
+            courseId);
+    }
+
+    public Task UpsertEventAsync(CourseEventDocument courseEvent)
+    {
+        courseEvent.DocumentType = CourseDocumentTypes.Event;
+        if (string.IsNullOrWhiteSpace(courseEvent.Id))
+            courseEvent.Id = Guid.NewGuid().ToString("N");
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            courseEvent,
+            courseEvent.CourseId);
+    }
+
+    public async Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsAsync(string courseId, string eventId)
+    {
+        var registrations = await LoadPartitionItems<CourseEventRegistrationDocument>(
+            courseId,
+            CourseDocumentTypes.EventRegistration);
+
+        return registrations
+            .Where(registration => registration.EventId == eventId)
+            .ToList();
+    }
+
+    public Task<CourseEventRegistrationDocument?> GetEventRegistrationAsync(string courseId, string eventId, string athleteUserId)
+    {
+        return _db.LoadItem<CourseEventRegistrationDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            CourseDocumentIds.EventRegistration(eventId, athleteUserId),
+            courseId);
+    }
+
+    public Task UpsertEventRegistrationAsync(CourseEventRegistrationDocument registration)
+    {
+        registration.DocumentType = CourseDocumentTypes.EventRegistration;
+        registration.Id = CourseDocumentIds.EventRegistration(registration.EventId, registration.AthleteUserId);
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            registration,
+            registration.CourseId);
+    }
+
+    private async Task EnsureDefaultCoursesAsync()
+    {
+        var existingCourses = await _db.LoadData<CourseDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            CourseDocumentTypes.Course);
+        var existingIds = existingCourses.Select(course => course.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var course in CourseSeedData.CreateDefaultCourses())
+        {
+            if (existingIds.Contains(course.Id))
+                continue;
+
+            await UpsertCourseAsync(course);
+        }
+    }
+
+    private async Task<IReadOnlyList<T>> LoadPartitionItems<T>(string courseId, string documentType)
+    {
+        if (string.IsNullOrWhiteSpace(courseId))
+            return Array.Empty<T>();
+
+        var items = await _db.LoadPartitionData<T>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            courseId,
+            documentType);
+
+        return items.ToList();
+    }
+
+    private static void NormalizeCourse(CourseDocument course)
+    {
+        if (string.IsNullOrWhiteSpace(course.Id))
+            course.Id = course.CourseId;
+
+        if (string.IsNullOrWhiteSpace(course.CourseId))
+            course.CourseId = course.Id;
+
+        course.DocumentType = CourseDocumentTypes.Course;
+        course.Slug = string.IsNullOrWhiteSpace(course.Slug) ? course.Id : course.Slug;
+    }
+}
+
+public static class CourseDocumentIds
+{
+    public static string Enrollment(string courseId, string athleteUserId)
+    {
+        return $"enrollment:{courseId}:{athleteUserId}";
+    }
+
+    public static string EventRegistration(string eventId, string athleteUserId)
+    {
+        return $"event-registration:{eventId}:{athleteUserId}";
+    }
+}

--- a/PaceLetics.Web/Services/Courses/CourseDocuments.cs
+++ b/PaceLetics.Web/Services/Courses/CourseDocuments.cs
@@ -1,0 +1,120 @@
+using PaceLetics.CoreModule.Infrastructure.Interfaces;
+
+namespace PaceLetics.Web.Services.Courses;
+
+public static class CourseDocumentTypes
+{
+    public const string Course = "course";
+    public const string Enrollment = "courseEnrollment";
+    public const string Event = "courseEvent";
+    public const string EventRegistration = "courseEventRegistration";
+}
+
+public static class CourseEnrollmentStatus
+{
+    public const string Active = "active";
+    public const string Cancelled = "cancelled";
+}
+
+public static class CourseEventRegistrationStatus
+{
+    public const string Registered = "registered";
+    public const string Cancelled = "cancelled";
+}
+
+public sealed class CourseDocument : IQueryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string DocumentType { get; set; } = CourseDocumentTypes.Course;
+    public string Slug { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Level { get; set; } = string.Empty;
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public bool IsPublished { get; set; } = true;
+    public List<CourseDateDocument> Dates { get; set; } = new();
+    public List<CourseTrainerDocument> Trainers { get; set; } = new();
+    public List<CourseTrainingPlanPublicationDocument> TrainingPlanPublications { get; set; } = new();
+}
+
+public sealed class CourseDateDocument
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public DateTime StartsAt { get; set; }
+    public DateTime EndsAt { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public string Notes { get; set; } = string.Empty;
+}
+
+public sealed class CourseTrainerDocument
+{
+    public string TrainerUserId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Role { get; set; } = "Kursleitung";
+    public bool CanManagePlans { get; set; } = true;
+    public bool CanManageEvents { get; set; } = true;
+    public bool CanManageMembers { get; set; } = true;
+}
+
+public sealed class CourseTrainingPlanPublicationDocument
+{
+    public string TrainingPlanId { get; set; } = string.Empty;
+    public DateTime PublishedAt { get; set; }
+    public string PublishedByUserId { get; set; } = string.Empty;
+    public DateTime? VisibleFrom { get; set; }
+}
+
+public sealed class CourseEnrollmentDocument : IQueryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string DocumentType { get; set; } = CourseDocumentTypes.Enrollment;
+    public string AthleteUserId { get; set; } = string.Empty;
+    public string Status { get; set; } = CourseEnrollmentStatus.Active;
+    public DateTime RegisteredAt { get; set; }
+    public DateTime? CancelledAt { get; set; }
+}
+
+public sealed class CourseEventDocument : IQueryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string DocumentType { get; set; } = CourseDocumentTypes.Event;
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public DateTime StartsAt { get; set; }
+    public DateTime EndsAt { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public int? Capacity { get; set; }
+    public DateTime? RegistrationDeadline { get; set; }
+    public string CreatedByUserId { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}
+
+public sealed class CourseEventRegistrationDocument : IQueryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string EventId { get; set; } = string.Empty;
+    public string DocumentType { get; set; } = CourseDocumentTypes.EventRegistration;
+    public string AthleteUserId { get; set; } = string.Empty;
+    public string Status { get; set; } = CourseEventRegistrationStatus.Registered;
+    public DateTime RegisteredAt { get; set; }
+    public DateTime? CancelledAt { get; set; }
+}
+
+public sealed class CourseOverview
+{
+    public CourseOverview(CourseDocument course, CourseEnrollmentDocument? enrollment)
+    {
+        Course = course;
+        Enrollment = enrollment;
+    }
+
+    public CourseDocument Course { get; }
+    public CourseEnrollmentDocument? Enrollment { get; }
+    public bool IsJoined => Enrollment?.Status == CourseEnrollmentStatus.Active;
+}

--- a/PaceLetics.Web/Services/Courses/CourseSeedData.cs
+++ b/PaceLetics.Web/Services/Courses/CourseSeedData.cs
@@ -1,0 +1,139 @@
+namespace PaceLetics.Web.Services.Courses;
+
+public static class CourseSeedData
+{
+    private static readonly string[] LevelOnePlanIds =
+    {
+        "Level 1 Laufschule 2.5k Track A",
+        "Level 1 Laufschule 2.5k Track B",
+        "Level 1 Laufschule 5k Track C",
+        "Level 1 Laufschule 5k Track D",
+        "Level 1 Laufschule 10k Track E"
+    };
+
+    public static IReadOnlyList<CourseDocument> CreateDefaultCourses()
+    {
+        return new[]
+        {
+            CreateCourse(
+                "laufschule-einsteigende",
+                "Laufschule für Einsteigende",
+                "Level 1",
+                "Grundlagenkurs für den sicheren Einstieg ins strukturierte Lauftraining.",
+                new DateTime(2026, 4, 29),
+                new DateTime(2026, 6, 24),
+                LevelOnePlanIds,
+                CreateDates(
+                    "laufschule-einsteigende",
+                    "Laufschule",
+                    new[]
+                    {
+                        new DateTime(2026, 4, 29),
+                        new DateTime(2026, 5, 6),
+                        new DateTime(2026, 5, 13),
+                        new DateTime(2026, 5, 20),
+                        new DateTime(2026, 5, 27),
+                        new DateTime(2026, 6, 3),
+                        new DateTime(2026, 6, 10),
+                        new DateTime(2026, 6, 17),
+                        new DateTime(2026, 6, 24)
+                    },
+                    new TimeSpan(18, 0, 0),
+                    TimeSpan.FromMinutes(90))),
+            CreateCourse(
+                "technik-schnelligkeit-level-2",
+                "Schnelligkeits- und Techniktraining Level 2",
+                "Level 2",
+                "Technik, Laufökonomie und Schnelligkeitsentwicklung für fortgeschrittene Einsteiger:innen.",
+                new DateTime(2026, 4, 16),
+                new DateTime(2026, 7, 16),
+                new[] { "Level 2 Technik & Schnelligkeit" },
+                CreateDates(
+                    "technik-schnelligkeit-level-2",
+                    "Techniktraining Level 2",
+                    TechniqueCourseDates,
+                    new TimeSpan(18, 30, 0),
+                    TimeSpan.FromMinutes(90))),
+            CreateCourse(
+                "technik-schnelligkeit-level-3",
+                "Schnelligkeits- und Techniktraining Level 3",
+                "Level 3",
+                "Anspruchsvolle Einheiten für Athlet:innen mit stabiler Trainingsbasis.",
+                new DateTime(2026, 4, 16),
+                new DateTime(2026, 7, 16),
+                new[] { "Level 3 Technik & Schnelligkeit" },
+                CreateDates(
+                    "technik-schnelligkeit-level-3",
+                    "Techniktraining Level 3",
+                    TechniqueCourseDates,
+                    new TimeSpan(19, 0, 0),
+                    TimeSpan.FromMinutes(90)))
+        };
+    }
+
+    private static readonly DateTime[] TechniqueCourseDates =
+    {
+        new(2026, 4, 16),
+        new(2026, 4, 23),
+        new(2026, 4, 30),
+        new(2026, 5, 7),
+        new(2026, 5, 21),
+        new(2026, 5, 28),
+        new(2026, 6, 4),
+        new(2026, 6, 11),
+        new(2026, 6, 14),
+        new(2026, 6, 18),
+        new(2026, 6, 25),
+        new(2026, 7, 2),
+        new(2026, 7, 9),
+        new(2026, 7, 16)
+    };
+
+    private static CourseDocument CreateCourse(
+        string id,
+        string name,
+        string level,
+        string description,
+        DateTime startDate,
+        DateTime endDate,
+        IEnumerable<string> trainingPlanIds,
+        IEnumerable<CourseDateDocument> dates)
+    {
+        return new CourseDocument
+        {
+            Id = id,
+            CourseId = id,
+            Slug = id,
+            Name = name,
+            Level = level,
+            Description = description,
+            StartDate = startDate,
+            EndDate = endDate,
+            Dates = dates.ToList(),
+            TrainingPlanPublications = trainingPlanIds
+                .Select(planId => new CourseTrainingPlanPublicationDocument
+                {
+                    TrainingPlanId = planId,
+                    PublishedAt = startDate.AddDays(-14),
+                    VisibleFrom = startDate
+                })
+                .ToList()
+        };
+    }
+
+    private static IEnumerable<CourseDateDocument> CreateDates(
+        string courseId,
+        string title,
+        IEnumerable<DateTime> dates,
+        TimeSpan startsAt,
+        TimeSpan duration)
+    {
+        return dates.Select((date, index) => new CourseDateDocument
+        {
+            Id = $"{courseId}-{index + 1:00}",
+            Title = title,
+            StartsAt = date.Date.Add(startsAt),
+            EndsAt = date.Date.Add(startsAt).Add(duration)
+        });
+    }
+}

--- a/PaceLetics.Web/Services/Courses/CourseService.cs
+++ b/PaceLetics.Web/Services/Courses/CourseService.cs
@@ -1,0 +1,210 @@
+namespace PaceLetics.Web.Services.Courses;
+
+public sealed class CourseService : ICourseService
+{
+    private readonly ICourseRepository _repository;
+
+    public CourseService(ICourseRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IReadOnlyList<CourseOverview>> GetCoursesForAthleteAsync(string athleteUserId)
+    {
+        var courses = await _repository.GetCoursesAsync();
+        var enrollments = await _repository.GetEnrollmentsForAthleteAsync(athleteUserId);
+        var enrollmentByCourse = enrollments
+            .GroupBy(enrollment => enrollment.CourseId)
+            .ToDictionary(group => group.Key, group => group.OrderByDescending(enrollment => enrollment.RegisteredAt).First());
+
+        return courses
+            .Where(course => course.IsPublished)
+            .Select(course =>
+            {
+                enrollmentByCourse.TryGetValue(course.Id, out var enrollment);
+                return new CourseOverview(course, enrollment);
+            })
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<CourseDocument>> GetJoinedCoursesAsync(string athleteUserId)
+    {
+        var courses = await GetCoursesForAthleteAsync(athleteUserId);
+        return courses
+            .Where(course => course.IsJoined)
+            .Select(course => course.Course)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<string>> GetPublishedTrainingPlanIdsForAthleteAsync(string athleteUserId)
+    {
+        var now = DateTime.UtcNow;
+        var joinedCourses = await GetJoinedCoursesAsync(athleteUserId);
+
+        return joinedCourses
+            .SelectMany(course => course.TrainingPlanPublications)
+            .Where(publication => publication.VisibleFrom is null || publication.VisibleFrom <= now)
+            .Select(publication => publication.TrainingPlanId)
+            .Where(planId => !string.IsNullOrWhiteSpace(planId))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<CourseEnrollmentDocument> JoinCourseAsync(string courseId, string athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            throw new InvalidOperationException("Ein Kursbeitritt erfordert eine angemeldete Athlet:in.");
+
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        var existing = await _repository.GetEnrollmentAsync(course.Id, athleteUserId);
+        var enrollment = existing ?? new CourseEnrollmentDocument
+        {
+            CourseId = course.Id,
+            AthleteUserId = athleteUserId,
+            RegisteredAt = DateTime.UtcNow
+        };
+
+        enrollment.Status = CourseEnrollmentStatus.Active;
+        enrollment.CancelledAt = null;
+
+        if (enrollment.RegisteredAt == default)
+            enrollment.RegisteredAt = DateTime.UtcNow;
+
+        await _repository.UpsertEnrollmentAsync(enrollment);
+        return enrollment;
+    }
+
+    public async Task AssignTrainerAsync(string courseId, string trainerUserId, string displayName)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        course.Trainers.RemoveAll(trainer => trainer.TrainerUserId == trainerUserId);
+        course.Trainers.Add(new CourseTrainerDocument
+        {
+            TrainerUserId = trainerUserId,
+            DisplayName = displayName
+        });
+
+        await _repository.UpsertCourseAsync(course);
+    }
+
+    public async Task PublishTrainingPlanAsync(string courseId, string trainingPlanId, string publishedByUserId, DateTime? visibleFrom = null)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        var existing = course.TrainingPlanPublications
+            .FirstOrDefault(publication => publication.TrainingPlanId == trainingPlanId);
+
+        if (existing is null)
+        {
+            course.TrainingPlanPublications.Add(new CourseTrainingPlanPublicationDocument
+            {
+                TrainingPlanId = trainingPlanId,
+                PublishedAt = DateTime.UtcNow,
+                PublishedByUserId = publishedByUserId,
+                VisibleFrom = visibleFrom
+            });
+        }
+        else
+        {
+            existing.VisibleFrom = visibleFrom;
+            existing.PublishedByUserId = string.IsNullOrWhiteSpace(existing.PublishedByUserId)
+                ? publishedByUserId
+                : existing.PublishedByUserId;
+        }
+
+        await _repository.UpsertCourseAsync(course);
+    }
+
+    public Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId)
+    {
+        return _repository.GetEventsAsync(courseId);
+    }
+
+    public async Task<CourseEventDocument> CreateEventAsync(
+        string courseId,
+        string title,
+        DateTime startsAt,
+        DateTime endsAt,
+        string createdByUserId,
+        string description = "",
+        string location = "",
+        int? capacity = null,
+        DateTime? registrationDeadline = null)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new InvalidOperationException("Ein Event braucht einen Titel.");
+
+        if (endsAt <= startsAt)
+            throw new InvalidOperationException("Das Event-Ende muss nach dem Start liegen.");
+
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        var courseEvent = new CourseEventDocument
+        {
+            CourseId = course.Id,
+            Title = title,
+            StartsAt = startsAt,
+            EndsAt = endsAt,
+            Description = description,
+            Location = location,
+            Capacity = capacity,
+            RegistrationDeadline = registrationDeadline,
+            CreatedByUserId = createdByUserId,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _repository.UpsertEventAsync(courseEvent);
+        return courseEvent;
+    }
+
+    public async Task<CourseEventRegistrationDocument> RegisterForEventAsync(string courseId, string eventId, string athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            throw new InvalidOperationException("Eine Event-Anmeldung erfordert eine angemeldete Athlet:in.");
+
+        var enrollment = await _repository.GetEnrollmentAsync(courseId, athleteUserId);
+        if (enrollment?.Status != CourseEnrollmentStatus.Active)
+            throw new InvalidOperationException("Du musst dem Kurs beigetreten sein, bevor du dich für Events anmeldest.");
+
+        var courseEvent = await _repository.GetEventAsync(courseId, eventId)
+            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+
+        if (courseEvent.RegistrationDeadline is not null && courseEvent.RegistrationDeadline < DateTime.UtcNow)
+            throw new InvalidOperationException("Die Anmeldefrist für dieses Event ist abgelaufen.");
+
+        var registrations = await _repository.GetEventRegistrationsAsync(courseId, eventId);
+        var activeRegistrations = registrations.Count(registration =>
+            registration.Status == CourseEventRegistrationStatus.Registered);
+
+        if (courseEvent.Capacity is not null && activeRegistrations >= courseEvent.Capacity)
+        {
+            var existing = registrations.FirstOrDefault(registration => registration.AthleteUserId == athleteUserId);
+            if (existing?.Status != CourseEventRegistrationStatus.Registered)
+                throw new InvalidOperationException("Für dieses Event sind keine freien Plätze mehr verfügbar.");
+        }
+
+        var registration = await _repository.GetEventRegistrationAsync(courseId, eventId, athleteUserId)
+            ?? new CourseEventRegistrationDocument
+            {
+                CourseId = courseId,
+                EventId = eventId,
+                AthleteUserId = athleteUserId,
+                RegisteredAt = DateTime.UtcNow
+            };
+
+        registration.Status = CourseEventRegistrationStatus.Registered;
+        registration.CancelledAt = null;
+
+        if (registration.RegisteredAt == default)
+            registration.RegisteredAt = DateTime.UtcNow;
+
+        await _repository.UpsertEventRegistrationAsync(registration);
+        return registration;
+    }
+}

--- a/PaceLetics.Web/Services/Courses/ICourseRepository.cs
+++ b/PaceLetics.Web/Services/Courses/ICourseRepository.cs
@@ -1,0 +1,30 @@
+namespace PaceLetics.Web.Services.Courses;
+
+public interface ICourseRepository
+{
+    Task<IReadOnlyList<CourseDocument>> GetCoursesAsync();
+
+    Task<CourseDocument?> GetCourseAsync(string courseId);
+
+    Task UpsertCourseAsync(CourseDocument course);
+
+    Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForAthleteAsync(string athleteUserId);
+
+    Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForCourseAsync(string courseId);
+
+    Task<CourseEnrollmentDocument?> GetEnrollmentAsync(string courseId, string athleteUserId);
+
+    Task UpsertEnrollmentAsync(CourseEnrollmentDocument enrollment);
+
+    Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId);
+
+    Task<CourseEventDocument?> GetEventAsync(string courseId, string eventId);
+
+    Task UpsertEventAsync(CourseEventDocument courseEvent);
+
+    Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsAsync(string courseId, string eventId);
+
+    Task<CourseEventRegistrationDocument?> GetEventRegistrationAsync(string courseId, string eventId, string athleteUserId);
+
+    Task UpsertEventRegistrationAsync(CourseEventRegistrationDocument registration);
+}

--- a/PaceLetics.Web/Services/Courses/ICourseService.cs
+++ b/PaceLetics.Web/Services/Courses/ICourseService.cs
@@ -1,0 +1,31 @@
+namespace PaceLetics.Web.Services.Courses;
+
+public interface ICourseService
+{
+    Task<IReadOnlyList<CourseOverview>> GetCoursesForAthleteAsync(string athleteUserId);
+
+    Task<IReadOnlyList<CourseDocument>> GetJoinedCoursesAsync(string athleteUserId);
+
+    Task<IReadOnlyList<string>> GetPublishedTrainingPlanIdsForAthleteAsync(string athleteUserId);
+
+    Task<CourseEnrollmentDocument> JoinCourseAsync(string courseId, string athleteUserId);
+
+    Task AssignTrainerAsync(string courseId, string trainerUserId, string displayName);
+
+    Task PublishTrainingPlanAsync(string courseId, string trainingPlanId, string publishedByUserId, DateTime? visibleFrom = null);
+
+    Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId);
+
+    Task<CourseEventDocument> CreateEventAsync(
+        string courseId,
+        string title,
+        DateTime startsAt,
+        DateTime endsAt,
+        string createdByUserId,
+        string description = "",
+        string location = "",
+        int? capacity = null,
+        DateTime? registrationDeadline = null);
+
+    Task<CourseEventRegistrationDocument> RegisterForEventAsync(string courseId, string eventId, string athleteUserId);
+}

--- a/PaceLetics.Web/Services/ITrainingPlanService.cs
+++ b/PaceLetics.Web/Services/ITrainingPlanService.cs
@@ -7,5 +7,7 @@ public interface ITrainingPlanService
 {
     IReadOnlyList<TrainingPlan> LoadTrainingPlans();
 
+    Task<IReadOnlyList<TrainingPlan>> LoadTrainingPlansForUserAsync(string? userId);
+
     IReadOnlyList<RunningSession> LoadLegacySessions();
 }

--- a/PaceLetics.Web/Services/TrainingPlanService.cs
+++ b/PaceLetics.Web/Services/TrainingPlanService.cs
@@ -2,6 +2,7 @@ using PaceLetics.RunningModule.CodeBase.Models;
 using PaceLetics.RunningModule.CodeBase.Repositories;
 using PaceLetics.TrainingPlanModule.CodeBase.Models;
 using PaceLetics.TrainingPlanModule.CodeBase.Repositories;
+using PaceLetics.Web.Services.Courses;
 using PaceLetics.WorkoutModule.CodeBase.Interfaces;
 
 namespace PaceLetics.Web.Services;
@@ -10,11 +11,16 @@ public sealed class TrainingPlanService : ITrainingPlanService
 {
     private readonly IWebHostEnvironment _environment;
     private readonly IWorkoutCatalog _workoutCatalog;
+    private readonly ICourseService _courseService;
 
-    public TrainingPlanService(IWebHostEnvironment environment, IWorkoutCatalog workoutCatalog)
+    public TrainingPlanService(
+        IWebHostEnvironment environment,
+        IWorkoutCatalog workoutCatalog,
+        ICourseService courseService)
     {
         _environment = environment;
         _workoutCatalog = workoutCatalog;
+        _courseService = courseService;
     }
 
     public IReadOnlyList<TrainingPlan> LoadTrainingPlans()
@@ -39,6 +45,21 @@ public sealed class TrainingPlanService : ITrainingPlanService
                 session.Date,
                 new[] { session },
                 Array.Empty<WorkoutSessionDefinition>()))) };
+    }
+
+    public async Task<IReadOnlyList<TrainingPlan>> LoadTrainingPlansForUserAsync(string? userId)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+            return Array.Empty<TrainingPlan>();
+
+        var visiblePlanIds = await _courseService.GetPublishedTrainingPlanIdsForAthleteAsync(userId);
+        if (visiblePlanIds.Count == 0)
+            return Array.Empty<TrainingPlan>();
+
+        var visiblePlanIdSet = visiblePlanIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return LoadTrainingPlans()
+            .Where(plan => visiblePlanIdSet.Contains(plan.Id))
+            .ToList();
     }
 
     public IReadOnlyList<RunningSession> LoadLegacySessions()

--- a/PaceLetics.Web/Shared/DashboardNextTrainingSessionTile.razor
+++ b/PaceLetics.Web/Shared/DashboardNextTrainingSessionTile.razor
@@ -11,55 +11,73 @@
 
             <MudStack Spacing="1">
                 <MudText Typo="Typo.h6">
-                    @Session.Name
+                    @(Session?.Name ?? "Noch keine Trainingseinheit")
                 </MudText>
 
                 <MudText Typo="Typo.body2"
                          Class="pl-dashboard-muted">
-                    @Session.Date.ToString("dd.MM.yyyy")
-                    @(" / ")
-                    @GetSessionComposition(Session)
+                    @if (Session is null)
+                    {
+                        @("Tritt einem Kurs bei, um veröffentlichte Trainingspläne zu sehen.")
+                    }
+                    else
+                    {
+                        @Session.Date.ToString("dd.MM.yyyy")
+                        @(" / ")
+                        @GetSessionComposition(Session)
+                    }
                 </MudText>
             </MudStack>
 
-            <MudButton Href="/Athletes/trainingplanpage"
+            <MudButton Href="@(Session is null ? "/Athletes/courses" : "/Athletes/trainingplanpage")"
                        Variant="Variant.Filled"
                        Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.OpenInNew">
-                Open
+                @(Session is null ? "Kurse" : "Open")
             </MudButton>
         </MudStack>
 
-        <MudDivider />
+        @if (Session is not null)
+        {
+            <MudDivider />
 
-        <MudStack Row="true"
-                  AlignItems="AlignItems.Center"
-                  Spacing="2">
+            <MudStack Row="true"
+                      AlignItems="AlignItems.Center"
+                      Spacing="2">
 
-            <MudIcon Icon="@Icons.Material.Filled.Timeline"
-                     Color="Color.Primary" />
+                <MudIcon Icon="@Icons.Material.Filled.Timeline"
+                         Color="Color.Primary" />
 
-            <MudStack Spacing="0">
-                <MudText Typo="Typo.subtitle2">
-                    Vorschau
-                </MudText>
+                <MudStack Spacing="0">
+                    <MudText Typo="Typo.subtitle2">
+                        Vorschau
+                    </MudText>
 
-                <MudText Typo="Typo.body2"
-                         Class="pl-dashboard-muted">
-                    Trainingsdetails und Struktur der Einheit.
-                </MudText>
+                    <MudText Typo="Typo.body2"
+                             Class="pl-dashboard-muted">
+                        Trainingsdetails und Struktur der Einheit.
+                    </MudText>
+                </MudStack>
             </MudStack>
-        </MudStack>
+        }
 
     </MudStack>
 </MudPaper>
 
 @code {
     [Parameter]
-    public TrainingSession Session { get; set; } = default!;
+    public TrainingSession? Session { get; set; }
 
     private static string GetSessionComposition(TrainingSession session)
     {
-        return $"{session.PrimaryRun.TotalDistance} Abschnitte";
+        var parts = new List<string>();
+
+        if (session.PrimaryRun is not null)
+            parts.Add($"{session.PrimaryRun.TotalDistance / 1000.0:0.0} km");
+
+        if (session.Workouts.Count > 0)
+            parts.Add($"{session.Workouts.Count} Workout(s)");
+
+        return parts.Count == 0 ? "Trainingseinheit" : string.Join(" / ", parts);
     }
 }

--- a/PaceLetics.Web/Shared/NavMenu.razor
+++ b/PaceLetics.Web/Shared/NavMenu.razor
@@ -4,6 +4,7 @@
     <MudNavLink Href="/Athletes/dashboard" Match="NavLinkMatch.All">@L["Nav_Dashboard"]</MudNavLink>
     <MudNavLink Href="/Athletes/racepaces" Match="NavLinkMatch.Prefix">@L["Nav_RaceData"]</MudNavLink>
     <MudNavLink Href="/Athletes/trainingpaces" Match="NavLinkMatch.Prefix">@L["Nav_PaceZones"]</MudNavLink>
+    <MudNavLink Href="/Athletes/courses" Match="NavLinkMatch.Prefix">@L["Nav_Courses"]</MudNavLink>
     <MudNavLink Href="/Athletes/trainingplanpage" Match="NavLinkMatch.Prefix">@L["Nav_TrainingPlan"]</MudNavLink>
     <MudNavLink Href="/Workouts/WorkoutArea" Match="NavLinkMatch.Prefix">@L["Nav_Workouts"]</MudNavLink>
     <MudNavLink Href="/profiles" Match="NavLinkMatch.Prefix">@L["Nav_Profiles"]</MudNavLink>

--- a/PaceLetics.Web/appsettings.json
+++ b/PaceLetics.Web/appsettings.json
@@ -8,7 +8,8 @@
   },
   "AthleteData": {
     "DatabaseName": "paceleticsdata",
-    "AthleteContainerName": "athletedata"
+    "AthleteContainerName": "athletedata",
+    "CourseContainerName": "courses"
   },
   "TrainerVerification": {
     "Code": ""


### PR DESCRIPTION
## Summary
- add Cosmos-backed course domain with seeded default courses, enrollments, trainers, plan publications, events, and event registrations
- add "Meine Kurse" page and navigation entry for course enrollment
- filter visible training plans by joined courses and harden dashboard empty-state handling

## Test
- dotnet test PaceLeticsFramework.sln