### PR TITLE
Remove duplicate course join button

### DIFF
--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -86,7 +86,7 @@
 
                     <MudPaper Elevation="1" Class="pa-4">
                         <MudStack Spacing="3">
-                            <MudStack Row="true" AlignItems="AlignItems.Start" Justify="Justify.SpaceBetween" Style="width:100%; gap:12px;">
+                            <MudStack Row="true" AlignItems="AlignItems.Start" Style="width:100%; gap:12px;">
                                 <MudStack Spacing="1" Style="min-width:0;">
                                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="flex-wrap:wrap;">
                                         <MudText Typo="Typo.h6">@course.Name</MudText>
@@ -99,13 +99,6 @@
                                     <MudText Typo="Typo.body2" Color="Color.Secondary">@course.Description</MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatPeriod(course)</MudText>
                                 </MudStack>
-
-                                <MudButton Color="@(selected.IsJoined ? Color.Default : Color.Primary)"
-                                           Variant="@(selected.IsJoined ? Variant.Outlined : Variant.Filled)"
-                                           StartIcon="@(selected.IsJoined ? Icons.Material.Filled.Logout : Icons.Material.Filled.HowToReg)"
-                                           OnClick="@(() => ToggleCourseMembershipAsync(selected))">
-                                    @(selected.IsJoined ? "Austreten" : "Beitreten")
-                                </MudButton>
                             </MudStack>
 
                             <MudTabs Elevation="0" Rounded="false">


### PR DESCRIPTION
## Summary
- Entfernt den doppelten Beitreten/Austreten-Button aus dem großen Detailbereich des ausgewählten Kurses.
- Beitritt und Austritt bleiben über den kleinen Button in der oberen Kurskarte möglich.
- Reduziert doppelte Aktionen in der Kursübersicht und macht die Detailkarte ruhiger.

## Verification
- `dotnet build PaceLetics.Web\PaceLetics.Web.csproj --no-restore --disable-build-servers`