### PR TITLE
Add trainer course management

### DIFF
--- a/PaceLetics.Tests/CourseServiceTests.cs
+++ b/PaceLetics.Tests/CourseServiceTests.cs
@@ -5,6 +5,341 @@ namespace PaceLetics.Tests;
 public sealed class CourseServiceTests
 {
     [Fact]
+    public async Task CreateCourse_AddsCreatorAsTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        Assert.Equal("trainer-1", course.CreatedByTrainerUserId);
+        var trainer = Assert.Single(course.Trainers);
+        Assert.Equal("trainer-1", trainer.TrainerUserId);
+        Assert.Equal("Coach", trainer.DisplayName);
+    }
+
+    [Fact]
+    public async Task DeleteCourse_RequiresCreator()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.DeleteCourseAsync(course.Id, "trainer-2"));
+
+        Assert.NotNull(await repository.GetCourseAsync(course.Id));
+    }
+
+    [Fact]
+    public async Task DeleteCourse_RemovesCourseForCreator()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        await service.DeleteCourseAsync(course.Id, "trainer-1");
+
+        Assert.Null(await repository.GetCourseAsync(course.Id));
+    }
+
+    [Fact]
+    public async Task AddTrainer_AddsTrainerWhenRequesterCanManageMembers()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        await service.AddTrainerAsync(course.Id, "trainer-2", "Second Coach", "trainer-1");
+        var updatedCourse = await repository.GetCourseAsync(course.Id);
+
+        Assert.NotNull(updatedCourse);
+        Assert.Contains(updatedCourse.Trainers, trainer => trainer.TrainerUserId == "trainer-2");
+    }
+
+    [Fact]
+    public async Task RemoveTrainer_AllowsAddedTrainerToLeave()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+        await service.AddTrainerAsync(course.Id, "trainer-2", "Second Coach", "trainer-1");
+
+        await service.RemoveTrainerAsync(course.Id, "trainer-2", "trainer-2");
+        var updatedCourse = await repository.GetCourseAsync(course.Id);
+
+        Assert.NotNull(updatedCourse);
+        Assert.DoesNotContain(updatedCourse.Trainers, trainer => trainer.TrainerUserId == "trainer-2");
+    }
+
+    [Fact]
+    public async Task RemoveTrainer_DoesNotAllowCreatorToLeave()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.RemoveTrainerAsync(course.Id, "trainer-1", "trainer-1"));
+    }
+
+    [Fact]
+    public async Task AddCourseDate_AddsDateForAssignedTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        var date = await service.AddCourseDateAsync(
+            course.Id,
+            "Techniktraining",
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(1).AddHours(1),
+            "trainer-1",
+            "Stadion");
+        var updatedCourse = await repository.GetCourseAsync(course.Id);
+
+        Assert.NotNull(updatedCourse);
+        Assert.Contains(updatedCourse.Dates, existing => existing.Id == date.Id && existing.Location == "Stadion");
+    }
+
+    [Fact]
+    public async Task AddCourseDate_RequiresTrainerWithEventPermissions()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.AddCourseDateAsync(
+                course.Id,
+                "Techniktraining",
+                DateTime.UtcNow.AddDays(1),
+                DateTime.UtcNow.AddDays(1).AddHours(1),
+                "trainer-2"));
+    }
+
+    [Fact]
+    public async Task CreateEvent_AddsEventForAssignedTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        var courseEvent = await service.CreateEventAsync(
+            course.Id,
+            "Startanalyse",
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(1).AddHours(1),
+            "trainer-1");
+
+        Assert.Contains(repository.Events, existing => existing.Id == courseEvent.Id);
+    }
+
+    [Fact]
+    public async Task DeleteEvent_RemovesEventAndRegistrations()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+        await service.JoinCourseAsync(course.Id, "athlete-1");
+        var courseEvent = await service.CreateEventAsync(
+            course.Id,
+            "Startanalyse",
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(1).AddHours(1),
+            "trainer-1");
+        await service.RegisterForEventAsync(course.Id, courseEvent.Id, "athlete-1");
+
+        await service.DeleteEventAsync(course.Id, courseEvent.Id, "trainer-1");
+
+        Assert.DoesNotContain(repository.Events, existing => existing.Id == courseEvent.Id);
+        Assert.Empty(await repository.GetEventRegistrationsAsync(course.Id, courseEvent.Id));
+    }
+
+    [Fact]
+    public async Task GetEventRegistrationsForTrainer_ReturnsRegisteredParticipantsForAssignedTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+        await service.JoinCourseAsync(course.Id, "athlete-1");
+        await service.JoinCourseAsync(course.Id, "athlete-2");
+        var courseEvent = await service.CreateEventAsync(
+            course.Id,
+            "Startanalyse",
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(1).AddHours(1),
+            "trainer-1");
+        await service.RegisterForEventAsync(course.Id, courseEvent.Id, "athlete-1");
+        await service.RegisterForEventAsync(course.Id, courseEvent.Id, "athlete-2");
+        await service.LeaveCourseAsync(course.Id, "athlete-2");
+
+        var registrations = await service.GetEventRegistrationsForTrainerAsync(course.Id, courseEvent.Id, "trainer-1");
+
+        var registration = Assert.Single(registrations);
+        Assert.Equal("athlete-1", registration.AthleteUserId);
+    }
+
+    [Fact]
+    public async Task GetEventRegistrationsForTrainer_RequiresAssignedTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+        var courseEvent = await service.CreateEventAsync(
+            course.Id,
+            "Startanalyse",
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(1).AddHours(1),
+            "trainer-1");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.GetEventRegistrationsForTrainerAsync(course.Id, courseEvent.Id, "trainer-2"));
+    }
+
+    [Fact]
+    public async Task PublishTrainingPlan_AddsPublicationForAssignedTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        await service.PublishTrainingPlanAsync(course.Id, "plan-1", "trainer-1");
+        var updatedCourse = await repository.GetCourseAsync(course.Id);
+
+        Assert.NotNull(updatedCourse);
+        Assert.Contains(updatedCourse.TrainingPlanPublications, publication => publication.TrainingPlanId == "plan-1");
+    }
+
+    [Fact]
+    public async Task RemoveTrainingPlanPublication_RemovesPublicationForAssignedTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+        await service.PublishTrainingPlanAsync(course.Id, "plan-1", "trainer-1");
+
+        await service.RemoveTrainingPlanPublicationAsync(course.Id, "plan-1", "trainer-1");
+        var updatedCourse = await repository.GetCourseAsync(course.Id);
+
+        Assert.NotNull(updatedCourse);
+        Assert.Empty(updatedCourse.TrainingPlanPublications);
+    }
+
+    [Fact]
     public async Task JoinCourse_CreatesActiveEnrollment()
     {
         var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
@@ -68,6 +403,68 @@ public sealed class CourseServiceTests
         Assert.NotNull(registration);
         Assert.Equal(CourseEventRegistrationStatus.Cancelled, registration.Status);
         Assert.NotNull(registration.CancelledAt);
+    }
+
+    [Fact]
+    public async Task CancelEventRegistration_CancelsActiveRegistration()
+    {
+        var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
+        repository.Events.Add(new CourseEventDocument
+        {
+            Id = "event-1",
+            CourseId = "course-1",
+            Title = "Startanalyse",
+            StartsAt = DateTime.UtcNow.AddDays(1),
+            EndsAt = DateTime.UtcNow.AddDays(1).AddHours(1)
+        });
+        var service = new CourseService(repository);
+        await service.JoinCourseAsync("course-1", "athlete-1");
+        await service.RegisterForEventAsync("course-1", "event-1", "athlete-1");
+
+        var registration = await service.CancelEventRegistrationAsync("course-1", "event-1", "athlete-1");
+
+        Assert.Equal(CourseEventRegistrationStatus.Cancelled, registration.Status);
+        Assert.NotNull(registration.CancelledAt);
+    }
+
+    [Fact]
+    public async Task CancelEventRegistration_RequiresActiveRegistration()
+    {
+        var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
+        repository.Events.Add(new CourseEventDocument
+        {
+            Id = "event-1",
+            CourseId = "course-1",
+            Title = "Startanalyse",
+            StartsAt = DateTime.UtcNow.AddDays(1),
+            EndsAt = DateTime.UtcNow.AddDays(1).AddHours(1)
+        });
+        var service = new CourseService(repository);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CancelEventRegistrationAsync("course-1", "event-1", "athlete-1"));
+    }
+
+    [Fact]
+    public async Task GetEventRegistrationForAthlete_ReturnsRegistration()
+    {
+        var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
+        repository.Events.Add(new CourseEventDocument
+        {
+            Id = "event-1",
+            CourseId = "course-1",
+            Title = "Startanalyse",
+            StartsAt = DateTime.UtcNow.AddDays(1),
+            EndsAt = DateTime.UtcNow.AddDays(1).AddHours(1)
+        });
+        var service = new CourseService(repository);
+        await service.JoinCourseAsync("course-1", "athlete-1");
+        await service.RegisterForEventAsync("course-1", "event-1", "athlete-1");
+
+        var registration = await service.GetEventRegistrationForAthleteAsync("course-1", "event-1", "athlete-1");
+
+        Assert.NotNull(registration);
+        Assert.Equal(CourseEventRegistrationStatus.Registered, registration.Status);
     }
 
     [Fact]
@@ -140,6 +537,15 @@ public sealed class CourseServiceTests
             return Task.CompletedTask;
         }
 
+        public Task DeleteCourseAsync(string courseId)
+        {
+            _courses.RemoveAll(existing => existing.Id == courseId);
+            _enrollments.RemoveAll(existing => existing.CourseId == courseId);
+            Events.RemoveAll(existing => existing.CourseId == courseId);
+            _registrations.RemoveAll(existing => existing.CourseId == courseId);
+            return Task.CompletedTask;
+        }
+
         public Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForAthleteAsync(string athleteUserId)
         {
             return Task.FromResult<IReadOnlyList<CourseEnrollmentDocument>>(
@@ -180,8 +586,18 @@ public sealed class CourseServiceTests
 
         public Task UpsertEventAsync(CourseEventDocument courseEvent)
         {
+            if (string.IsNullOrWhiteSpace(courseEvent.Id))
+                courseEvent.Id = Guid.NewGuid().ToString("N");
+
             Events.RemoveAll(existing => existing.Id == courseEvent.Id);
             Events.Add(courseEvent);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteEventAsync(string courseId, string eventId)
+        {
+            Events.RemoveAll(existing => existing.CourseId == courseId && existing.Id == eventId);
+            _registrations.RemoveAll(existing => existing.CourseId == courseId && existing.EventId == eventId);
             return Task.CompletedTask;
         }
 

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -159,9 +159,26 @@
                                                         <MudText Typo="Typo.body2">@courseEvent.Title</MudText>
                                                         <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatEventDate(courseEvent)</MudText>
                                                     </div>
-                                                    <MudIconButton Icon="@Icons.Material.Filled.EventAvailable"
+                                                    @if (IsRegisteredForEvent(courseEvent.Id))
+                                                    {
+                                                        <MudButton Size="Size.Small"
+                                                                   Color="Color.Default"
+                                                                   Variant="Variant.Outlined"
+                                                                   StartIcon="@Icons.Material.Filled.EventBusy"
+                                                                   OnClick="@(() => CancelEventRegistrationAsync(course.Id, courseEvent.Id))">
+                                                            Abmelden
+                                                        </MudButton>
+                                                    }
+                                                    else
+                                                    {
+                                                        <MudButton Size="Size.Small"
                                                                    Color="Color.Primary"
-                                                                   OnClick="@(() => RegisterForEventAsync(course.Id, courseEvent.Id))" />
+                                                                   Variant="Variant.Filled"
+                                                                   StartIcon="@Icons.Material.Filled.EventAvailable"
+                                                                   OnClick="@(() => RegisterForEventAsync(course.Id, courseEvent.Id))">
+                                                            Anmelden
+                                                        </MudButton>
+                                                    }
                                                 </div>
                                             }
                                         </MudStack>
@@ -183,6 +200,7 @@
     private string? _selectedCourseId;
     private IReadOnlyList<CourseOverview> _courses = Array.Empty<CourseOverview>();
     private Dictionary<string, IReadOnlyList<CourseEventDocument>> _eventsByCourse = new();
+    private Dictionary<string, CourseEventRegistrationDocument> _registeredEvents = new(StringComparer.OrdinalIgnoreCase);
 
     private CourseOverview? SelectedOverview =>
         _courses.FirstOrDefault(course => course.Course.Id == _selectedCourseId)
@@ -203,10 +221,23 @@
             _errorMessage = null;
             _courses = await CourseService.GetCoursesForAthleteAsync(_userId ?? string.Empty);
             _eventsByCourse = new Dictionary<string, IReadOnlyList<CourseEventDocument>>();
+            _registeredEvents = new Dictionary<string, CourseEventRegistrationDocument>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var course in _courses.Where(course => course.IsJoined).Select(course => course.Course))
             {
-                _eventsByCourse[course.Id] = await CourseService.GetEventsAsync(course.Id);
+                var courseEvents = await CourseService.GetEventsAsync(course.Id);
+                _eventsByCourse[course.Id] = courseEvents;
+
+                foreach (var courseEvent in courseEvents)
+                {
+                    var registration = await CourseService.GetEventRegistrationForAthleteAsync(
+                        course.Id,
+                        courseEvent.Id,
+                        _userId ?? string.Empty);
+
+                    if (registration?.Status == CourseEventRegistrationStatus.Registered)
+                        _registeredEvents[courseEvent.Id] = registration;
+                }
             }
 
             if (_courses.Count == 0)
@@ -282,7 +313,22 @@
         try
         {
             await CourseService.RegisterForEventAsync(courseId, eventId, _userId ?? string.Empty);
+            await LoadCoursesAsync();
             Snackbar.Add("Du bist für das Event angemeldet.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task CancelEventRegistrationAsync(string courseId, string eventId)
+    {
+        try
+        {
+            await CourseService.CancelEventRegistrationAsync(courseId, eventId, _userId ?? string.Empty);
+            await LoadCoursesAsync();
+            Snackbar.Add("Du bist fuer das Event abgemeldet.", Severity.Success);
         }
         catch (Exception ex)
         {
@@ -302,6 +348,11 @@
         return _eventsByCourse.TryGetValue(courseId, out var events)
             ? events.OrderBy(courseEvent => courseEvent.StartsAt)
             : Array.Empty<CourseEventDocument>();
+    }
+
+    private bool IsRegisteredForEvent(string eventId)
+    {
+        return _registeredEvents.ContainsKey(eventId);
     }
 
     private static string GetCourseCardStyle(bool isSelected)

--- a/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
@@ -1,0 +1,908 @@
+@page "/Trainers/courses"
+@attribute [Authorize(Roles = ApplicationRoles.Trainer)]
+@using AthleteDataAccessLibrary.Contracts
+@using PaceLetics.AthleteModule.CodeBase.Models
+@using PaceLetics.TrainingPlanModule.CodeBase.Models
+@using PaceLetics.Web.Services
+@using PaceLetics.Web.Services.Courses
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ICourseService CourseService
+@inject ITrainingPlanService TrainingPlanService
+@inject IAthleteData AthleteData
+@inject IJSRuntime JS
+@inject ISnackbar Snackbar
+
+<PageTitle>Kurse verwalten</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Medium">
+    @if (_isLoading)
+    {
+        <LoadingScreen Label="Kurse werden geladen" />
+    }
+    else
+    {
+        <PageHeader Title="Kurse verwalten"
+                    Subtitle="Kurse erstellen, Trainer:innen hinzufuegen und eigene Kurse loeschen." />
+
+        <MudDivider Class="my-4" />
+
+        @if (!string.IsNullOrWhiteSpace(_errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">@_errorMessage</MudAlert>
+        }
+
+        <MudStack Spacing="4">
+            <MudPaper Elevation="1" Class="pa-4">
+                <MudStack Spacing="3">
+                    <MudText Typo="Typo.h6">Neuen Kurs erstellen</MudText>
+
+                    <MudGrid Spacing="2">
+                        <MudItem xs="12" md="6">
+                            <MudTextField Label="Name" @bind-Value="_courseName" Variant="Variant.Outlined" />
+                        </MudItem>
+                        <MudItem xs="12" md="6">
+                            <MudTextField Label="Level" @bind-Value="_courseLevel" Variant="Variant.Outlined" />
+                        </MudItem>
+                        <MudItem xs="12">
+                            <MudTextField Label="Beschreibung"
+                                          @bind-Value="_courseDescription"
+                                          Variant="Variant.Outlined"
+                                          Lines="3" />
+                        </MudItem>
+                        <MudItem xs="12" md="6">
+                            <MudDatePicker Label="Start"
+                                           Date="_courseStartDate"
+                                           DateChanged="@(date => _courseStartDate = date)"
+                                           Variant="Variant.Outlined" />
+                        </MudItem>
+                        <MudItem xs="12" md="6">
+                            <MudDatePicker Label="Ende"
+                                           Date="_courseEndDate"
+                                           DateChanged="@(date => _courseEndDate = date)"
+                                           Variant="Variant.Outlined" />
+                        </MudItem>
+                    </MudGrid>
+
+                    <MudStack Row="true" Justify="Justify.FlexEnd">
+                        <MudButton Color="Color.Primary"
+                                   Variant="Variant.Filled"
+                                   StartIcon="@Icons.Material.Filled.Add"
+                                   OnClick="CreateCourseAsync">
+                            Kurs erstellen
+                        </MudButton>
+                    </MudStack>
+                </MudStack>
+            </MudPaper>
+
+            @if (_courses.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                    Du bist aktuell keinem Kurs als Trainer:in zugeordnet.
+                </MudAlert>
+            }
+            else
+            {
+                <MudPaper Elevation="1" Class="pa-4">
+                    <MudStack Spacing="3">
+                        <MudSelect T="string"
+                                   Label="Kurs"
+                                   Value="_selectedCourseId"
+                                   ValueChanged="OnSelectedCourseChanged"
+                                   Variant="Variant.Outlined">
+                            @foreach (var course in _courses)
+                            {
+                                <MudSelectItem T="string" Value="@course.Id">@course.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+
+                        @if (SelectedCourse is not null)
+                        {
+                            var course = SelectedCourse;
+                            var isCreator = IsCreator(course);
+                            var canLeave = IsAssignedTrainer(course) && !isCreator;
+
+                            <MudDivider />
+
+                            <MudStack Spacing="2">
+                                <MudStack Row="true" AlignItems="AlignItems.Start" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                                    <MudStack Spacing="1" Style="min-width:0;">
+                                        <MudText Typo="Typo.h6">@course.Name</MudText>
+                                        <MudText Typo="Typo.body2" Color="Color.Secondary">@course.Description</MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatPeriod(course)</MudText>
+                                    </MudStack>
+
+                                    @if (isCreator)
+                                    {
+                                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                       Color="Color.Error"
+                                                       OnClick="@(() => DeleteCourseAsync(course))" />
+                                    }
+                                    else if (canLeave)
+                                    {
+                                        <MudButton Size="Size.Small"
+                                                   Color="Color.Default"
+                                                   Variant="Variant.Outlined"
+                                                   StartIcon="@Icons.Material.Filled.Logout"
+                                                   OnClick="@(() => LeaveTrainerAsync(course))">
+                                            Austreten
+                                        </MudButton>
+                                    }
+                                </MudStack>
+
+                                <MudText Typo="Typo.subtitle2">Trainer:innen</MudText>
+                                <MudStack Spacing="1">
+                                    @foreach (var trainer in course.Trainers.OrderBy(trainer => trainer.DisplayName))
+                                    {
+                                        <MudPaper Elevation="0" Class="pa-2" Style="border:1px solid var(--mud-palette-lines-default);">
+                                            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                                                <MudStack Spacing="0" Style="min-width:0;">
+                                                    <MudText Typo="Typo.body2">@trainer.DisplayName</MudText>
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@trainer.Role</MudText>
+                                                </MudStack>
+
+                                                @if (isCreator && trainer.TrainerUserId != course.CreatedByTrainerUserId)
+                                                {
+                                                    <MudIconButton Icon="@Icons.Material.Filled.PersonRemove"
+                                                                   Color="Color.Default"
+                                                                   OnClick="@(() => RemoveTrainerAsync(course, trainer))" />
+                                                }
+                                            </MudStack>
+                                        </MudPaper>
+                                    }
+                                </MudStack>
+
+                                <MudDivider Class="my-2" />
+
+                                <MudStack Row="true" AlignItems="AlignItems.End" Style="gap:12px; flex-wrap:wrap;">
+                                    <MudSelect T="string"
+                                               Label="Trainer:in hinzufuegen"
+                                               Value="_selectedTrainerToAddId"
+                                               ValueChanged="OnTrainerToAddChanged"
+                                               Variant="Variant.Outlined"
+                                               Style="min-width:260px; flex:1;">
+                                        @foreach (var trainer in AvailableTrainerCandidates)
+                                        {
+                                            <MudSelectItem T="string" Value="@trainer.UserId">@trainer.DisplayName</MudSelectItem>
+                                        }
+                                    </MudSelect>
+
+                                    <MudButton Color="Color.Primary"
+                                               Variant="Variant.Filled"
+                                               StartIcon="@Icons.Material.Filled.PersonAdd"
+                                               Disabled="@string.IsNullOrWhiteSpace(_selectedTrainerToAddId)"
+                                               OnClick="@(() => AddTrainerAsync(course))">
+                                        Hinzufuegen
+                                    </MudButton>
+                                </MudStack>
+
+                                <MudTabs Elevation="0" Rounded="false" Class="mt-2">
+                                    <MudTabPanel Text="Termine">
+                                        <MudStack Spacing="2" Class="pt-2">
+                                            @if (course.Dates.Count == 0)
+                                            {
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Termine.</MudText>
+                                            }
+                                            else
+                                            {
+                                                @foreach (var date in course.Dates.OrderBy(date => date.StartsAt))
+                                                {
+                                                    <MudPaper Elevation="0" Class="pa-2" Style="border:1px solid var(--mud-palette-lines-default);">
+                                                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                                                            <MudStack Spacing="0" Style="min-width:0;">
+                                                                <MudText Typo="Typo.body2">@date.Title</MudText>
+                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatDateRange(date.StartsAt, date.EndsAt)</MudText>
+                                                                @if (!string.IsNullOrWhiteSpace(date.Location))
+                                                                {
+                                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@date.Location</MudText>
+                                                                }
+                                                            </MudStack>
+                                                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                                           Color="Color.Default"
+                                                                           OnClick="@(() => RemoveCourseDateAsync(course, date))" />
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                }
+                                            }
+
+                                            <MudDivider Class="my-2" />
+                                            <MudGrid Spacing="2">
+                                                <MudItem xs="12" md="6">
+                                                    <MudTextField Label="Titel" @bind-Value="_dateTitle" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudTextField Label="Ort" @bind-Value="_dateLocation" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="4">
+                                                    <MudDatePicker Label="Datum" Date="_dateStartDate" DateChanged="@(date => _dateStartDate = date)" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="6" md="4">
+                                                    <MudTextField Label="Startzeit" @bind-Value="_dateStartTime" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="6" md="4">
+                                                    <MudTextField Label="Endzeit" @bind-Value="_dateEndTime" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12">
+                                                    <MudTextField Label="Notizen" @bind-Value="_dateNotes" Variant="Variant.Outlined" Lines="2" />
+                                                </MudItem>
+                                            </MudGrid>
+                                            <MudStack Row="true" Justify="Justify.FlexEnd">
+                                                <MudButton Color="Color.Primary"
+                                                           Variant="Variant.Filled"
+                                                           StartIcon="@Icons.Material.Filled.Event"
+                                                           OnClick="@(() => AddCourseDateAsync(course))">
+                                                    Termin hinzufuegen
+                                                </MudButton>
+                                            </MudStack>
+                                        </MudStack>
+                                    </MudTabPanel>
+
+                                    <MudTabPanel Text="Events">
+                                        <MudStack Spacing="2" Class="pt-2">
+                                            @if (_selectedCourseEvents.Count == 0)
+                                            {
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Events.</MudText>
+                                            }
+                                            else
+                                            {
+                                                @foreach (var courseEvent in _selectedCourseEvents.OrderBy(courseEvent => courseEvent.StartsAt))
+                                                {
+                                                    <MudPaper Elevation="0" Class="pa-2" Style="border:1px solid var(--mud-palette-lines-default);">
+                                                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+                                                            <MudStack Spacing="0" Style="min-width:0;">
+                                                                <MudText Typo="Typo.body2">@courseEvent.Title</MudText>
+                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatDateRange(courseEvent.StartsAt, courseEvent.EndsAt)</MudText>
+                                                                @if (!string.IsNullOrWhiteSpace(courseEvent.Location))
+                                                                {
+                                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@courseEvent.Location</MudText>
+                                                                }
+                                                            </MudStack>
+                                                            <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:4px;">
+                                                                <MudButton Size="Size.Small"
+                                                                           Variant="Variant.Text"
+                                                                           Color="Color.Primary"
+                                                                           StartIcon="@Icons.Material.Filled.People"
+                                                                           OnClick="@(() => ToggleEventParticipantsAsync(course, courseEvent))">
+                                                                    @GetParticipantsButtonText(courseEvent.Id)
+                                                                </MudButton>
+                                                                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                                               Color="Color.Default"
+                                                                               OnClick="@(() => DeleteEventAsync(course, courseEvent))" />
+                                                            </MudStack>
+                                                        </MudStack>
+
+                                                        @if (IsParticipantListOpen(courseEvent.Id))
+                                                        {
+                                                            <MudDivider Class="my-2" />
+
+                                                            @if (_eventParticipants.TryGetValue(courseEvent.Id, out var participants) && participants.Count > 0)
+                                                            {
+                                                                <MudStack Spacing="1">
+                                                                    @foreach (var participant in participants)
+                                                                    {
+                                                                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                                                                            <MudText Typo="Typo.body2">@GetParticipantDisplayName(participant.AthleteUserId)</MudText>
+                                                                            <MudText Typo="Typo.caption" Color="Color.Secondary">@participant.RegisteredAt.ToString("dd.MM.yyyy HH:mm")</MudText>
+                                                                        </MudStack>
+                                                                    }
+                                                                </MudStack>
+                                                            }
+                                                            else
+                                                            {
+                                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Teilnehmenden registriert.</MudText>
+                                                            }
+                                                        }
+                                                    </MudPaper>
+                                                }
+                                            }
+
+                                            <MudDivider Class="my-2" />
+                                            <MudGrid Spacing="2">
+                                                <MudItem xs="12" md="6">
+                                                    <MudTextField Label="Titel" @bind-Value="_eventTitle" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudTextField Label="Ort" @bind-Value="_eventLocation" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12">
+                                                    <MudTextField Label="Beschreibung" @bind-Value="_eventDescription" Variant="Variant.Outlined" Lines="2" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="4">
+                                                    <MudDatePicker Label="Datum" Date="_eventStartDate" DateChanged="@(date => _eventStartDate = date)" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="6" md="4">
+                                                    <MudTextField Label="Startzeit" @bind-Value="_eventStartTime" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="6" md="4">
+                                                    <MudTextField Label="Endzeit" @bind-Value="_eventEndTime" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudNumericField T="int?" Label="Kapazitaet" @bind-Value="_eventCapacity" Variant="Variant.Outlined" Min="1" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudDatePicker Label="Anmeldefrist" Date="_eventRegistrationDeadline" DateChanged="@(date => _eventRegistrationDeadline = date)" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                            </MudGrid>
+                                            <MudStack Row="true" Justify="Justify.FlexEnd">
+                                                <MudButton Color="Color.Primary"
+                                                           Variant="Variant.Filled"
+                                                           StartIcon="@Icons.Material.Filled.EventAvailable"
+                                                           OnClick="@(() => CreateEventAsync(course))">
+                                                    Event hinzufuegen
+                                                </MudButton>
+                                            </MudStack>
+                                        </MudStack>
+                                    </MudTabPanel>
+
+                                    <MudTabPanel Text="Trainingsplaene">
+                                        <MudStack Spacing="2" Class="pt-2">
+                                            @if (course.TrainingPlanPublications.Count == 0)
+                                            {
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch kein Plan veroeffentlicht.</MudText>
+                                            }
+                                            else
+                                            {
+                                                @foreach (var publication in course.TrainingPlanPublications.OrderBy(publication => publication.TrainingPlanId))
+                                                {
+                                                    <MudPaper Elevation="0" Class="pa-2" Style="border:1px solid var(--mud-palette-lines-default);">
+                                                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                                                            <MudStack Spacing="0" Style="min-width:0;">
+                                                                <MudText Typo="Typo.body2">@GetTrainingPlanName(publication.TrainingPlanId)</MudText>
+                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">Seit @publication.PublishedAt.ToString("dd.MM.yyyy")</MudText>
+                                                            </MudStack>
+                                                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                                           Color="Color.Default"
+                                                                           OnClick="@(() => RemoveTrainingPlanAsync(course, publication.TrainingPlanId))" />
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                }
+                                            }
+
+                                            <MudDivider Class="my-2" />
+                                            <MudStack Row="true" AlignItems="AlignItems.End" Style="gap:12px; flex-wrap:wrap;">
+                                                <MudSelect T="string"
+                                                           Label="Trainingsplan"
+                                                           Value="_selectedTrainingPlanId"
+                                                           ValueChanged="OnTrainingPlanChanged"
+                                                           Variant="Variant.Outlined"
+                                                           Style="min-width:260px; flex:1;">
+                                                    @foreach (var plan in AvailableTrainingPlans(course))
+                                                    {
+                                                        <MudSelectItem T="string" Value="@plan.Id">@plan.Name</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                                <MudButton Color="Color.Primary"
+                                                           Variant="Variant.Filled"
+                                                           StartIcon="@Icons.Material.Filled.Publish"
+                                                           Disabled="@string.IsNullOrWhiteSpace(_selectedTrainingPlanId)"
+                                                           OnClick="@(() => PublishTrainingPlanAsync(course))">
+                                                    Plan hinzufuegen
+                                                </MudButton>
+                                            </MudStack>
+                                        </MudStack>
+                                    </MudTabPanel>
+                                </MudTabs>
+                            </MudStack>
+                        }
+                    </MudStack>
+                </MudPaper>
+            }
+        </MudStack>
+    }
+</MudContainer>
+
+@code {
+    private bool _isLoading = true;
+    private string? _userId;
+    private string _displayName = string.Empty;
+    private string? _errorMessage;
+    private string? _selectedCourseId;
+    private string? _selectedTrainerToAddId;
+    private string? _selectedTrainingPlanId;
+    private List<CourseDocument> _courses = new();
+    private List<TrainerCandidate> _trainerCandidates = new();
+    private List<CourseEventDocument> _selectedCourseEvents = new();
+    private List<TrainingPlan> _trainingPlans = new();
+    private Dictionary<string, string> _athleteDisplayNamesById = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, IReadOnlyList<CourseEventRegistrationDocument>> _eventParticipants = new(StringComparer.OrdinalIgnoreCase);
+    private HashSet<string> _openParticipantLists = new(StringComparer.OrdinalIgnoreCase);
+
+    private string _courseName = string.Empty;
+    private string _courseDescription = string.Empty;
+    private string _courseLevel = string.Empty;
+    private DateTime? _courseStartDate = DateTime.Today;
+    private DateTime? _courseEndDate = DateTime.Today.AddMonths(3);
+
+    private string _dateTitle = string.Empty;
+    private string _dateLocation = string.Empty;
+    private string _dateNotes = string.Empty;
+    private DateTime? _dateStartDate = DateTime.Today;
+    private string _dateStartTime = "18:00";
+    private string _dateEndTime = "19:30";
+
+    private string _eventTitle = string.Empty;
+    private string _eventDescription = string.Empty;
+    private string _eventLocation = string.Empty;
+    private DateTime? _eventStartDate = DateTime.Today;
+    private string _eventStartTime = "18:00";
+    private string _eventEndTime = "19:30";
+    private int? _eventCapacity;
+    private DateTime? _eventRegistrationDeadline;
+
+    private CourseDocument? SelectedCourse =>
+        _courses.FirstOrDefault(course => course.Id == _selectedCourseId)
+            ?? _courses.FirstOrDefault();
+
+    private IEnumerable<TrainerCandidate> AvailableTrainerCandidates =>
+        SelectedCourse is null
+            ? _trainerCandidates
+            : _trainerCandidates.Where(candidate =>
+                SelectedCourse.Trainers.All(trainer => trainer.TrainerUserId != candidate.UserId));
+
+    private IEnumerable<TrainingPlan> AvailableTrainingPlans(CourseDocument course)
+    {
+        var publishedPlanIds = course.TrainingPlanPublications
+            .Select(publication => publication.TrainingPlanId)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return _trainingPlans.Where(plan => !publishedPlanIds.Contains(plan.Id));
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            _isLoading = true;
+            _errorMessage = null;
+
+            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            var user = authState.User;
+            _userId = user.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
+
+            if (string.IsNullOrWhiteSpace(_userId))
+                throw new InvalidOperationException("Trainer:in konnte nicht ermittelt werden.");
+
+            var athlete = await AthleteData.GetAthlete(_userId);
+            _displayName = GetDisplayName(athlete, user.Identity?.Name ?? _userId);
+
+            var athletes = (await AthleteData.GetAthletes()).ToList();
+            _athleteDisplayNamesById = athletes
+                .ToDictionary(athlete => athlete.Id, athlete => GetDisplayName(athlete, athlete.Id), StringComparer.OrdinalIgnoreCase);
+
+            _trainerCandidates = athletes
+                .Where(athlete => athlete.Id != _userId
+                    && athlete.Roles.AssignedRoles.Contains(ApplicationRoles.Trainer))
+                .Select(athlete => new TrainerCandidate(athlete.Id, GetDisplayName(athlete, athlete.Id)))
+                .OrderBy(trainer => trainer.DisplayName)
+                .ToList();
+
+            _courses = (await CourseService.GetCoursesForTrainerAsync(_userId)).ToList();
+            _trainingPlans = TrainingPlanService.LoadTrainingPlans().ToList();
+            EnsureSelection();
+            await LoadSelectedCourseEventsAsync();
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = ex.Message;
+            _courses = new();
+            _selectedCourseEvents = new();
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private void EnsureSelection()
+    {
+        if (_courses.Count == 0)
+        {
+            _selectedCourseId = null;
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(_selectedCourseId)
+            || _courses.All(course => course.Id != _selectedCourseId))
+        {
+            _selectedCourseId = _courses.First().Id;
+        }
+    }
+
+    private Task OnSelectedCourseChanged(string courseId)
+    {
+        _selectedCourseId = courseId;
+        _selectedTrainerToAddId = null;
+        _selectedTrainingPlanId = null;
+        _eventParticipants.Clear();
+        _openParticipantLists.Clear();
+        return LoadSelectedCourseEventsAsync();
+    }
+
+    private Task OnTrainerToAddChanged(string trainerUserId)
+    {
+        _selectedTrainerToAddId = trainerUserId;
+        return Task.CompletedTask;
+    }
+
+    private Task OnTrainingPlanChanged(string trainingPlanId)
+    {
+        _selectedTrainingPlanId = trainingPlanId;
+        return Task.CompletedTask;
+    }
+
+    private async Task LoadSelectedCourseEventsAsync()
+    {
+        _selectedCourseEvents = SelectedCourse is null
+            ? new List<CourseEventDocument>()
+            : (await CourseService.GetEventsAsync(SelectedCourse.Id)).ToList();
+
+        _eventParticipants.Clear();
+        _openParticipantLists.Clear();
+    }
+
+    private async Task CreateCourseAsync()
+    {
+        try
+        {
+            var course = await CourseService.CreateCourseAsync(
+                new CourseCreateRequest
+                {
+                    Name = _courseName,
+                    Description = _courseDescription,
+                    Level = _courseLevel,
+                    StartDate = _courseStartDate ?? DateTime.Today,
+                    EndDate = _courseEndDate ?? DateTime.Today,
+                    IsPublished = true
+                },
+                _userId ?? string.Empty,
+                _displayName);
+
+            Snackbar.Add("Kurs wurde erstellt.", Severity.Success);
+            ResetCreateForm();
+            _selectedCourseId = course.Id;
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task DeleteCourseAsync(CourseDocument course)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Kurs \"{course.Name}\" wirklich loeschen?");
+        if (!confirmed)
+            return;
+
+        try
+        {
+            await CourseService.DeleteCourseAsync(course.Id, _userId ?? string.Empty);
+            Snackbar.Add("Kurs wurde geloescht.", Severity.Success);
+            _selectedCourseId = null;
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task AddTrainerAsync(CourseDocument course)
+    {
+        var candidate = _trainerCandidates.FirstOrDefault(trainer => trainer.UserId == _selectedTrainerToAddId);
+        if (candidate is null)
+            return;
+
+        try
+        {
+            await CourseService.AddTrainerAsync(
+                course.Id,
+                candidate.UserId,
+                candidate.DisplayName,
+                _userId ?? string.Empty);
+
+            Snackbar.Add("Trainer:in wurde hinzugefuegt.", Severity.Success);
+            _selectedTrainerToAddId = null;
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task RemoveTrainerAsync(CourseDocument course, CourseTrainerDocument trainer)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"{trainer.DisplayName} aus dem Kurs entfernen?");
+        if (!confirmed)
+            return;
+
+        try
+        {
+            await CourseService.RemoveTrainerAsync(course.Id, trainer.TrainerUserId, _userId ?? string.Empty);
+            Snackbar.Add("Trainer:in wurde entfernt.", Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task LeaveTrainerAsync(CourseDocument course)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Als Trainer:in aus \"{course.Name}\" austreten?");
+        if (!confirmed)
+            return;
+
+        try
+        {
+            await CourseService.RemoveTrainerAsync(course.Id, _userId ?? string.Empty, _userId ?? string.Empty);
+            Snackbar.Add("Du bist als Trainer:in ausgetreten.", Severity.Success);
+            _selectedCourseId = null;
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task AddCourseDateAsync(CourseDocument course)
+    {
+        try
+        {
+            var startsAt = CombineDateAndTime(_dateStartDate, _dateStartTime);
+            var endsAt = CombineDateAndTime(_dateStartDate, _dateEndTime);
+
+            await CourseService.AddCourseDateAsync(
+                course.Id,
+                _dateTitle,
+                startsAt,
+                endsAt,
+                _userId ?? string.Empty,
+                _dateLocation,
+                _dateNotes);
+
+            Snackbar.Add("Termin wurde hinzugefuegt.", Severity.Success);
+            ResetDateForm();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task RemoveCourseDateAsync(CourseDocument course, CourseDateDocument date)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Termin \"{date.Title}\" entfernen?");
+        if (!confirmed)
+            return;
+
+        try
+        {
+            await CourseService.RemoveCourseDateAsync(course.Id, date.Id, _userId ?? string.Empty);
+            Snackbar.Add("Termin wurde entfernt.", Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task CreateEventAsync(CourseDocument course)
+    {
+        try
+        {
+            var startsAt = CombineDateAndTime(_eventStartDate, _eventStartTime);
+            var endsAt = CombineDateAndTime(_eventStartDate, _eventEndTime);
+
+            await CourseService.CreateEventAsync(
+                course.Id,
+                _eventTitle,
+                startsAt,
+                endsAt,
+                _userId ?? string.Empty,
+                _eventDescription,
+                _eventLocation,
+                _eventCapacity,
+                _eventRegistrationDeadline?.Date);
+
+            Snackbar.Add("Event wurde hinzugefuegt.", Severity.Success);
+            ResetEventForm();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task DeleteEventAsync(CourseDocument course, CourseEventDocument courseEvent)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Event \"{courseEvent.Title}\" entfernen?");
+        if (!confirmed)
+            return;
+
+        try
+        {
+            await CourseService.DeleteEventAsync(course.Id, courseEvent.Id, _userId ?? string.Empty);
+            Snackbar.Add("Event wurde entfernt.", Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task ToggleEventParticipantsAsync(CourseDocument course, CourseEventDocument courseEvent)
+    {
+        if (_openParticipantLists.Remove(courseEvent.Id))
+            return;
+
+        try
+        {
+            if (!_eventParticipants.ContainsKey(courseEvent.Id))
+            {
+                _eventParticipants[courseEvent.Id] =
+                    await CourseService.GetEventRegistrationsForTrainerAsync(course.Id, courseEvent.Id, _userId ?? string.Empty);
+            }
+
+            _openParticipantLists.Add(courseEvent.Id);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task PublishTrainingPlanAsync(CourseDocument course)
+    {
+        if (string.IsNullOrWhiteSpace(_selectedTrainingPlanId))
+            return;
+
+        try
+        {
+            await CourseService.PublishTrainingPlanAsync(
+                course.Id,
+                _selectedTrainingPlanId,
+                _userId ?? string.Empty);
+
+            Snackbar.Add("Trainingsplan wurde hinzugefuegt.", Severity.Success);
+            _selectedTrainingPlanId = null;
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task RemoveTrainingPlanAsync(CourseDocument course, string trainingPlanId)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Trainingsplan \"{GetTrainingPlanName(trainingPlanId)}\" entfernen?");
+        if (!confirmed)
+            return;
+
+        try
+        {
+            await CourseService.RemoveTrainingPlanPublicationAsync(course.Id, trainingPlanId, _userId ?? string.Empty);
+            Snackbar.Add("Trainingsplan wurde entfernt.", Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private void ResetCreateForm()
+    {
+        _courseName = string.Empty;
+        _courseDescription = string.Empty;
+        _courseLevel = string.Empty;
+        _courseStartDate = DateTime.Today;
+        _courseEndDate = DateTime.Today.AddMonths(3);
+    }
+
+    private void ResetDateForm()
+    {
+        _dateTitle = string.Empty;
+        _dateLocation = string.Empty;
+        _dateNotes = string.Empty;
+        _dateStartDate = DateTime.Today;
+        _dateStartTime = "18:00";
+        _dateEndTime = "19:30";
+    }
+
+    private void ResetEventForm()
+    {
+        _eventTitle = string.Empty;
+        _eventDescription = string.Empty;
+        _eventLocation = string.Empty;
+        _eventStartDate = DateTime.Today;
+        _eventStartTime = "18:00";
+        _eventEndTime = "19:30";
+        _eventCapacity = null;
+        _eventRegistrationDeadline = null;
+    }
+
+    private bool IsCreator(CourseDocument course)
+    {
+        return course.CreatedByTrainerUserId == _userId;
+    }
+
+    private bool IsAssignedTrainer(CourseDocument course)
+    {
+        return course.Trainers.Any(trainer => trainer.TrainerUserId == _userId);
+    }
+
+    private static string FormatPeriod(CourseDocument course)
+    {
+        return $"{course.StartDate:dd.MM.yyyy} bis {course.EndDate:dd.MM.yyyy}";
+    }
+
+    private static string FormatDateRange(DateTime startsAt, DateTime endsAt)
+    {
+        return $"{startsAt:dd.MM.yyyy HH:mm} bis {endsAt:HH:mm} Uhr";
+    }
+
+    private string GetTrainingPlanName(string trainingPlanId)
+    {
+        return _trainingPlans.FirstOrDefault(plan => plan.Id == trainingPlanId)?.Name ?? trainingPlanId;
+    }
+
+    private bool IsParticipantListOpen(string eventId)
+    {
+        return _openParticipantLists.Contains(eventId);
+    }
+
+    private string GetParticipantsButtonText(string eventId)
+    {
+        if (!_eventParticipants.TryGetValue(eventId, out var participants))
+            return "Teilnehmende";
+
+        return $"Teilnehmende ({participants.Count})";
+    }
+
+    private string GetParticipantDisplayName(string athleteUserId)
+    {
+        return _athleteDisplayNamesById.TryGetValue(athleteUserId, out var displayName)
+            ? displayName
+            : athleteUserId;
+    }
+
+    private static DateTime CombineDateAndTime(DateTime? date, string time)
+    {
+        if (date is null)
+            throw new InvalidOperationException("Bitte ein Datum auswaehlen.");
+
+        if (!TimeSpan.TryParse(time, out var parsedTime))
+            throw new InvalidOperationException("Bitte eine Uhrzeit im Format HH:mm eingeben.");
+
+        return date.Value.Date.Add(parsedTime);
+    }
+
+    private static string GetDisplayName(AthleteModel? athlete, string fallback)
+    {
+        if (!string.IsNullOrWhiteSpace(athlete?.PublicProfile?.PublicUserName)
+            && athlete.PublicProfile.PublicUserName != "NA")
+        {
+            return athlete.PublicProfile.PublicUserName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(athlete?.Name) && athlete.Name != "NA")
+            return athlete.Name;
+
+        return fallback;
+    }
+
+    private sealed record TrainerCandidate(string UserId, string DisplayName);
+}

--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Laufdaten</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pacebereiche</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>Meine Kurse</value></data>
+  <data name="Nav_TrainerCourses" xml:space="preserve"><value>Kurse verwalten</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Trainingsplanung</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profile</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
+  <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/PaceLetics.Web/Services/Courses/CosmosCourseRepository.cs
+++ b/PaceLetics.Web/Services/Courses/CosmosCourseRepository.cs
@@ -50,6 +50,44 @@ public sealed class CosmosCourseRepository : ICourseRepository
             course.CourseId);
     }
 
+    public async Task DeleteCourseAsync(string courseId)
+    {
+        var registrations = await LoadPartitionItems<CourseEventRegistrationDocument>(
+            courseId,
+            CourseDocumentTypes.EventRegistration);
+        var events = await LoadPartitionItems<CourseEventDocument>(courseId, CourseDocumentTypes.Event);
+        var enrollments = await LoadPartitionItems<CourseEnrollmentDocument>(
+            courseId,
+            CourseDocumentTypes.Enrollment);
+
+        foreach (var registration in registrations)
+            await _db.DeleteItem<CourseEventRegistrationDocument>(
+                _options.DatabaseName,
+                _options.CourseContainerName,
+                registration.Id,
+                courseId);
+
+        foreach (var courseEvent in events)
+            await _db.DeleteItem<CourseEventDocument>(
+                _options.DatabaseName,
+                _options.CourseContainerName,
+                courseEvent.Id,
+                courseId);
+
+        foreach (var enrollment in enrollments)
+            await _db.DeleteItem<CourseEnrollmentDocument>(
+                _options.DatabaseName,
+                _options.CourseContainerName,
+                enrollment.Id,
+                courseId);
+
+        await _db.DeleteItem<CourseDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            courseId,
+            courseId);
+    }
+
     public async Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForAthleteAsync(string athleteUserId)
     {
         if (string.IsNullOrWhiteSpace(athleteUserId))
@@ -127,6 +165,26 @@ public sealed class CosmosCourseRepository : ICourseRepository
             _options.CourseContainerName,
             courseEvent,
             courseEvent.CourseId);
+    }
+
+    public async Task DeleteEventAsync(string courseId, string eventId)
+    {
+        var registrations = await GetEventRegistrationsAsync(courseId, eventId);
+
+        foreach (var registration in registrations)
+        {
+            await _db.DeleteItem<CourseEventRegistrationDocument>(
+                _options.DatabaseName,
+                _options.CourseContainerName,
+                registration.Id,
+                courseId);
+        }
+
+        await _db.DeleteItem<CourseEventDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            eventId,
+            courseId);
     }
 
     public async Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsAsync(string courseId, string eventId)

--- a/PaceLetics.Web/Services/Courses/CourseDocuments.cs
+++ b/PaceLetics.Web/Services/Courses/CourseDocuments.cs
@@ -33,10 +33,22 @@ public sealed class CourseDocument : IQueryItem
     public string Level { get; set; } = string.Empty;
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
+    public string CreatedByTrainerUserId { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
     public bool IsPublished { get; set; } = true;
     public List<CourseDateDocument> Dates { get; set; } = new();
     public List<CourseTrainerDocument> Trainers { get; set; } = new();
     public List<CourseTrainingPlanPublicationDocument> TrainingPlanPublications { get; set; } = new();
+}
+
+public sealed class CourseCreateRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Level { get; set; } = string.Empty;
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public bool IsPublished { get; set; } = true;
 }
 
 public sealed class CourseDateDocument

--- a/PaceLetics.Web/Services/Courses/CourseService.cs
+++ b/PaceLetics.Web/Services/Courses/CourseService.cs
@@ -27,6 +27,20 @@ public sealed class CourseService : ICourseService
             .ToList();
     }
 
+    public async Task<IReadOnlyList<CourseDocument>> GetCoursesForTrainerAsync(string trainerUserId)
+    {
+        if (string.IsNullOrWhiteSpace(trainerUserId))
+            return Array.Empty<CourseDocument>();
+
+        var courses = await _repository.GetCoursesAsync();
+
+        return courses
+            .Where(course => course.Trainers.Any(trainer => trainer.TrainerUserId == trainerUserId))
+            .OrderBy(course => course.StartDate)
+            .ThenBy(course => course.Name)
+            .ToList();
+    }
+
     public async Task<IReadOnlyList<CourseDocument>> GetJoinedCoursesAsync(string athleteUserId)
     {
         var courses = await GetCoursesForAthleteAsync(athleteUserId);
@@ -48,6 +62,67 @@ public sealed class CourseService : ICourseService
             .Where(planId => !string.IsNullOrWhiteSpace(planId))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    public async Task<CourseDocument> CreateCourseAsync(
+        CourseCreateRequest request,
+        string creatorTrainerUserId,
+        string creatorDisplayName)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        if (string.IsNullOrWhiteSpace(creatorTrainerUserId))
+            throw new InvalidOperationException("Ein Kurs braucht eine angemeldete Trainer:in.");
+
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new InvalidOperationException("Ein Kurs braucht einen Namen.");
+
+        if (request.EndDate.Date < request.StartDate.Date)
+            throw new InvalidOperationException("Das Kursende darf nicht vor dem Kursstart liegen.");
+
+        var courseId = CreateCourseId(request.Name);
+        var now = DateTime.UtcNow;
+        var course = new CourseDocument
+        {
+            Id = courseId,
+            CourseId = courseId,
+            Slug = courseId,
+            Name = request.Name.Trim(),
+            Description = request.Description?.Trim() ?? string.Empty,
+            Level = request.Level?.Trim() ?? string.Empty,
+            StartDate = request.StartDate.Date,
+            EndDate = request.EndDate.Date,
+            CreatedByTrainerUserId = creatorTrainerUserId,
+            CreatedAt = now,
+            IsPublished = request.IsPublished,
+            Trainers =
+            {
+                new CourseTrainerDocument
+                {
+                    TrainerUserId = creatorTrainerUserId,
+                    DisplayName = NormalizeDisplayName(creatorDisplayName, creatorTrainerUserId),
+                    Role = "Kursleitung",
+                    CanManagePlans = true,
+                    CanManageEvents = true,
+                    CanManageMembers = true
+                }
+            }
+        };
+
+        await _repository.UpsertCourseAsync(course);
+        return course;
+    }
+
+    public async Task DeleteCourseAsync(string courseId, string requestingTrainerUserId)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        if (course.CreatedByTrainerUserId != requestingTrainerUserId)
+            throw new InvalidOperationException("Nur die Trainer:in, die den Kurs erstellt hat, kann ihn loeschen.");
+
+        await _repository.DeleteCourseAsync(course.Id);
     }
 
     public async Task<CourseEnrollmentDocument> JoinCourseAsync(string courseId, string athleteUserId)
@@ -112,10 +187,112 @@ public sealed class CourseService : ICourseService
         await _repository.UpsertCourseAsync(course);
     }
 
-    public async Task PublishTrainingPlanAsync(string courseId, string trainingPlanId, string publishedByUserId, DateTime? visibleFrom = null)
+    public async Task AddTrainerAsync(
+        string courseId,
+        string trainerUserId,
+        string displayName,
+        string requestingTrainerUserId)
+    {
+        if (string.IsNullOrWhiteSpace(trainerUserId))
+            throw new InvalidOperationException("Bitte eine Trainer:in auswaehlen.");
+
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        RequireTrainerManagement(course, requestingTrainerUserId);
+
+        course.Trainers.RemoveAll(trainer => trainer.TrainerUserId == trainerUserId);
+        course.Trainers.Add(new CourseTrainerDocument
+        {
+            TrainerUserId = trainerUserId,
+            DisplayName = NormalizeDisplayName(displayName, trainerUserId),
+            Role = "Trainer:in",
+            CanManagePlans = true,
+            CanManageEvents = true,
+            CanManageMembers = true
+        });
+
+        await _repository.UpsertCourseAsync(course);
+    }
+
+    public async Task RemoveTrainerAsync(string courseId, string trainerUserId, string requestingTrainerUserId)
     {
         var course = await _repository.GetCourseAsync(courseId)
             ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        if (course.CreatedByTrainerUserId == trainerUserId)
+            throw new InvalidOperationException("Die Kursleitung kann den Kurs loeschen, aber nicht austreten.");
+
+        if (trainerUserId != requestingTrainerUserId)
+            RequireTrainerManagement(course, requestingTrainerUserId);
+
+        var removed = course.Trainers.RemoveAll(trainer => trainer.TrainerUserId == trainerUserId);
+        if (removed == 0)
+            throw new InvalidOperationException("Diese Trainer:in ist dem Kurs nicht zugeordnet.");
+
+        await _repository.UpsertCourseAsync(course);
+    }
+
+    public async Task<CourseDateDocument> AddCourseDateAsync(
+        string courseId,
+        string title,
+        DateTime startsAt,
+        DateTime endsAt,
+        string requestingTrainerUserId,
+        string location = "",
+        string notes = "")
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new InvalidOperationException("Ein Termin braucht einen Titel.");
+
+        if (endsAt <= startsAt)
+            throw new InvalidOperationException("Das Termin-Ende muss nach dem Start liegen.");
+
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        RequireEventManagement(course, requestingTrainerUserId);
+
+        var date = new CourseDateDocument
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Title = title.Trim(),
+            StartsAt = startsAt,
+            EndsAt = endsAt,
+            Location = location?.Trim() ?? string.Empty,
+            Notes = notes?.Trim() ?? string.Empty
+        };
+
+        course.Dates.Add(date);
+        course.Dates = course.Dates.OrderBy(date => date.StartsAt).ToList();
+
+        await _repository.UpsertCourseAsync(course);
+        return date;
+    }
+
+    public async Task RemoveCourseDateAsync(string courseId, string dateId, string requestingTrainerUserId)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        RequireEventManagement(course, requestingTrainerUserId);
+
+        var removed = course.Dates.RemoveAll(date => date.Id == dateId);
+        if (removed == 0)
+            throw new InvalidOperationException("Der Termin wurde nicht gefunden.");
+
+        await _repository.UpsertCourseAsync(course);
+    }
+
+    public async Task PublishTrainingPlanAsync(string courseId, string trainingPlanId, string publishedByUserId, DateTime? visibleFrom = null)
+    {
+        if (string.IsNullOrWhiteSpace(trainingPlanId))
+            throw new InvalidOperationException("Bitte einen Trainingsplan auswaehlen.");
+
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        RequirePlanManagement(course, publishedByUserId);
 
         var existing = course.TrainingPlanPublications
             .FirstOrDefault(publication => publication.TrainingPlanId == trainingPlanId);
@@ -137,6 +314,20 @@ public sealed class CourseService : ICourseService
                 ? publishedByUserId
                 : existing.PublishedByUserId;
         }
+
+        await _repository.UpsertCourseAsync(course);
+    }
+
+    public async Task RemoveTrainingPlanPublicationAsync(string courseId, string trainingPlanId, string requestingTrainerUserId)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        RequirePlanManagement(course, requestingTrainerUserId);
+
+        var removed = course.TrainingPlanPublications.RemoveAll(publication => publication.TrainingPlanId == trainingPlanId);
+        if (removed == 0)
+            throw new InvalidOperationException("Der Trainingsplan wurde nicht gefunden.");
 
         await _repository.UpsertCourseAsync(course);
     }
@@ -166,6 +357,8 @@ public sealed class CourseService : ICourseService
         var course = await _repository.GetCourseAsync(courseId)
             ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
 
+        RequireEventManagement(course, createdByUserId);
+
         var courseEvent = new CourseEventDocument
         {
             CourseId = course.Id,
@@ -182,6 +375,52 @@ public sealed class CourseService : ICourseService
 
         await _repository.UpsertEventAsync(courseEvent);
         return courseEvent;
+    }
+
+    public async Task DeleteEventAsync(string courseId, string eventId, string requestingTrainerUserId)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        RequireEventManagement(course, requestingTrainerUserId);
+
+        var courseEvent = await _repository.GetEventAsync(courseId, eventId)
+            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+
+        await _repository.DeleteEventAsync(course.Id, courseEvent.Id);
+    }
+
+    public async Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsForTrainerAsync(
+        string courseId,
+        string eventId,
+        string requestingTrainerUserId)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+
+        RequireEventManagement(course, requestingTrainerUserId);
+
+        _ = await _repository.GetEventAsync(courseId, eventId)
+            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+
+        return (await _repository.GetEventRegistrationsAsync(courseId, eventId))
+            .Where(registration => registration.Status == CourseEventRegistrationStatus.Registered)
+            .OrderBy(registration => registration.RegisteredAt)
+            .ToList();
+    }
+
+    public async Task<CourseEventRegistrationDocument?> GetEventRegistrationForAthleteAsync(
+        string courseId,
+        string eventId,
+        string athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return null;
+
+        _ = await _repository.GetEventAsync(courseId, eventId)
+            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+
+        return await _repository.GetEventRegistrationAsync(courseId, eventId, athleteUserId);
     }
 
     public async Task<CourseEventRegistrationDocument> RegisterForEventAsync(string courseId, string eventId, string athleteUserId)
@@ -229,6 +468,27 @@ public sealed class CourseService : ICourseService
         return registration;
     }
 
+    public async Task<CourseEventRegistrationDocument> CancelEventRegistrationAsync(string courseId, string eventId, string athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            throw new InvalidOperationException("Eine Event-Abmeldung erfordert eine angemeldete Athlet:in.");
+
+        _ = await _repository.GetEventAsync(courseId, eventId)
+            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+
+        var registration = await _repository.GetEventRegistrationAsync(courseId, eventId, athleteUserId)
+            ?? throw new InvalidOperationException("Du bist fuer dieses Event nicht angemeldet.");
+
+        if (registration.Status != CourseEventRegistrationStatus.Registered)
+            throw new InvalidOperationException("Du bist fuer dieses Event nicht angemeldet.");
+
+        registration.Status = CourseEventRegistrationStatus.Cancelled;
+        registration.CancelledAt = DateTime.UtcNow;
+
+        await _repository.UpsertEventRegistrationAsync(registration);
+        return registration;
+    }
+
     private async Task CancelActiveEventRegistrationsAsync(string courseId, string athleteUserId, DateTime cancelledAt)
     {
         var events = await _repository.GetEventsAsync(courseId);
@@ -243,5 +503,49 @@ public sealed class CourseService : ICourseService
             registration.CancelledAt = cancelledAt;
             await _repository.UpsertEventRegistrationAsync(registration);
         }
+    }
+
+    private static string CreateCourseId(string name)
+    {
+        var slug = new string(name
+            .Trim()
+            .ToLowerInvariant()
+            .Select(character => char.IsLetterOrDigit(character) ? character : '-')
+            .ToArray());
+        slug = string.Join("-", slug.Split('-', StringSplitOptions.RemoveEmptyEntries));
+
+        if (string.IsNullOrWhiteSpace(slug))
+            slug = "kurs";
+
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        return $"{slug}-{suffix}";
+    }
+
+    private static string NormalizeDisplayName(string displayName, string fallbackUserId)
+    {
+        return string.IsNullOrWhiteSpace(displayName)
+            ? fallbackUserId
+            : displayName.Trim();
+    }
+
+    private static void RequireTrainerManagement(CourseDocument course, string requestingTrainerUserId)
+    {
+        var trainer = course.Trainers.FirstOrDefault(trainer => trainer.TrainerUserId == requestingTrainerUserId);
+        if (trainer is null || !trainer.CanManageMembers)
+            throw new InvalidOperationException("Du darfst die Trainer:innen dieses Kurses nicht verwalten.");
+    }
+
+    private static void RequireEventManagement(CourseDocument course, string requestingTrainerUserId)
+    {
+        var trainer = course.Trainers.FirstOrDefault(trainer => trainer.TrainerUserId == requestingTrainerUserId);
+        if (trainer is null || !trainer.CanManageEvents)
+            throw new InvalidOperationException("Du darfst Termine und Events dieses Kurses nicht verwalten.");
+    }
+
+    private static void RequirePlanManagement(CourseDocument course, string requestingTrainerUserId)
+    {
+        var trainer = course.Trainers.FirstOrDefault(trainer => trainer.TrainerUserId == requestingTrainerUserId);
+        if (trainer is null || !trainer.CanManagePlans)
+            throw new InvalidOperationException("Du darfst Trainingsplaene dieses Kurses nicht verwalten.");
     }
 }

--- a/PaceLetics.Web/Services/Courses/ICourseRepository.cs
+++ b/PaceLetics.Web/Services/Courses/ICourseRepository.cs
@@ -8,6 +8,8 @@ public interface ICourseRepository
 
     Task UpsertCourseAsync(CourseDocument course);
 
+    Task DeleteCourseAsync(string courseId);
+
     Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForAthleteAsync(string athleteUserId);
 
     Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForCourseAsync(string courseId);
@@ -21,6 +23,8 @@ public interface ICourseRepository
     Task<CourseEventDocument?> GetEventAsync(string courseId, string eventId);
 
     Task UpsertEventAsync(CourseEventDocument courseEvent);
+
+    Task DeleteEventAsync(string courseId, string eventId);
 
     Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsAsync(string courseId, string eventId);
 

--- a/PaceLetics.Web/Services/Courses/ICourseService.cs
+++ b/PaceLetics.Web/Services/Courses/ICourseService.cs
@@ -4,9 +4,15 @@ public interface ICourseService
 {
     Task<IReadOnlyList<CourseOverview>> GetCoursesForAthleteAsync(string athleteUserId);
 
+    Task<IReadOnlyList<CourseDocument>> GetCoursesForTrainerAsync(string trainerUserId);
+
     Task<IReadOnlyList<CourseDocument>> GetJoinedCoursesAsync(string athleteUserId);
 
     Task<IReadOnlyList<string>> GetPublishedTrainingPlanIdsForAthleteAsync(string athleteUserId);
+
+    Task<CourseDocument> CreateCourseAsync(CourseCreateRequest request, string creatorTrainerUserId, string creatorDisplayName);
+
+    Task DeleteCourseAsync(string courseId, string requestingTrainerUserId);
 
     Task<CourseEnrollmentDocument> JoinCourseAsync(string courseId, string athleteUserId);
 
@@ -14,7 +20,24 @@ public interface ICourseService
 
     Task AssignTrainerAsync(string courseId, string trainerUserId, string displayName);
 
+    Task AddTrainerAsync(string courseId, string trainerUserId, string displayName, string requestingTrainerUserId);
+
+    Task RemoveTrainerAsync(string courseId, string trainerUserId, string requestingTrainerUserId);
+
+    Task<CourseDateDocument> AddCourseDateAsync(
+        string courseId,
+        string title,
+        DateTime startsAt,
+        DateTime endsAt,
+        string requestingTrainerUserId,
+        string location = "",
+        string notes = "");
+
+    Task RemoveCourseDateAsync(string courseId, string dateId, string requestingTrainerUserId);
+
     Task PublishTrainingPlanAsync(string courseId, string trainingPlanId, string publishedByUserId, DateTime? visibleFrom = null);
+
+    Task RemoveTrainingPlanPublicationAsync(string courseId, string trainingPlanId, string requestingTrainerUserId);
 
     Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId);
 
@@ -29,5 +52,19 @@ public interface ICourseService
         int? capacity = null,
         DateTime? registrationDeadline = null);
 
+    Task DeleteEventAsync(string courseId, string eventId, string requestingTrainerUserId);
+
+    Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsForTrainerAsync(
+        string courseId,
+        string eventId,
+        string requestingTrainerUserId);
+
+    Task<CourseEventRegistrationDocument?> GetEventRegistrationForAthleteAsync(
+        string courseId,
+        string eventId,
+        string athleteUserId);
+
     Task<CourseEventRegistrationDocument> RegisterForEventAsync(string courseId, string eventId, string athleteUserId);
+
+    Task<CourseEventRegistrationDocument> CancelEventRegistrationAsync(string courseId, string eventId, string athleteUserId);
 }

--- a/PaceLetics.Web/Shared/DashboardNextTrainingSessionTile.razor
+++ b/PaceLetics.Web/Shared/DashboardNextTrainingSessionTile.razor
@@ -10,7 +10,7 @@
                   Justify="Justify.SpaceBetween">
 
             <MudStack Spacing="1">
-                <MudText Typo="Typo.h6">
+                <MudText Typo="Typo.h6">                                                                                   
                     @(Session?.Name ?? "Noch keine Trainingseinheit")
                 </MudText>
 

--- a/PaceLetics.Web/Shared/NavMenu.razor
+++ b/PaceLetics.Web/Shared/NavMenu.razor
@@ -5,6 +5,11 @@
     <MudNavLink Href="/Athletes/racepaces" Match="NavLinkMatch.Prefix">@L["Nav_RaceData"]</MudNavLink>
     <MudNavLink Href="/Athletes/trainingpaces" Match="NavLinkMatch.Prefix">@L["Nav_PaceZones"]</MudNavLink>
     <MudNavLink Href="/Athletes/courses" Match="NavLinkMatch.Prefix">@L["Nav_Courses"]</MudNavLink>
+    <AuthorizeView Roles="@ApplicationRoles.Trainer">
+        <Authorized>
+            <MudNavLink Href="/Trainers/courses" Match="NavLinkMatch.Prefix">@L["Nav_TrainerCourses"]</MudNavLink>
+        </Authorized>
+    </AuthorizeView>
     <MudNavLink Href="/Athletes/trainingplanpage" Match="NavLinkMatch.Prefix">@L["Nav_TrainingPlan"]</MudNavLink>
     <MudNavLink Href="/Workouts/WorkoutArea" Match="NavLinkMatch.Prefix">@L["Nav_Workouts"]</MudNavLink>
     <MudNavLink Href="/profiles" Match="NavLinkMatch.Prefix">@L["Nav_Profiles"]</MudNavLink>


### PR DESCRIPTION
PR-Report

Titel: Trainer course management and event registration updates

Summary

Added trainer-only course management page for creating/deleting courses, managing trainers, dates, events, and training plans.
Added event participant visibility for trainers.
Added athlete event unregister flow with Anmelden/Abmelden state in course events.
Restricted Manage Courses sidebar entry to trainers.
Extended course service/repository contracts and Cosmos implementation for course/event management.
Added German/English navigation labels and focused service tests.
Tests

dotnet build PaceLetics.Web\PaceLetics.Web.csproj --no-restore --disable-build-servers -p:UseAppHost=false -p:OutputPath=..\artifacts\verify-web\
dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore --disable-build-servers -p:UseAppHost=false -p:OutputPath=..\artifacts\verify-tests\
Result: 56/56 tests passed
Notes

Normal build output is currently locked by a running PaceLetics.Web/Visual Studio process, so verification used temporary output folders.
Existing NU1902 package warnings for OpenMcdf and SharpCompress remain unchanged.