### PR TITLE
Localize remaining UI text

### DIFF
--- a/PR_REPORT.md
+++ b/PR_REPORT.md
@@ -1,0 +1,22 @@
+# PR Report: Missing Localization
+
+## Summary
+- Localized newly introduced course and profile UI surfaces with German and English `.resx` resources.
+- Replaced hard-coded user-facing course service exceptions with localizable resource lookups and safe German fallbacks.
+- Added localization for remaining workout, athlete dialog, dashboard, Identity account, and small legacy view strings.
+
+## Main Areas Changed
+- Athlete course overview: `MyCourses.razor`
+- Trainer course management: `CourseManagement.razor`
+- Public profiles: `Profiles.razor`
+- Dashboard next training tile and legacy shared views
+- Identity login/register/manage PageModels and views
+- Workout and athlete module residual button/fallback strings
+
+## Verification
+- `dotnet build PaceLeticsFramework.sln` succeeded.
+- `dotnet test PaceLeticsFramework.sln --no-build` succeeded: 56 passed, 0 failed.
+
+## Notes
+- Build still reports existing package vulnerability warnings for `OpenMcdf` and `SharpCompress`; these are unrelated to this localization change.
+- Technical configuration exceptions remain in English where they are intended for operators/developers rather than end users.

--- a/PaceLetics.AthleteModule.Components/AddRaceDialog.razor
+++ b/PaceLetics.AthleteModule.Components/AddRaceDialog.razor
@@ -30,7 +30,7 @@
     </DialogContent>
     <DialogActions>
         <MudButton Disabled="@string.IsNullOrWhiteSpace(this._id)" OnClick="@this.OK" Size="@Size.Small">
-            Ok
+            @L["AddRaceDialog_Ok"]
         </MudButton>
     </DialogActions>
 </MudDialog>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.de.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.de.resx
@@ -26,4 +26,5 @@
   <data name="AddRaceDialog_Date" xml:space="preserve"><value>Datum</value></data>
   <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>Achtung</value></data>
   <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>Bitte überprüfe, ob die Eingabe der Laufzeit im richtigen Format vorliegt (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>Ok</value></data>
 </root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.en.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.en.resx
@@ -26,4 +26,5 @@
   <data name="AddRaceDialog_Date" xml:space="preserve"><value>Date</value></data>
   <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>Attention</value></data>
   <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>Please check that the race time is in the correct format (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>Ok</value></data>
 </root>

--- a/PaceLetics.TrainingModule.Components/Running/RunningResources.de.resx
+++ b/PaceLetics.TrainingModule.Components/Running/RunningResources.de.resx
@@ -6,4 +6,5 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="MiniCard_Interval" xml:space="preserve"><value>Intervall</value></data>
   <data name="MiniCard_Run" xml:space="preserve"><value>Lauf</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
 </root>

--- a/PaceLetics.TrainingModule.Components/Running/TrainingCard.razor
+++ b/PaceLetics.TrainingModule.Components/Running/TrainingCard.razor
@@ -1,4 +1,6 @@
-﻿<h3>TrainingCard</h3>
+@inject IStringLocalizer<RunningResources> L
+
+<h3>@L["TrainingCard_Title"]</h3>
 
 @code {
 

--- a/PaceLetics.TrainingModule.Components/Workouts/WorkoutFinishedDialog.razor
+++ b/PaceLetics.TrainingModule.Components/Workouts/WorkoutFinishedDialog.razor
@@ -2,6 +2,7 @@
 
 
 @namespace PaceLetics.TrainingModule.Components.Workouts
+@inject IStringLocalizer<WorkoutResources> L
 
 <MudDialog>
     <DialogContent>
@@ -11,7 +12,7 @@
         
     </DialogContent>
     <DialogActions>
-        <MudButton Color="Color.Primary" OnClick="Submit">Yes!</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit">@L["FinishedDialog_Confirm"]</MudButton>
     </DialogActions>
 </MudDialog>
 @code {

--- a/PaceLetics.TrainingModule.Components/Workouts/WorkoutResources.de.resx
+++ b/PaceLetics.TrainingModule.Components/Workouts/WorkoutResources.de.resx
@@ -35,4 +35,10 @@
   <data name="Level_Moderate" xml:space="preserve"><value>Fortgeschritten</value></data>
   <data name="Level_Advanced" xml:space="preserve"><value>Schwer</value></data>
   <data name="Level_Epic" xml:space="preserve"><value>Episch</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>Pause</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>Zuruecksetzen</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>Kein Workout geladen.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>Ja!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
 </root>

--- a/PaceLetics.TrainingModule.Components/Workouts/WorkoutResources.en.resx
+++ b/PaceLetics.TrainingModule.Components/Workouts/WorkoutResources.en.resx
@@ -35,4 +35,10 @@
   <data name="Level_Moderate" xml:space="preserve"><value>Moderate</value></data>
   <data name="Level_Advanced" xml:space="preserve"><value>Advanced</value></data>
   <data name="Level_Epic" xml:space="preserve"><value>Epic</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>Pause</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>Reset</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>No workout loaded.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>Yes!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
 </root>

--- a/PaceLetics.TrainingModule.Components/Workouts/WorkoutTopBar.razor
+++ b/PaceLetics.TrainingModule.Components/Workouts/WorkoutTopBar.razor
@@ -26,14 +26,14 @@
                        Color="@(IsToggled ? Color.Warning : Color.Success)"
                        OnClick="ToggleWorkout"
                        StartIcon="@(IsToggled ? Icons.Material.Filled.Pause : Icons.Material.Filled.PlayArrow)">
-                @(IsToggled ? "Pause" : "Start")
+                @(IsToggled ? L["TopBar_Pause"] : L["TopBar_Start"])
             </MudButton>
 
             <MudButton Variant="Variant.Outlined"
                        Color="Color.Default"
                        OnClick="ResetAndStopWorkout"
                        StartIcon="@Icons.Material.Filled.Refresh">
-                Reset
+                @L["TopBar_Reset"]
             </MudButton>
         </MudStack>
     </MudStack>

--- a/PaceLetics.TrainingModule.Components/Workouts/WorkoutView.razor
+++ b/PaceLetics.TrainingModule.Components/Workouts/WorkoutView.razor
@@ -1,9 +1,10 @@
 @using MudBlazor
 @using PaceLetics.TrainingModule.CodeBase.Workouts.Interfaces
+@inject IStringLocalizer<WorkoutResources> L
 
 @if (Workout is null)
 {
-    <MudText>Kein Workout geladen.</MudText>
+    <MudText>@L["WorkoutView_NoWorkout"]</MudText>
 }
 else
 {

--- a/PaceLetics.Web/App.razor
+++ b/PaceLetics.Web/App.razor
@@ -1,4 +1,5 @@
-﻿@using System.Globalization
+@using System.Globalization
+@inject IStringLocalizer<App> L
 
 <CascadingAuthenticationState>
     <Router AppAssembly="@typeof(App).Assembly">
@@ -7,7 +8,7 @@
             <FocusOnNavigate RouteData="@routeData" Selector="h1" />
         </Found>
         <NotFound>
-            <PageTitle>Not found</PageTitle>
+            <PageTitle>@L["NotFoundTitle"]</PageTitle>
             <LayoutView Layout="@typeof(MainLayout)">
                 <p role="alert"></p>
             </LayoutView>

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable disable
 
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using PaceLetics.Web.Data;
 
@@ -23,15 +24,18 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly ILogger<LoginModel> _logger;
+        private readonly IStringLocalizer<LoginModel> _localizer;
 
         public LoginModel(
             SignInManager<ApplicationUser> signInManager,
             UserManager<ApplicationUser> userManager,
-            ILogger<LoginModel> logger)
+            ILogger<LoginModel> logger,
+            IStringLocalizer<LoginModel> localizer)
         {
             _signInManager = signInManager;
             _userManager = userManager;
             _logger = logger;
+            _localizer = localizer;
         }
 
         /// <summary>
@@ -140,7 +144,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
                 }
                 else
                 {
-                    ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+                    ModelState.AddModelError(string.Empty, _localizer["InvalidLoginAttempt"]);
                     return Page();
                 }
             }

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable disable
 
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using PaceLetics.Web.Data;
 
@@ -18,15 +19,18 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<ChangePasswordModel> _logger;
+        private readonly IStringLocalizer<ChangePasswordModel> _localizer;
 
         public ChangePasswordModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
-            ILogger<ChangePasswordModel> logger)
+            ILogger<ChangePasswordModel> logger,
+            IStringLocalizer<ChangePasswordModel> localizer)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _logger = logger;
+            _localizer = localizer;
         }
 
         /// <summary>
@@ -73,7 +77,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
             [DataType(DataType.Password)]
-            [Display(Name = "Neues Passwort best�tigen")]
+            [Display(Name = "Neues Passwort bestätigen")]
             [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
             public string ConfirmPassword { get; set; }
         }
@@ -120,7 +124,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
 
             await _signInManager.RefreshSignInAsync(user);
             _logger.LogInformation("User changed their password successfully.");
-            StatusMessage = "Ein neues Passwort wurde vergeben.";
+            StatusMessage = _localizer["PasswordChanged"];
 
             return RedirectToPage();
         }

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable disable
 
@@ -7,6 +7,7 @@ using AthleteDataAccessLibrary.Contracts;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Localization;
 using PaceLetics.Web.Data;
 
 namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
@@ -17,16 +18,19 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<DeletePersonalDataModel> _logger;
         private readonly IAthleteData _athleteData;
+        private readonly IStringLocalizer<DeletePersonalDataModel> _localizer;
         public DeletePersonalDataModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             IAthleteData ad,
-            ILogger<DeletePersonalDataModel> logger)
+            ILogger<DeletePersonalDataModel> logger,
+            IStringLocalizer<DeletePersonalDataModel> localizer)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _logger = logger;
             _athleteData = ad;
+            _localizer = localizer;
         }
 
         /// <summary>
@@ -82,7 +86,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             {
                 if (!await _userManager.CheckPasswordAsync(user, Input.Password))
                 {
-                    ModelState.AddModelError(string.Empty, "Incorrect password.");
+                    ModelState.AddModelError(string.Empty, _localizer["IncorrectPassword"]);
                     return Page();
                 }
             }

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/Email.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/Email.cshtml.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+ï»¿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable disable
 
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Localization;
 using PaceLetics.Web.Data;
 
 namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
@@ -21,15 +22,18 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly IEmailSender _emailSender;
+        private readonly IStringLocalizer<EmailModel> _localizer;
 
         public EmailModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
-            IEmailSender emailSender)
+            IEmailSender emailSender,
+            IStringLocalizer<EmailModel> localizer)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _emailSender = emailSender;
+            _localizer = localizer;
         }
 
         /// <summary>
@@ -127,14 +131,14 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
                     protocol: Request.Scheme);
                 await _emailSender.SendEmailAsync(
                     Input.NewEmail,
-                    "Confirm your email",
-                    $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+                    _localizer["ConfirmEmailSubject"],
+                    string.Format(_localizer["ConfirmEmailBody"], HtmlEncoder.Default.Encode(callbackUrl)));
 
-                StatusMessage = "Bestätigung gesendet. Bitte E-Mails prüfen.";
+                StatusMessage = _localizer["ConfirmationSent"];
                 return RedirectToPage();
             }
 
-            StatusMessage = "Das ist ja die gleiche Adresse.";
+            StatusMessage = _localizer["EmailUnchanged"];
             return RedirectToPage();
         }
 
@@ -163,10 +167,10 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
                 protocol: Request.Scheme);
             await _emailSender.SendEmailAsync(
                 email,
-                "Confirm your email",
-                $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+                _localizer["ConfirmEmailSubject"],
+                string.Format(_localizer["ConfirmEmailBody"], HtmlEncoder.Default.Encode(callbackUrl)));
 
-            StatusMessage = "Bestätigung gesendet. Bitte E-Mails prüfen.";
+            StatusMessage = _localizer["ConfirmationSent"];
             return RedirectToPage();
         }
     }

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml
@@ -9,7 +9,7 @@
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h3 class="mb-0">@ViewData["Title"]</h3>
-    <a class="btn btn-outline-secondary" href="/">Zur Hauptansicht</a>
+    <a class="btn btn-outline-secondary" href="/">@Localizer["BackToApp"]</a>
 </div>
 <partial name="_StatusMessage" for="StatusMessage" />
 <div class="row">
@@ -21,36 +21,36 @@
                 <label asp-for="Username" class="form-label"></label>
             </div>
             <div class="form-floating mb-3">
-                <input value="@Model.Roles" class="form-control" placeholder="Rolle" disabled />
-                <label class="form-label">Rolle</label>
+                <input value="@Model.Roles" class="form-control" placeholder="@Localizer["Role"]" disabled />
+                <label class="form-label">@Localizer["Role"]</label>
             </div>
             <div class="form-floating mb-3">
                 <input asp-for="Input.PublicUserName" class="form-control" placeholder="pace-runner" />
-                <label asp-for="Input.PublicUserName" class="form-label"></label>
+                <label asp-for="Input.PublicUserName" class="form-label">@Localizer["PublicUserName"]</label>
                 <span asp-validation-for="Input.PublicUserName" class="text-danger"></span>
             </div>
             <div class="form-floating mb-3">
                 <input asp-for="Input.ProfileImageUrl" class="form-control" placeholder="https://example.com/profile.jpg" />
-                <label asp-for="Input.ProfileImageUrl" class="form-label"></label>
+                <label asp-for="Input.ProfileImageUrl" class="form-label">@Localizer["ProfileImageUrl"]</label>
                 <span asp-validation-for="Input.ProfileImageUrl" class="text-danger"></span>
             </div>
             <div class="form-check form-switch mb-4">
                 <input asp-for="Input.IsPublicProfileVisible" class="form-check-input" />
-                <label asp-for="Input.IsPublicProfileVisible" class="form-check-label"></label>
+                <label asp-for="Input.IsPublicProfileVisible" class="form-check-label">@Localizer["IsPublicProfileVisible"]</label>
             </div>
             @if (!Model.IsTrainer)
             {
                 <div class="mud-divider my-4"></div>
-                <h4>Trainerrolle beantragen</h4>
-                <p class="text-muted">Mit einem gueltigen Verifikationscode wird die Trainerrolle zusaetzlich zur Athlet:innenrolle aktiviert.</p>
+                <h4>@Localizer["RequestTrainerRole"]</h4>
+                <p class="text-muted">@Localizer["RequestTrainerRoleDescription"]</p>
                 <div class="form-floating mb-3">
                     <input asp-for="Input.TrainerVerificationCode" class="form-control" placeholder="Code" autocomplete="off" />
-                    <label asp-for="Input.TrainerVerificationCode" class="form-label"></label>
+                    <label asp-for="Input.TrainerVerificationCode" class="form-label">@Localizer["TrainerVerificationCode"]</label>
                     <span asp-validation-for="Input.TrainerVerificationCode" class="text-danger"></span>
                 </div>
             }
             <button id="update-profile-button" type="submit" class="w-100 btn btn-lg btn-primary">@Localizer["Save"]</button>
-            <a class="w-100 btn btn-link mt-2" href="/">Zur Hauptansicht</a>
+            <a class="w-100 btn btn-link mt-2" href="/">@Localizer["BackToApp"]</a>
         </form>
     </div>
 </div>

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -13,6 +13,7 @@ using AthleteDataAccessLibrary.Contracts;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using PaceLetics.AthleteModule.CodeBase.Models;
 using PaceLetics.Web.Configuration;
@@ -26,17 +27,20 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly TrainerVerificationOptions _trainerVerificationOptions;
         private readonly IAthleteData _athleteData;
+        private readonly IStringLocalizer<IndexModel> _localizer;
 
         public IndexModel(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             IOptions<TrainerVerificationOptions> trainerVerificationOptions,
-            IAthleteData athleteData)
+            IAthleteData athleteData,
+            IStringLocalizer<IndexModel> localizer)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _trainerVerificationOptions = trainerVerificationOptions.Value;
             _athleteData = athleteData;
+            _localizer = localizer;
         }
 
         [Display(Name = "Name")]
@@ -80,7 +84,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             var publicProfile = athlete.PublicProfile;
 
             Username = userName;
-            Roles = string.Join(", ", roles.Select(ApplicationRoles.GetDisplayName));
+            Roles = string.Join(", ", roles.Select(GetRoleDisplayName));
             IsTrainer = roles.Contains(ApplicationRoles.Trainer);
 
             Input = new InputModel
@@ -116,7 +120,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             {
                 if (await PublicUserNameExistsAsync(publicUserName, user.Id))
                 {
-                    ModelState.AddModelError("Input.PublicUserName", "Dieser oeffentliche Nutzername ist bereits vergeben.");
+                    ModelState.AddModelError("Input.PublicUserName", _localizer["PublicUserNameExists"]);
                 }
             }
 
@@ -158,7 +162,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             await _athleteData.UpdateAthlete(athlete);
 
             await _signInManager.RefreshSignInAsync(user);
-            StatusMessage = "Your profile has been updated";
+            StatusMessage = _localizer["ProfileUpdated"];
             return RedirectToPage();
         }
 
@@ -171,13 +175,13 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
 
             if (string.IsNullOrWhiteSpace(_trainerVerificationOptions.Code))
             {
-                ModelState.AddModelError("Input.TrainerVerificationCode", "Die Trainer-Verifikation ist noch nicht konfiguriert.");
+                ModelState.AddModelError("Input.TrainerVerificationCode", _localizer["TrainerVerificationNotConfigured"]);
                 return false;
             }
 
             if (!IsVerificationCodeValid(verificationCode, _trainerVerificationOptions.Code))
             {
-                ModelState.AddModelError("Input.TrainerVerificationCode", "Der Trainer-Verifikationscode ist ungueltig.");
+                ModelState.AddModelError("Input.TrainerVerificationCode", _localizer["TrainerVerificationInvalid"]);
                 return false;
             }
 
@@ -312,6 +316,16 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             return roles.Contains(ApplicationRoles.Trainer)
                 ? ApplicationRoles.Trainer
                 : ApplicationRoles.Athlete;
+        }
+
+        private string GetRoleDisplayName(string role)
+        {
+            return role switch
+            {
+                ApplicationRoles.Athlete => _localizer["RoleAthlete"],
+                ApplicationRoles.Trainer => _localizer["RoleTrainer"],
+                _ => role
+            };
         }
 
         private static string NormalizePublicUserName(string value)

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using PaceLetics.AthleteModule.CodeBase.Models;
 using PaceLetics.Web.Data;
@@ -33,13 +34,15 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
         private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
         private readonly IAthleteData _athleteData;
+        private readonly IStringLocalizer<RegisterModel> _localizer;
         public RegisterModel(
             UserManager<ApplicationUser> userManager,
             IUserStore<ApplicationUser> userStore,
             SignInManager<ApplicationUser> signInManager,
             ILogger<RegisterModel> logger,
             IEmailSender emailSender,
-            IAthleteData ad)
+            IAthleteData ad,
+            IStringLocalizer<RegisterModel> localizer)
         {
             _userManager = userManager;
             _userStore = userStore;
@@ -48,6 +51,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
             _logger = logger;
             _emailSender = emailSender;
             _athleteData = ad;
+            _localizer = localizer;
         }
 
         /// <summary>
@@ -134,7 +138,7 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
                 if (!string.IsNullOrWhiteSpace(email)
                     && await _userManager.FindByEmailAsync(email) is not null)
                 {
-                    ModelState.AddModelError("Input.Email", "Email is already in use.");
+                    ModelState.AddModelError("Input.Email", _localizer["EmailAlreadyInUse"]);
                     return Page();
                 }
 
@@ -179,8 +183,10 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
                             values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
                             protocol: Request.Scheme);
 
-                        await _emailSender.SendEmailAsync(email, "Confirm your email",
-                            $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+                        await _emailSender.SendEmailAsync(
+                            email,
+                            _localizer["ConfirmEmailSubject"],
+                            string.Format(_localizer["ConfirmEmailBody"], HtmlEncoder.Default.Encode(callbackUrl)));
                     }
 
                     if (_userManager.Options.SignIn.RequireConfirmedAccount && !string.IsNullOrWhiteSpace(email))

--- a/PaceLetics.Web/Pages/AthleteListView.razor
+++ b/PaceLetics.Web/Pages/AthleteListView.razor
@@ -1,18 +1,19 @@
-﻿@using AthleteDataAccessLibrary;
+@using AthleteDataAccessLibrary;
 @using AthleteDataAccessLibrary.Contracts;
 @using PaceLetics.AthleteModule.CodeBase.Models;
 
 @inject IAthleteData _ad;
+@inject IStringLocalizer<AthleteListView> L
 
-<h3>AthleteListView</h3>
+<h3>@L["Title"]</h3>
 
 <DataGridView Athletes="@athletes"></DataGridView>
 
 @code {
-	private IList<AthleteModel>? athletes;
+    private IList<AthleteModel>? athletes;
 
-	protected override async Task OnInitializedAsync()
-	{
-		athletes = await _ad.GetAthletes();
-	}
+    protected override async Task OnInitializedAsync()
+    {
+        athletes = await _ad.GetAthletes();
+    }
 }

--- a/PaceLetics.Web/Pages/Athletes/Konfigurations.razor
+++ b/PaceLetics.Web/Pages/Athletes/Konfigurations.razor
@@ -1,7 +1,6 @@
-﻿<h3>Athlete Konfigurations</h3>
+@inject IStringLocalizer<Konfigurations> L
 
-
-
+<h3>@L["Title"]</h3>
 
 @code {
 

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -5,17 +5,18 @@
 @inject ICourseService CourseService
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
+@inject IStringLocalizer<MyCourses> L
 
-<PageTitle>Meine Kurse</PageTitle>
+<PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
     @if (_isLoading)
     {
-        <LoadingScreen Label="Kurse werden geladen" />
+        <LoadingScreen Label="@L["Loading"]" />
     }
     else
     {
-        <PageHeader Title="Meine Kurse" Subtitle="Kursbeitritte, Termine und Events" />
+        <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
 
         <MudDivider Class="my-4" />
 
@@ -26,7 +27,7 @@
 
         @if (_courses.Count == 0)
         {
-            <MudText Typo="Typo.body2" Color="Color.Secondary">Aktuell sind keine Kurse veroeffentlicht.</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoPublishedCourses"]</MudText>
         }
         else
         {
@@ -59,7 +60,7 @@
                                 <MudStack Spacing="0">
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatShortPeriod(course)</MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        @(nextDate is null ? "Kein kommender Termin" : $"{nextDate.StartsAt:dd.MM. HH:mm} Uhr")
+                                        @FormatUpcomingDate(nextDate)
                                     </MudText>
                                 </MudStack>
 
@@ -70,7 +71,7 @@
                                            Variant="Variant.Outlined"
                                            StartIcon="@Icons.Material.Filled.Logout"
                                            OnClick="@(() => LeaveCourseAsync(course.Id, course.Name))">
-                                    Austreten
+                                    @L["Leave"]
                                 </MudButton>
                             </MudStack>
                         </MudPaper>
@@ -82,14 +83,14 @@
                               @onclick="OpenCoursePicker">
                         <MudStack AlignItems="AlignItems.Center" Justify="Justify.Center" Style="height:100%; gap:8px;">
                             <MudIcon Icon="@Icons.Material.Filled.Add" Color="Color.Primary" Size="Size.Large" />
-                            <MudText Typo="Typo.body2" Color="Color.Primary">Kurs hinzufuegen</MudText>
+                            <MudText Typo="Typo.body2" Color="Color.Primary">@L["AddCourse"]</MudText>
                         </MudStack>
                     </MudPaper>
                 </div>
 
                 @if (joinedCourses.Count == 0)
                 {
-                    <MudText Typo="Typo.body2" Color="Color.Secondary">Du bist noch keinem Kurs beigetreten.</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoJoinedCourses"]</MudText>
                 }
 
                 @if (_isCoursePickerOpen)
@@ -98,13 +99,13 @@
                         <MudPaper Elevation="8" Class="pa-4" Style="width:min(560px, 100%); max-height:min(720px, 88vh); overflow:auto;" @onclick:stopPropagation="true">
                             <MudStack Spacing="3">
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
-                                    <MudText Typo="Typo.h6">Kurs hinzufuegen</MudText>
+                                    <MudText Typo="Typo.h6">@L["AddCourse"]</MudText>
                                     <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="CloseCoursePicker" />
                                 </MudStack>
 
                                 @if (availableCourses.Count == 0)
                                 {
-                                    <MudText Typo="Typo.body2" Color="Color.Secondary">Aktuell sind keine weiteren Kurse verfuegbar.</MudText>
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoAvailableCourses"]</MudText>
                                 }
                                 else
                                 {
@@ -123,7 +124,7 @@
                                                         </MudStack>
                                                         <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatShortPeriod(course)</MudText>
                                                         <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                                            @(nextDate is null ? "Kein kommender Termin" : $"{nextDate.StartsAt:dd.MM. HH:mm} Uhr")
+                                                            @FormatUpcomingDate(nextDate)
                                                         </MudText>
                                                     </MudStack>
                                                     <MudButton Size="Size.Small"
@@ -131,7 +132,7 @@
                                                                Variant="Variant.Filled"
                                                                StartIcon="@Icons.Material.Filled.HowToReg"
                                                                OnClick="@(() => JoinCourseAsync(course.Id))">
-                                                        Beitreten
+                                                        @L["Join"]
                                                     </MudButton>
                                                 </MudStack>
                                             </div>
@@ -158,7 +159,7 @@
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="flex-wrap:wrap;">
                                     <MudText Typo="Typo.h6">@course.Name</MudText>
                                     <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@course.Level</MudChip>
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">Beigetreten</MudChip>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">@L["Joined"]</MudChip>
                                 </MudStack>
                                 <MudText Typo="Typo.body2" Color="Color.Secondary" Style="display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden;">
                                     @course.Description
@@ -168,21 +169,21 @@
 
                             <section>
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
-                                    <MudText Typo="Typo.subtitle2">Termine</MudText>
+                                    <MudText Typo="Typo.subtitle2">@L["Dates"]</MudText>
                                     @if (upcomingDates.Count > 1)
                                     {
                                         <MudButton Size="Size.Small"
                                                    Variant="Variant.Text"
                                                    Color="Color.Primary"
                                                    OnClick="@(() => _showAllDates = !_showAllDates)">
-                                            @(_showAllDates ? "Weniger" : "Alle")
+                                            @(_showAllDates ? L["ShowLess"] : L["ShowAll"])
                                         </MudButton>
                                     }
                                 </MudStack>
 
                                 @if (upcomingDates.Count == 0)
                                 {
-                                    <MudText Typo="Typo.body2" Color="Color.Secondary">Keine kommenden Termine.</MudText>
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoUpcomingDates"]</MudText>
                                 }
                                 else
                                 {
@@ -210,14 +211,14 @@
                                                    Variant="Variant.Text"
                                                    Color="Color.Primary"
                                                    OnClick="@(() => _showAllEvents = !_showAllEvents)">
-                                            @(_showAllEvents ? "Weniger" : "Alle")
+                                            @(_showAllEvents ? L["ShowLess"] : L["ShowAll"])
                                         </MudButton>
                                     }
                                 </MudStack>
 
                                 @if (courseEvents.Count == 0)
                                 {
-                                    <MudText Typo="Typo.body2" Color="Color.Secondary">Aktuell sind keine Events eingestellt.</MudText>
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoEvents"]</MudText>
                                 }
                                 else
                                 {
@@ -236,7 +237,7 @@
                                                                Variant="Variant.Outlined"
                                                                StartIcon="@Icons.Material.Filled.EventBusy"
                                                                OnClick="@(() => CancelEventRegistrationAsync(course.Id, courseEvent.Id))">
-                                                        Abmelden
+                                                        @L["CancelRegistration"]
                                                     </MudButton>
                                                 }
                                                 else
@@ -246,7 +247,7 @@
                                                                Variant="Variant.Filled"
                                                                StartIcon="@Icons.Material.Filled.EventAvailable"
                                                                OnClick="@(() => RegisterForEventAsync(course.Id, courseEvent.Id))">
-                                                        Anmelden
+                                                        @L["Register"]
                                                     </MudButton>
                                                 }
                                             </div>
@@ -257,21 +258,21 @@
 
                             <section>
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
-                                    <MudText Typo="Typo.subtitle2">Trainingsplaene</MudText>
+                                    <MudText Typo="Typo.subtitle2">@L["TrainingPlans"]</MudText>
                                     @if (trainingPlanPublications.Count > 2)
                                     {
                                         <MudButton Size="Size.Small"
                                                    Variant="Variant.Text"
                                                    Color="Color.Primary"
                                                    OnClick="@(() => _showAllTrainingPlans = !_showAllTrainingPlans)">
-                                            @(_showAllTrainingPlans ? "Weniger" : "Alle")
+                                            @(_showAllTrainingPlans ? L["ShowLess"] : L["ShowAll"])
                                         </MudButton>
                                     }
                                 </MudStack>
 
                                 @if (trainingPlanPublications.Count == 0)
                                 {
-                                    <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Trainingsplaene veroeffentlicht.</MudText>
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoTrainingPlans"]</MudText>
                                 }
                                 else
                                 {
@@ -365,7 +366,7 @@
         }
         catch
         {
-            _errorMessage = "Die Kurse konnten nicht aus Cosmos DB geladen werden.";
+            _errorMessage = L["LoadError"];
             _courses = Array.Empty<CourseOverview>();
             _selectedCourseId = null;
             ResetDetailExpansion();
@@ -401,7 +402,7 @@
         {
             _selectedCourseId = courseId;
             await CourseService.JoinCourseAsync(courseId, _userId ?? string.Empty);
-            Snackbar.Add("Du bist dem Kurs beigetreten.", Severity.Success);
+            Snackbar.Add(L["JoinSuccess"], Severity.Success);
             _isCoursePickerOpen = false;
             ResetDetailExpansion();
             await LoadCoursesAsync();
@@ -416,13 +417,13 @@
     {
         try
         {
-            var confirmed = await JS.InvokeAsync<bool>("confirm", $"Aus \"{courseName}\" austreten?");
+            var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["LeaveConfirm"], courseName));
             if (!confirmed)
                 return;
 
             _selectedCourseId = courseId;
             await CourseService.LeaveCourseAsync(courseId, _userId ?? string.Empty);
-            Snackbar.Add("Du bist aus dem Kurs ausgetreten.", Severity.Success);
+            Snackbar.Add(L["LeaveSuccess"], Severity.Success);
             ResetDetailExpansion();
             await LoadCoursesAsync();
         }
@@ -438,7 +439,7 @@
         {
             await CourseService.RegisterForEventAsync(courseId, eventId, _userId ?? string.Empty);
             await LoadCoursesAsync();
-            Snackbar.Add("Du bist fuer das Event angemeldet.", Severity.Success);
+            Snackbar.Add(L["RegisterSuccess"], Severity.Success);
         }
         catch (Exception ex)
         {
@@ -452,7 +453,7 @@
         {
             await CourseService.CancelEventRegistrationAsync(courseId, eventId, _userId ?? string.Empty);
             await LoadCoursesAsync();
-            Snackbar.Add("Du bist fuer das Event abgemeldet.", Severity.Success);
+            Snackbar.Add(L["CancelRegistrationSuccess"], Severity.Success);
         }
         catch (Exception ex)
         {
@@ -516,23 +517,30 @@
         return "flex:0 0 132px; width:132px; min-height:178px; scroll-snap-align:start; cursor:pointer; border-radius:8px; border:1px dashed var(--mud-palette-primary);";
     }
 
-    private static string FormatPeriod(CourseDocument course)
+    private string FormatPeriod(CourseDocument course)
     {
-        return $"{course.StartDate:dd.MM.yyyy} bis {course.EndDate:dd.MM.yyyy}";
+        return string.Format(L["Period"], course.StartDate, course.EndDate);
     }
 
-    private static string FormatShortPeriod(CourseDocument course)
+    private string FormatShortPeriod(CourseDocument course)
     {
-        return $"{course.StartDate:dd.MM.} bis {course.EndDate:dd.MM.}";
+        return string.Format(L["ShortPeriod"], course.StartDate, course.EndDate);
     }
 
-    private static string FormatTimeRange(CourseDateDocument date)
+    private string FormatTimeRange(CourseDateDocument date)
     {
-        return $"{date.StartsAt:HH:mm} bis {date.EndsAt:HH:mm} Uhr";
+        return string.Format(L["TimeRange"], date.StartsAt, date.EndsAt);
     }
 
-    private static string FormatEventDate(CourseEventDocument courseEvent)
+    private string FormatEventDate(CourseEventDocument courseEvent)
     {
-        return $"{courseEvent.StartsAt:dd.MM.yyyy HH:mm} bis {courseEvent.EndsAt:HH:mm} Uhr";
+        return string.Format(L["EventDate"], courseEvent.StartsAt, courseEvent.EndsAt);
+    }
+
+    private string FormatUpcomingDate(CourseDateDocument? date)
+    {
+        return date is null
+            ? L["NoUpcomingDate"]
+            : string.Format(L["UpcomingDate"], date.StartsAt);
     }
 }

--- a/PaceLetics.Web/Pages/Profiles.razor
+++ b/PaceLetics.Web/Pages/Profiles.razor
@@ -3,13 +3,14 @@
 @using AthleteDataAccessLibrary.Contracts
 @using PaceLetics.AthleteModule.CodeBase.Models
 @inject IAthleteData AthleteData
+@inject IStringLocalizer<Profiles> L
 
-<PageTitle>Profile</PageTitle>
+<PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
     @if (_isLoading)
     {
-        <LoadingScreen Label="Profile werden geladen" />
+        <LoadingScreen Label="@L["Loading"]" />
     }
     else if (_selectedProfile is not null)
     {
@@ -19,7 +20,7 @@
                            Variant="Variant.Outlined"
                            Color="Color.Default"
                            StartIcon="@Icons.Material.Filled.ArrowBack">
-                    Zurueck
+                    @L["Back"]
                 </MudButton>
             </Actions>
         </PageHeader>
@@ -45,44 +46,44 @@
     }
     else if (_profileNotFound)
     {
-        <PageHeader Title="Profil nicht gefunden" Subtitle="Dieses Profil ist nicht sichtbar oder existiert nicht." />
+        <PageHeader Title="@L["NotFoundTitle"]" Subtitle="@L["NotFoundSubtitle"]" />
 
         <MudDivider Class="my-4" />
 
-        <DashboardNewsFeedTile Title="Profil nicht gefunden"
-                               Detail="Oeffne die Profiluebersicht oder pruefe den Link."
+        <DashboardNewsFeedTile Title="@L["NotFoundTitle"]"
+                               Detail="@L["NotFoundDetail"]"
                                Icon="@Icons.Material.Filled.PersonSearch"
                                Severity="Severity.Warning"
                                Href="/profiles" />
     }
     else
     {
-        <PageHeader Title="Profile" Subtitle="Sichtbare Athlet:innen- und Trainer:innenprofile." />
+        <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
 
         <MudDivider Class="my-4" />
 
         <MudStack Spacing="4">
             <MudGrid Spacing="3">
                 <MudItem xs="12" sm="6" lg="4">
-                    <DashboardMetricTile Label="Sichtbar"
+                    <DashboardMetricTile Label="@L["MetricVisible"]"
                                          Value="@_profiles.Count.ToString()"
-                                         Detail="oeffentliche Profile"
+                                         Detail="@L["MetricVisibleDetail"]"
                                          Icon="@Icons.Material.Filled.Groups"
                                          Accent="blue" />
                 </MudItem>
 
                 <MudItem xs="12" sm="6" lg="4">
-                    <DashboardMetricTile Label="Trainer:innen"
+                    <DashboardMetricTile Label="@L["MetricTrainers"]"
                                          Value="@_profiles.Count(profile => profile.PublicRole == ApplicationRoles.Trainer).ToString()"
-                                         Detail="verifizierte Profile"
+                                         Detail="@L["MetricTrainersDetail"]"
                                          Icon="@Icons.Material.Filled.Verified"
                                          Accent="green" />
                 </MudItem>
 
                 <MudItem xs="12" sm="6" lg="4">
-                    <DashboardMetricTile Label="Athlet:innen"
+                    <DashboardMetricTile Label="@L["MetricAthletes"]"
                                          Value="@_profiles.Count(profile => profile.PublicRole == ApplicationRoles.Athlete).ToString()"
-                                         Detail="aktive Profile"
+                                         Detail="@L["MetricAthletesDetail"]"
                                          Icon="@Icons.Material.Filled.DirectionsRun"
                                          Accent="orange" />
                 </MudItem>
@@ -90,8 +91,8 @@
 
             @if (_profiles.Count == 0)
             {
-                <DashboardNewsFeedTile Title="Keine oeffentlichen Profile"
-                                       Detail="Aktuell sind keine Profile sichtbar geschaltet."
+                <DashboardNewsFeedTile Title="@L["NoProfilesTitle"]"
+                                       Detail="@L["NoProfilesDetail"]"
                                        Icon="@Icons.Material.Filled.VisibilityOff"
                                        Severity="Severity.Info"
                                        Href="/Identity/Account/Manage" />

--- a/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
@@ -11,18 +11,19 @@
 @inject IAthleteData AthleteData
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
+@inject IStringLocalizer<CourseManagement> L
 
-<PageTitle>Kurse verwalten</PageTitle>
+<PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Medium">
     @if (_isLoading)
     {
-        <LoadingScreen Label="Kurse werden geladen" />
+        <LoadingScreen Label="@L["Loading"]" />
     }
     else
     {
-        <PageHeader Title="Kurse verwalten"
-                    Subtitle="Kurse erstellen, Trainer:innen hinzufuegen und eigene Kurse loeschen." />
+        <PageHeader Title="@L["Title"]"
+                    Subtitle="@L["Subtitle"]" />
 
         <MudDivider Class="my-4" />
 
@@ -34,29 +35,29 @@
         <MudStack Spacing="4">
             <MudPaper Elevation="1" Class="pa-4">
                 <MudStack Spacing="3">
-                    <MudText Typo="Typo.h6">Neuen Kurs erstellen</MudText>
+                    <MudText Typo="Typo.h6">@L["CreateCourseTitle"]</MudText>
 
                     <MudGrid Spacing="2">
                         <MudItem xs="12" md="6">
-                            <MudTextField Label="Name" @bind-Value="_courseName" Variant="Variant.Outlined" />
+                            <MudTextField Label="@L["Name"]" @bind-Value="_courseName" Variant="Variant.Outlined" />
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudTextField Label="Level" @bind-Value="_courseLevel" Variant="Variant.Outlined" />
+                            <MudTextField Label="@L["Level"]" @bind-Value="_courseLevel" Variant="Variant.Outlined" />
                         </MudItem>
                         <MudItem xs="12">
-                            <MudTextField Label="Beschreibung"
+                            <MudTextField Label="@L["Description"]"
                                           @bind-Value="_courseDescription"
                                           Variant="Variant.Outlined"
                                           Lines="3" />
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudDatePicker Label="Start"
+                            <MudDatePicker Label="@L["Start"]"
                                            Date="_courseStartDate"
                                            DateChanged="@(date => _courseStartDate = date)"
                                            Variant="Variant.Outlined" />
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudDatePicker Label="Ende"
+                            <MudDatePicker Label="@L["End"]"
                                            Date="_courseEndDate"
                                            DateChanged="@(date => _courseEndDate = date)"
                                            Variant="Variant.Outlined" />
@@ -68,7 +69,7 @@
                                    Variant="Variant.Filled"
                                    StartIcon="@Icons.Material.Filled.Add"
                                    OnClick="CreateCourseAsync">
-                            Kurs erstellen
+                            @L["CreateCourse"]
                         </MudButton>
                     </MudStack>
                 </MudStack>
@@ -77,7 +78,7 @@
             @if (_courses.Count == 0)
             {
                 <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
-                    Du bist aktuell keinem Kurs als Trainer:in zugeordnet.
+                    @L["NoTrainerCourses"]
                 </MudAlert>
             }
             else
@@ -85,7 +86,7 @@
                 <MudPaper Elevation="1" Class="pa-4">
                     <MudStack Spacing="3">
                         <MudSelect T="string"
-                                   Label="Kurs"
+                                   Label="@L["Course"]"
                                    Value="_selectedCourseId"
                                    ValueChanged="OnSelectedCourseChanged"
                                    Variant="Variant.Outlined">
@@ -124,12 +125,12 @@
                                                    Variant="Variant.Outlined"
                                                    StartIcon="@Icons.Material.Filled.Logout"
                                                    OnClick="@(() => LeaveTrainerAsync(course))">
-                                            Austreten
+                                            @L["Leave"]
                                         </MudButton>
                                     }
                                 </MudStack>
 
-                                <MudText Typo="Typo.subtitle2">Trainer:innen</MudText>
+                                <MudText Typo="Typo.subtitle2">@L["Trainers"]</MudText>
                                 <MudStack Spacing="1">
                                     @foreach (var trainer in course.Trainers.OrderBy(trainer => trainer.DisplayName))
                                     {
@@ -155,7 +156,7 @@
 
                                 <MudStack Row="true" AlignItems="AlignItems.End" Style="gap:12px; flex-wrap:wrap;">
                                     <MudSelect T="string"
-                                               Label="Trainer:in hinzufuegen"
+                                               Label="@L["AddTrainerLabel"]"
                                                Value="_selectedTrainerToAddId"
                                                ValueChanged="OnTrainerToAddChanged"
                                                Variant="Variant.Outlined"
@@ -171,16 +172,16 @@
                                                StartIcon="@Icons.Material.Filled.PersonAdd"
                                                Disabled="@string.IsNullOrWhiteSpace(_selectedTrainerToAddId)"
                                                OnClick="@(() => AddTrainerAsync(course))">
-                                        Hinzufuegen
+                                        @L["Add"]
                                     </MudButton>
                                 </MudStack>
 
                                 <MudTabs Elevation="0" Rounded="false" Class="mt-2">
-                                    <MudTabPanel Text="Termine">
+                                    <MudTabPanel Text="@L["Dates"]">
                                         <MudStack Spacing="2" Class="pt-2">
                                             @if (course.Dates.Count == 0)
                                             {
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Termine.</MudText>
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoDates"]</MudText>
                                             }
                                             else
                                             {
@@ -207,22 +208,22 @@
                                             <MudDivider Class="my-2" />
                                             <MudGrid Spacing="2">
                                                 <MudItem xs="12" md="6">
-                                                    <MudTextField Label="Titel" @bind-Value="_dateTitle" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["EventTitle"]" @bind-Value="_dateTitle" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="12" md="6">
-                                                    <MudTextField Label="Ort" @bind-Value="_dateLocation" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["Location"]" @bind-Value="_dateLocation" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="12" md="4">
-                                                    <MudDatePicker Label="Datum" Date="_dateStartDate" DateChanged="@(date => _dateStartDate = date)" Variant="Variant.Outlined" />
+                                                    <MudDatePicker Label="@L["Date"]" Date="_dateStartDate" DateChanged="@(date => _dateStartDate = date)" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="6" md="4">
-                                                    <MudTextField Label="Startzeit" @bind-Value="_dateStartTime" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["StartTime"]" @bind-Value="_dateStartTime" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="6" md="4">
-                                                    <MudTextField Label="Endzeit" @bind-Value="_dateEndTime" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["EndTime"]" @bind-Value="_dateEndTime" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="12">
-                                                    <MudTextField Label="Notizen" @bind-Value="_dateNotes" Variant="Variant.Outlined" Lines="2" />
+                                                    <MudTextField Label="@L["Notes"]" @bind-Value="_dateNotes" Variant="Variant.Outlined" Lines="2" />
                                                 </MudItem>
                                             </MudGrid>
                                             <MudStack Row="true" Justify="Justify.FlexEnd">
@@ -230,17 +231,17 @@
                                                            Variant="Variant.Filled"
                                                            StartIcon="@Icons.Material.Filled.Event"
                                                            OnClick="@(() => AddCourseDateAsync(course))">
-                                                    Termin hinzufuegen
+                                                    @L["AddDate"]
                                                 </MudButton>
                                             </MudStack>
                                         </MudStack>
                                     </MudTabPanel>
 
-                                    <MudTabPanel Text="Events">
+                                    <MudTabPanel Text="@L["Events"]">
                                         <MudStack Spacing="2" Class="pt-2">
                                             @if (_selectedCourseEvents.Count == 0)
                                             {
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Events.</MudText>
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoEvents"]</MudText>
                                             }
                                             else
                                             {
@@ -288,7 +289,7 @@
                                                             }
                                                             else
                                                             {
-                                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch keine Teilnehmenden registriert.</MudText>
+                                                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoParticipants"]</MudText>
                                                             }
                                                         }
                                                     </MudPaper>
@@ -298,28 +299,28 @@
                                             <MudDivider Class="my-2" />
                                             <MudGrid Spacing="2">
                                                 <MudItem xs="12" md="6">
-                                                    <MudTextField Label="Titel" @bind-Value="_eventTitle" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["EventTitle"]" @bind-Value="_eventTitle" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="12" md="6">
-                                                    <MudTextField Label="Ort" @bind-Value="_eventLocation" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["Location"]" @bind-Value="_eventLocation" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="12">
-                                                    <MudTextField Label="Beschreibung" @bind-Value="_eventDescription" Variant="Variant.Outlined" Lines="2" />
+                                                    <MudTextField Label="@L["Description"]" @bind-Value="_eventDescription" Variant="Variant.Outlined" Lines="2" />
                                                 </MudItem>
                                                 <MudItem xs="12" md="4">
-                                                    <MudDatePicker Label="Datum" Date="_eventStartDate" DateChanged="@(date => _eventStartDate = date)" Variant="Variant.Outlined" />
+                                                    <MudDatePicker Label="@L["Date"]" Date="_eventStartDate" DateChanged="@(date => _eventStartDate = date)" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="6" md="4">
-                                                    <MudTextField Label="Startzeit" @bind-Value="_eventStartTime" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["StartTime"]" @bind-Value="_eventStartTime" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="6" md="4">
-                                                    <MudTextField Label="Endzeit" @bind-Value="_eventEndTime" Variant="Variant.Outlined" />
+                                                    <MudTextField Label="@L["EndTime"]" @bind-Value="_eventEndTime" Variant="Variant.Outlined" />
                                                 </MudItem>
                                                 <MudItem xs="12" md="6">
-                                                    <MudNumericField T="int?" Label="Kapazitaet" @bind-Value="_eventCapacity" Variant="Variant.Outlined" Min="1" />
+                                                    <MudNumericField T="int?" Label="@L["Capacity"]" @bind-Value="_eventCapacity" Variant="Variant.Outlined" Min="1" />
                                                 </MudItem>
                                                 <MudItem xs="12" md="6">
-                                                    <MudDatePicker Label="Anmeldefrist" Date="_eventRegistrationDeadline" DateChanged="@(date => _eventRegistrationDeadline = date)" Variant="Variant.Outlined" />
+                                                    <MudDatePicker Label="@L["RegistrationDeadline"]" Date="_eventRegistrationDeadline" DateChanged="@(date => _eventRegistrationDeadline = date)" Variant="Variant.Outlined" />
                                                 </MudItem>
                                             </MudGrid>
                                             <MudStack Row="true" Justify="Justify.FlexEnd">
@@ -327,17 +328,17 @@
                                                            Variant="Variant.Filled"
                                                            StartIcon="@Icons.Material.Filled.EventAvailable"
                                                            OnClick="@(() => CreateEventAsync(course))">
-                                                    Event hinzufuegen
+                                                    @L["AddEvent"]
                                                 </MudButton>
                                             </MudStack>
                                         </MudStack>
                                     </MudTabPanel>
 
-                                    <MudTabPanel Text="Trainingsplaene">
+                                    <MudTabPanel Text="@L["TrainingPlans"]">
                                         <MudStack Spacing="2" Class="pt-2">
                                             @if (course.TrainingPlanPublications.Count == 0)
                                             {
-                                                <MudText Typo="Typo.body2" Color="Color.Secondary">Noch kein Plan veroeffentlicht.</MudText>
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoPublishedPlan"]</MudText>
                                             }
                                             else
                                             {
@@ -360,7 +361,7 @@
                                             <MudDivider Class="my-2" />
                                             <MudStack Row="true" AlignItems="AlignItems.End" Style="gap:12px; flex-wrap:wrap;">
                                                 <MudSelect T="string"
-                                                           Label="Trainingsplan"
+                                                           Label="@L["TrainingPlan"]"
                                                            Value="_selectedTrainingPlanId"
                                                            ValueChanged="OnTrainingPlanChanged"
                                                            Variant="Variant.Outlined"
@@ -375,7 +376,7 @@
                                                            StartIcon="@Icons.Material.Filled.Publish"
                                                            Disabled="@string.IsNullOrWhiteSpace(_selectedTrainingPlanId)"
                                                            OnClick="@(() => PublishTrainingPlanAsync(course))">
-                                                    Plan hinzufuegen
+                                                    @L["AddPlan"]
                                                 </MudButton>
                                             </MudStack>
                                         </MudStack>
@@ -464,7 +465,7 @@
             _userId = user.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
 
             if (string.IsNullOrWhiteSpace(_userId))
-                throw new InvalidOperationException("Trainer:in konnte nicht ermittelt werden.");
+                throw new InvalidOperationException(L["TrainerNotResolved"]);
 
             var athlete = await AthleteData.GetAthlete(_userId);
             _displayName = GetDisplayName(athlete, user.Identity?.Name ?? _userId);
@@ -561,7 +562,7 @@
                 _userId ?? string.Empty,
                 _displayName);
 
-            Snackbar.Add("Kurs wurde erstellt.", Severity.Success);
+            Snackbar.Add(L["CreateCourseSuccess"], Severity.Success);
             ResetCreateForm();
             _selectedCourseId = course.Id;
             await LoadAsync();
@@ -574,14 +575,14 @@
 
     private async Task DeleteCourseAsync(CourseDocument course)
     {
-        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Kurs \"{course.Name}\" wirklich loeschen?");
+        var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["DeleteCourseConfirm"], course.Name));
         if (!confirmed)
             return;
 
         try
         {
             await CourseService.DeleteCourseAsync(course.Id, _userId ?? string.Empty);
-            Snackbar.Add("Kurs wurde geloescht.", Severity.Success);
+            Snackbar.Add(L["DeleteCourseSuccess"], Severity.Success);
             _selectedCourseId = null;
             await LoadAsync();
         }
@@ -605,7 +606,7 @@
                 candidate.DisplayName,
                 _userId ?? string.Empty);
 
-            Snackbar.Add("Trainer:in wurde hinzugefuegt.", Severity.Success);
+            Snackbar.Add(L["AddTrainerSuccess"], Severity.Success);
             _selectedTrainerToAddId = null;
             await LoadAsync();
         }
@@ -617,14 +618,14 @@
 
     private async Task RemoveTrainerAsync(CourseDocument course, CourseTrainerDocument trainer)
     {
-        var confirmed = await JS.InvokeAsync<bool>("confirm", $"{trainer.DisplayName} aus dem Kurs entfernen?");
+        var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["RemoveTrainerConfirm"], trainer.DisplayName));
         if (!confirmed)
             return;
 
         try
         {
             await CourseService.RemoveTrainerAsync(course.Id, trainer.TrainerUserId, _userId ?? string.Empty);
-            Snackbar.Add("Trainer:in wurde entfernt.", Severity.Success);
+            Snackbar.Add(L["RemoveTrainerSuccess"], Severity.Success);
             await LoadAsync();
         }
         catch (Exception ex)
@@ -635,14 +636,14 @@
 
     private async Task LeaveTrainerAsync(CourseDocument course)
     {
-        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Als Trainer:in aus \"{course.Name}\" austreten?");
+        var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["LeaveTrainerConfirm"], course.Name));
         if (!confirmed)
             return;
 
         try
         {
             await CourseService.RemoveTrainerAsync(course.Id, _userId ?? string.Empty, _userId ?? string.Empty);
-            Snackbar.Add("Du bist als Trainer:in ausgetreten.", Severity.Success);
+            Snackbar.Add(L["LeaveTrainerSuccess"], Severity.Success);
             _selectedCourseId = null;
             await LoadAsync();
         }
@@ -668,7 +669,7 @@
                 _dateLocation,
                 _dateNotes);
 
-            Snackbar.Add("Termin wurde hinzugefuegt.", Severity.Success);
+            Snackbar.Add(L["AddDateSuccess"], Severity.Success);
             ResetDateForm();
             await LoadAsync();
         }
@@ -680,14 +681,14 @@
 
     private async Task RemoveCourseDateAsync(CourseDocument course, CourseDateDocument date)
     {
-        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Termin \"{date.Title}\" entfernen?");
+        var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["RemoveDateConfirm"], date.Title));
         if (!confirmed)
             return;
 
         try
         {
             await CourseService.RemoveCourseDateAsync(course.Id, date.Id, _userId ?? string.Empty);
-            Snackbar.Add("Termin wurde entfernt.", Severity.Success);
+            Snackbar.Add(L["RemoveDateSuccess"], Severity.Success);
             await LoadAsync();
         }
         catch (Exception ex)
@@ -714,7 +715,7 @@
                 _eventCapacity,
                 _eventRegistrationDeadline?.Date);
 
-            Snackbar.Add("Event wurde hinzugefuegt.", Severity.Success);
+            Snackbar.Add(L["AddEventSuccess"], Severity.Success);
             ResetEventForm();
             await LoadAsync();
         }
@@ -726,14 +727,14 @@
 
     private async Task DeleteEventAsync(CourseDocument course, CourseEventDocument courseEvent)
     {
-        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Event \"{courseEvent.Title}\" entfernen?");
+        var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["DeleteEventConfirm"], courseEvent.Title));
         if (!confirmed)
             return;
 
         try
         {
             await CourseService.DeleteEventAsync(course.Id, courseEvent.Id, _userId ?? string.Empty);
-            Snackbar.Add("Event wurde entfernt.", Severity.Success);
+            Snackbar.Add(L["DeleteEventSuccess"], Severity.Success);
             await LoadAsync();
         }
         catch (Exception ex)
@@ -775,7 +776,7 @@
                 _selectedTrainingPlanId,
                 _userId ?? string.Empty);
 
-            Snackbar.Add("Trainingsplan wurde hinzugefuegt.", Severity.Success);
+            Snackbar.Add(L["PublishPlanSuccess"], Severity.Success);
             _selectedTrainingPlanId = null;
             await LoadAsync();
         }
@@ -787,14 +788,14 @@
 
     private async Task RemoveTrainingPlanAsync(CourseDocument course, string trainingPlanId)
     {
-        var confirmed = await JS.InvokeAsync<bool>("confirm", $"Trainingsplan \"{GetTrainingPlanName(trainingPlanId)}\" entfernen?");
+        var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["RemovePlanConfirm"], GetTrainingPlanName(trainingPlanId)));
         if (!confirmed)
             return;
 
         try
         {
             await CourseService.RemoveTrainingPlanPublicationAsync(course.Id, trainingPlanId, _userId ?? string.Empty);
-            Snackbar.Add("Trainingsplan wurde entfernt.", Severity.Success);
+            Snackbar.Add(L["RemovePlanSuccess"], Severity.Success);
             await LoadAsync();
         }
         catch (Exception ex)
@@ -844,14 +845,14 @@
         return course.Trainers.Any(trainer => trainer.TrainerUserId == _userId);
     }
 
-    private static string FormatPeriod(CourseDocument course)
+    private string FormatPeriod(CourseDocument course)
     {
-        return $"{course.StartDate:dd.MM.yyyy} bis {course.EndDate:dd.MM.yyyy}";
+        return string.Format(L["Period"], course.StartDate, course.EndDate);
     }
 
-    private static string FormatDateRange(DateTime startsAt, DateTime endsAt)
+    private string FormatDateRange(DateTime startsAt, DateTime endsAt)
     {
-        return $"{startsAt:dd.MM.yyyy HH:mm} bis {endsAt:HH:mm} Uhr";
+        return string.Format(L["DateRange"], startsAt, endsAt);
     }
 
     private string GetTrainingPlanName(string trainingPlanId)
@@ -867,9 +868,9 @@
     private string GetParticipantsButtonText(string eventId)
     {
         if (!_eventParticipants.TryGetValue(eventId, out var participants))
-            return "Teilnehmende";
+            return L["Participants"];
 
-        return $"Teilnehmende ({participants.Count})";
+        return string.Format(L["ParticipantsCount"], participants.Count);
     }
 
     private string GetParticipantDisplayName(string athleteUserId)
@@ -879,13 +880,13 @@
             : athleteUserId;
     }
 
-    private static DateTime CombineDateAndTime(DateTime? date, string time)
+    private DateTime CombineDateAndTime(DateTime? date, string time)
     {
         if (date is null)
-            throw new InvalidOperationException("Bitte ein Datum auswaehlen.");
+            throw new InvalidOperationException(L["ValidationDateRequired"]);
 
         if (!TimeSpan.TryParse(time, out var parsedTime))
-            throw new InvalidOperationException("Bitte eine Uhrzeit im Format HH:mm eingeben.");
+            throw new InvalidOperationException(L["ValidationTimeFormat"]);
 
         return date.Value.Date.Add(parsedTime);
     }

--- a/PaceLetics.Web/Resources/App.de.resx
+++ b/PaceLetics.Web/Resources/App.de.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="NotFoundTitle" xml:space="preserve"><value>Nicht gefunden</value></data>
 </root>

--- a/PaceLetics.Web/Resources/App.en.resx
+++ b/PaceLetics.Web/Resources/App.en.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="NotFoundTitle" xml:space="preserve"><value>Not found</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.de.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="InvalidLoginAttempt" xml:space="preserve"><value>Ungueltiger Anmeldeversuch.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.en.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="InvalidLoginAttempt" xml:space="preserve"><value>Invalid login attempt.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.de.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="PasswordChanged" xml:space="preserve"><value>Ein neues Passwort wurde vergeben.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.en.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="PasswordChanged" xml:space="preserve"><value>Your password has been changed.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.de.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="IncorrectPassword" xml:space="preserve"><value>Das Passwort ist nicht korrekt.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.en.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="IncorrectPassword" xml:space="preserve"><value>Incorrect password.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.de.resx
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="ConfirmEmailSubject" xml:space="preserve"><value>E-Mail bestaetigen</value></data>
+  <data name="ConfirmEmailBody" xml:space="preserve"><value>Bitte bestaetige deinen Account mit einem Klick auf &lt;a href='{0}'&gt;diesen Link&lt;/a&gt;.</value></data>
+  <data name="ConfirmationSent" xml:space="preserve"><value>Bestaetigung gesendet. Bitte E-Mails pruefen.</value></data>
+  <data name="EmailUnchanged" xml:space="preserve"><value>Das ist bereits die gleiche Adresse.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.en.resx
@@ -4,7 +4,8 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="ConfirmEmailSubject" xml:space="preserve"><value>Confirm your email</value></data>
+  <data name="ConfirmEmailBody" xml:space="preserve"><value>Please confirm your account by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value></data>
+  <data name="ConfirmationSent" xml:space="preserve"><value>Confirmation sent. Please check your email.</value></data>
+  <data name="EmailUnchanged" xml:space="preserve"><value>This is already the same address.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Index.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Index.de.resx
@@ -7,4 +7,12 @@
   <data name="Title" xml:space="preserve"><value>Profil</value></data>
   <data name="UsernamePlaceholder" xml:space="preserve"><value>Bitte Benutzername wählen.</value></data>
   <data name="Save" xml:space="preserve"><value>Speichern</value></data>
+  <data name="BackToApp" xml:space="preserve"><value>Zur Hauptansicht</value></data>
+  <data name="Role" xml:space="preserve"><value>Rolle</value></data>
+  <data name="RequestTrainerRole" xml:space="preserve"><value>Trainerrolle beantragen</value></data>
+  <data name="RequestTrainerRoleDescription" xml:space="preserve"><value>Mit einem gueltigen Verifikationscode wird die Trainerrolle zusaetzlich zur Athlet:innenrolle aktiviert.</value></data>
+  <data name="PublicUserName" xml:space="preserve"><value>Oeffentlicher Nutzername</value></data>
+  <data name="ProfileImageUrl" xml:space="preserve"><value>Profilfoto URL</value></data>
+  <data name="IsPublicProfileVisible" xml:space="preserve"><value>Oeffentliches Profil sichtbar</value></data>
+  <data name="TrainerVerificationCode" xml:space="preserve"><value>Trainer-Verifikationscode</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Index.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Index.en.resx
@@ -7,4 +7,12 @@
   <data name="Title" xml:space="preserve"><value>Profile</value></data>
   <data name="UsernamePlaceholder" xml:space="preserve"><value>Please choose your username.</value></data>
   <data name="Save" xml:space="preserve"><value>Save</value></data>
+  <data name="BackToApp" xml:space="preserve"><value>Back to app</value></data>
+  <data name="Role" xml:space="preserve"><value>Role</value></data>
+  <data name="RequestTrainerRole" xml:space="preserve"><value>Request coach role</value></data>
+  <data name="RequestTrainerRoleDescription" xml:space="preserve"><value>A valid verification code enables the coach role in addition to the athlete role.</value></data>
+  <data name="PublicUserName" xml:space="preserve"><value>Public username</value></data>
+  <data name="ProfileImageUrl" xml:space="preserve"><value>Profile photo URL</value></data>
+  <data name="IsPublicProfileVisible" xml:space="preserve"><value>Public profile visible</value></data>
+  <data name="TrainerVerificationCode" xml:space="preserve"><value>Coach verification code</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/IndexModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/IndexModel.de.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ProfileUpdated" xml:space="preserve"><value>Dein Profil wurde aktualisiert.</value></data>
+  <data name="PublicUserNameExists" xml:space="preserve"><value>Dieser oeffentliche Nutzername ist bereits vergeben.</value></data>
+  <data name="RoleAthlete" xml:space="preserve"><value>Athlet:in</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Trainer:in</value></data>
+  <data name="TrainerVerificationInvalid" xml:space="preserve"><value>Der Trainer-Verifikationscode ist ungueltig.</value></data>
+  <data name="TrainerVerificationNotConfigured" xml:space="preserve"><value>Die Trainer-Verifikation ist noch nicht konfiguriert.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/IndexModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/IndexModel.en.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ProfileUpdated" xml:space="preserve"><value>Your profile has been updated.</value></data>
+  <data name="PublicUserNameExists" xml:space="preserve"><value>This public username is already taken.</value></data>
+  <data name="RoleAthlete" xml:space="preserve"><value>Athlete</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Coach</value></data>
+  <data name="TrainerVerificationInvalid" xml:space="preserve"><value>The coach verification code is invalid.</value></data>
+  <data name="TrainerVerificationNotConfigured" xml:space="preserve"><value>Coach verification is not configured yet.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.de.resx
@@ -4,7 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="ConfirmEmailSubject" xml:space="preserve"><value>E-Mail bestaetigen</value></data>
+  <data name="ConfirmEmailBody" xml:space="preserve"><value>Bitte bestaetige deinen Account mit einem Klick auf &lt;a href='{0}'&gt;diesen Link&lt;/a&gt;.</value></data>
+  <data name="EmailAlreadyInUse" xml:space="preserve"><value>Diese E-Mail-Adresse wird bereits verwendet.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.en.resx
@@ -4,7 +4,7 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="ConfirmEmailSubject" xml:space="preserve"><value>Confirm your email</value></data>
+  <data name="ConfirmEmailBody" xml:space="preserve"><value>Please confirm your account by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value></data>
+  <data name="EmailAlreadyInUse" xml:space="preserve"><value>Email is already in use.</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.de.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.de.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="Title" xml:space="preserve"><value>Athlet:innen</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.en.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.en.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="Title" xml:space="preserve"><value>Athletes</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.de.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="Title" xml:space="preserve"><value>Athlet:innen-Konfiguration</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.en.resx
@@ -4,7 +4,5 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="Title" xml:space="preserve"><value>Athlete configuration</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.de.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Meine Kurse</value></data>
+  <data name="Loading" xml:space="preserve"><value>Kurse werden geladen</value></data>
+  <data name="Title" xml:space="preserve"><value>Meine Kurse</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Kursbeitritte, Termine und Events</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>Aktuell sind keine Kurse veroeffentlicht.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>Kein kommender Termin</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:dd.MM. HH:mm} Uhr</value></data>
+  <data name="Leave" xml:space="preserve"><value>Austreten</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>Kurs hinzufuegen</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>Du bist noch keinem Kurs beigetreten.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>Aktuell sind keine weiteren Kurse verfuegbar.</value></data>
+  <data name="Join" xml:space="preserve"><value>Beitreten</value></data>
+  <data name="Joined" xml:space="preserve"><value>Beigetreten</value></data>
+  <data name="Dates" xml:space="preserve"><value>Termine</value></data>
+  <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Trainingsplaene</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>Alle</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>Weniger</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>Keine kommenden Termine.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Aktuell sind keine Events eingestellt.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>Abmelden</value></data>
+  <data name="Register" xml:space="preserve"><value>Anmelden</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>Noch keine Trainingsplaene veroeffentlicht.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Die Kurse konnten nicht aus Cosmos DB geladen werden.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>Du bist dem Kurs beigetreten.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>Aus "{0}" austreten?</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>Du bist aus dem Kurs ausgetreten.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>Du bist fuer das Event angemeldet.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>Du bist fuer das Event abgemeldet.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} bis {1:dd.MM.yyyy}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:dd.MM.} bis {1:dd.MM.}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} bis {1:HH:mm} Uhr</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} bis {1:HH:mm} Uhr</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.en.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>My courses</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading courses</value></data>
+  <data name="Title" xml:space="preserve"><value>My courses</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Course memberships, dates, and events</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>No courses are currently published.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>No upcoming date</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:MM/dd HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>Leave</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>Add course</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>You have not joined a course yet.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>No additional courses are currently available.</value></data>
+  <data name="Join" xml:space="preserve"><value>Join</value></data>
+  <data name="Joined" xml:space="preserve"><value>Joined</value></data>
+  <data name="Dates" xml:space="preserve"><value>Dates</value></data>
+  <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Training plans</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>All</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>Less</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>No upcoming dates.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>No events are currently listed.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Register" xml:space="preserve"><value>Register</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>No training plans published yet.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>The courses could not be loaded from Cosmos DB.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>You joined the course.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>Leave "{0}"?</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>You left the course.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>You registered for the event.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>Your event registration was cancelled.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:MM/dd/yyyy} to {1:MM/dd/yyyy}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:MM/dd} to {1:MM/dd}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} to {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:MM/dd/yyyy HH:mm} to {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Profiles.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Profiles.de.resx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Profile</value></data>
+  <data name="Loading" xml:space="preserve"><value>Profile werden geladen</value></data>
+  <data name="Back" xml:space="preserve"><value>Zurueck</value></data>
+  <data name="NotFoundTitle" xml:space="preserve"><value>Profil nicht gefunden</value></data>
+  <data name="NotFoundSubtitle" xml:space="preserve"><value>Dieses Profil ist nicht sichtbar oder existiert nicht.</value></data>
+  <data name="NotFoundDetail" xml:space="preserve"><value>Oeffne die Profiluebersicht oder pruefe den Link.</value></data>
+  <data name="Title" xml:space="preserve"><value>Profile</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Sichtbare Athlet:innen- und Trainer:innenprofile.</value></data>
+  <data name="MetricVisible" xml:space="preserve"><value>Sichtbar</value></data>
+  <data name="MetricVisibleDetail" xml:space="preserve"><value>oeffentliche Profile</value></data>
+  <data name="MetricTrainers" xml:space="preserve"><value>Trainer:innen</value></data>
+  <data name="MetricTrainersDetail" xml:space="preserve"><value>verifizierte Profile</value></data>
+  <data name="MetricAthletes" xml:space="preserve"><value>Athlet:innen</value></data>
+  <data name="MetricAthletesDetail" xml:space="preserve"><value>aktive Profile</value></data>
+  <data name="NoProfilesTitle" xml:space="preserve"><value>Keine oeffentlichen Profile</value></data>
+  <data name="NoProfilesDetail" xml:space="preserve"><value>Aktuell sind keine Profile sichtbar geschaltet.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Profiles.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Profiles.en.resx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Profiles</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading profiles</value></data>
+  <data name="Back" xml:space="preserve"><value>Back</value></data>
+  <data name="NotFoundTitle" xml:space="preserve"><value>Profile not found</value></data>
+  <data name="NotFoundSubtitle" xml:space="preserve"><value>This profile is not visible or does not exist.</value></data>
+  <data name="NotFoundDetail" xml:space="preserve"><value>Open the profile overview or check the link.</value></data>
+  <data name="Title" xml:space="preserve"><value>Profiles</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Visible athlete and coach profiles.</value></data>
+  <data name="MetricVisible" xml:space="preserve"><value>Visible</value></data>
+  <data name="MetricVisibleDetail" xml:space="preserve"><value>public profiles</value></data>
+  <data name="MetricTrainers" xml:space="preserve"><value>Coaches</value></data>
+  <data name="MetricTrainersDetail" xml:space="preserve"><value>verified profiles</value></data>
+  <data name="MetricAthletes" xml:space="preserve"><value>Athletes</value></data>
+  <data name="MetricAthletesDetail" xml:space="preserve"><value>active profiles</value></data>
+  <data name="NoProfilesTitle" xml:space="preserve"><value>No public profiles</value></data>
+  <data name="NoProfilesDetail" xml:space="preserve"><value>No profiles are currently visible.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Kurse verwalten</value></data>
+  <data name="Loading" xml:space="preserve"><value>Kurse werden geladen</value></data>
+  <data name="Title" xml:space="preserve"><value>Kurse verwalten</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Kurse erstellen, Trainer:innen hinzufuegen und eigene Kurse loeschen.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>Neuen Kurs erstellen</value></data>
+  <data name="Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Level" xml:space="preserve"><value>Level</value></data>
+  <data name="Description" xml:space="preserve"><value>Beschreibung</value></data>
+  <data name="Start" xml:space="preserve"><value>Start</value></data>
+  <data name="End" xml:space="preserve"><value>Ende</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>Kurs erstellen</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>Du bist aktuell keinem Kurs als Trainer:in zugeordnet.</value></data>
+  <data name="Course" xml:space="preserve"><value>Kurs</value></data>
+  <data name="Leave" xml:space="preserve"><value>Austreten</value></data>
+  <data name="Trainers" xml:space="preserve"><value>Trainer:innen</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>Trainer:in hinzufuegen</value></data>
+  <data name="Add" xml:space="preserve"><value>Hinzufuegen</value></data>
+  <data name="Dates" xml:space="preserve"><value>Termine</value></data>
+  <data name="NoDates" xml:space="preserve"><value>Noch keine Termine.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>Titel</value></data>
+  <data name="Location" xml:space="preserve"><value>Ort</value></data>
+  <data name="Date" xml:space="preserve"><value>Datum</value></data>
+  <data name="StartTime" xml:space="preserve"><value>Startzeit</value></data>
+  <data name="EndTime" xml:space="preserve"><value>Endzeit</value></data>
+  <data name="Notes" xml:space="preserve"><value>Notizen</value></data>
+  <data name="AddDate" xml:space="preserve"><value>Termin hinzufuegen</value></data>
+  <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Noch keine Events.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>Noch keine Teilnehmenden registriert.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>Kapazitaet</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>Anmeldefrist</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>Event hinzufuegen</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Trainingsplaene</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>Noch kein Plan veroeffentlicht.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>Trainingsplan</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>Plan hinzufuegen</value></data>
+  <data name="Participants" xml:space="preserve"><value>Teilnehmende</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>Teilnehmende ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>Kurs wurde erstellt.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>Kurs "{0}" wirklich loeschen?</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>Kurs wurde geloescht.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>Trainer:in wurde hinzugefuegt.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>{0} aus dem Kurs entfernen?</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>Trainer:in wurde entfernt.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>Als Trainer:in aus "{0}" austreten?</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>Du bist als Trainer:in ausgetreten.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>Termin wurde hinzugefuegt.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>Termin "{0}" entfernen?</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>Termin wurde entfernt.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>Event wurde hinzugefuegt.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>Event "{0}" entfernen?</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>Event wurde entfernt.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>Trainingsplan wurde hinzugefuegt.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>Trainingsplan "{0}" entfernen?</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>Trainingsplan wurde entfernt.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} bis {1:dd.MM.yyyy}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} bis {1:HH:mm} Uhr</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>Bitte ein Datum auswaehlen.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>Bitte eine Uhrzeit im Format HH:mm eingeben.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>Trainer:in konnte nicht ermittelt werden.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.en.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Manage courses</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading courses</value></data>
+  <data name="Title" xml:space="preserve"><value>Manage courses</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Create courses, add coaches, and delete your own courses.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>Create a new course</value></data>
+  <data name="Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Level" xml:space="preserve"><value>Level</value></data>
+  <data name="Description" xml:space="preserve"><value>Description</value></data>
+  <data name="Start" xml:space="preserve"><value>Start</value></data>
+  <data name="End" xml:space="preserve"><value>End</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>Create course</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>You are not assigned to any course as a coach.</value></data>
+  <data name="Course" xml:space="preserve"><value>Course</value></data>
+  <data name="Leave" xml:space="preserve"><value>Leave</value></data>
+  <data name="Trainers" xml:space="preserve"><value>Coaches</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>Add coach</value></data>
+  <data name="Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Dates" xml:space="preserve"><value>Dates</value></data>
+  <data name="NoDates" xml:space="preserve"><value>No dates yet.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>Title</value></data>
+  <data name="Location" xml:space="preserve"><value>Location</value></data>
+  <data name="Date" xml:space="preserve"><value>Date</value></data>
+  <data name="StartTime" xml:space="preserve"><value>Start time</value></data>
+  <data name="EndTime" xml:space="preserve"><value>End time</value></data>
+  <data name="Notes" xml:space="preserve"><value>Notes</value></data>
+  <data name="AddDate" xml:space="preserve"><value>Add date</value></data>
+  <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>No events yet.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>No participants registered yet.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>Capacity</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>Registration deadline</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>Add event</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Training plans</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>No plan published yet.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>Training plan</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>Add plan</value></data>
+  <data name="Participants" xml:space="preserve"><value>Participants</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>Participants ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>Course was created.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>Really delete course "{0}"?</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>Course was deleted.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>Coach was added.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>Remove {0} from the course?</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>Coach was removed.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>Leave "{0}" as a coach?</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>You left as a coach.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>Date was added.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>Remove date "{0}"?</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>Date was removed.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>Event was added.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>Remove event "{0}"?</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>Event was removed.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>Training plan was added.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>Remove training plan "{0}"?</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>Training plan was removed.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:MM/dd/yyyy} to {1:MM/dd/yyyy}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:MM/dd/yyyy HH:mm} to {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>Please select a date.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>Please enter a time in HH:mm format.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>The coach could not be resolved.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.de.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.de.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>Bitte eine Trainer:in auswaehlen.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>Eine Event-Abmeldung erfordert eine angemeldete Athlet:in.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>Du bist fuer dieses Event nicht angemeldet.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>Der Kurs wurde nicht gefunden.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>Das Kursende darf nicht vor dem Kursstart liegen.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>Ein Kurs braucht einen Namen.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>Ein Kurs braucht eine angemeldete Trainer:in.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>Das Termin-Ende muss nach dem Start liegen.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>Der Termin wurde nicht gefunden.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>Ein Termin braucht einen Titel.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>Nur die Trainer:in, die den Kurs erstellt hat, kann ihn loeschen.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>Das Event-Ende muss nach dem Start liegen.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>Das Event wurde nicht gefunden.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>Ein Event braucht einen Titel.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>Ein Kursbeitritt erfordert eine angemeldete Athlet:in.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>Ein Kursaustritt erfordert eine angemeldete Athlet:in.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>Du bist diesem Kurs nicht beigetreten.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>Du darfst Termine und Events dieses Kurses nicht verwalten.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>Du darfst Trainingsplaene dieses Kurses nicht verwalten.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>Du darfst die Trainer:innen dieses Kurses nicht verwalten.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>Eine Event-Anmeldung erfordert eine angemeldete Athlet:in.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>Die Anmeldefrist fuer dieses Event ist abgelaufen.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>Fuer dieses Event sind keine freien Plaetze mehr verfuegbar.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>Du musst dem Kurs beigetreten sein, bevor du dich fuer Events anmeldest.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>Die Kursleitung kann den Kurs loeschen, aber nicht austreten.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>Diese Trainer:in ist dem Kurs nicht zugeordnet.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>Kursleitung</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Trainer:in</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>Der Trainingsplan wurde nicht gefunden.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>Bitte einen Trainingsplan auswaehlen.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.en.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.en.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>Please select a coach.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>Cancelling an event registration requires a signed-in athlete.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>You are not registered for this event.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>The course was not found.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>The course end date cannot be before the start date.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>A course needs a name.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>A course needs a signed-in coach.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>The date end time must be after the start time.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>The date was not found.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>A date needs a title.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>Only the coach who created this course can delete it.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>The event end time must be after the start time.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>The event was not found.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>An event needs a title.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>Joining a course requires a signed-in athlete.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>Leaving a course requires a signed-in athlete.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>You have not joined this course.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>You are not allowed to manage dates and events for this course.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>You are not allowed to manage training plans for this course.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>You are not allowed to manage this course's coaches.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>Event registration requires a signed-in athlete.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>The registration deadline for this event has passed.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>No spots are available for this event.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>You must join the course before registering for events.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>The course lead can delete the course, but cannot leave it.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>This coach is not assigned to the course.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>Course lead</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Coach</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>The training plan was not found.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>Please select a training plan.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.de.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.de.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>Noch keine Trainingseinheit</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>Tritt einem Kurs bei, um veroeffentlichte Trainingsplaene zu sehen.</value></data>
+  <data name="Courses" xml:space="preserve"><value>Kurse</value></data>
+  <data name="Open" xml:space="preserve"><value>Oeffnen</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>Vorschau</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>Trainingsdetails und Struktur der Einheit.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} Workout(s)</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>Trainingseinheit</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.en.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.en.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>No training session yet</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>Join a course to see published training plans.</value></data>
+  <data name="Courses" xml:space="preserve"><value>Courses</value></data>
+  <data name="Open" xml:space="preserve"><value>Open</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>Preview</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>Training details and session structure.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} workout(s)</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>Training session</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.de.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.de.resx
@@ -4,7 +4,6 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="Loading" xml:space="preserve"><value>Laedt...</value></data>
+  <data name="Name" xml:space="preserve"><value>Name</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.en.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.en.resx
@@ -4,7 +4,6 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
-  <data name="MiniCard_Run" xml:space="preserve"><value>Run</value></data>
-  <data name="TrainingCard_Title" xml:space="preserve"><value>Training</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading...</value></data>
+  <data name="Name" xml:space="preserve"><value>Name</value></data>
 </root>

--- a/PaceLetics.Web/Services/Courses/CourseService.cs
+++ b/PaceLetics.Web/Services/Courses/CourseService.cs
@@ -1,12 +1,16 @@
+using Microsoft.Extensions.Localization;
+
 namespace PaceLetics.Web.Services.Courses;
 
 public sealed class CourseService : ICourseService
 {
     private readonly ICourseRepository _repository;
+    private readonly IStringLocalizer<CourseService>? _localizer;
 
-    public CourseService(ICourseRepository repository)
+    public CourseService(ICourseRepository repository, IStringLocalizer<CourseService>? localizer = null)
     {
         _repository = repository;
+        _localizer = localizer;
     }
 
     public async Task<IReadOnlyList<CourseOverview>> GetCoursesForAthleteAsync(string athleteUserId)
@@ -73,13 +77,13 @@ public sealed class CourseService : ICourseService
             throw new ArgumentNullException(nameof(request));
 
         if (string.IsNullOrWhiteSpace(creatorTrainerUserId))
-            throw new InvalidOperationException("Ein Kurs braucht eine angemeldete Trainer:in.");
+            throw new InvalidOperationException(Text("CreateCourseTrainerRequired", "Ein Kurs braucht eine angemeldete Trainer:in."));
 
         if (string.IsNullOrWhiteSpace(request.Name))
-            throw new InvalidOperationException("Ein Kurs braucht einen Namen.");
+            throw new InvalidOperationException(Text("CreateCourseNameRequired", "Ein Kurs braucht einen Namen."));
 
         if (request.EndDate.Date < request.StartDate.Date)
-            throw new InvalidOperationException("Das Kursende darf nicht vor dem Kursstart liegen.");
+            throw new InvalidOperationException(Text("CreateCourseEndBeforeStart", "Das Kursende darf nicht vor dem Kursstart liegen."));
 
         var courseId = CreateCourseId(request.Name);
         var now = DateTime.UtcNow;
@@ -102,7 +106,7 @@ public sealed class CourseService : ICourseService
                 {
                     TrainerUserId = creatorTrainerUserId,
                     DisplayName = NormalizeDisplayName(creatorDisplayName, creatorTrainerUserId),
-                    Role = "Kursleitung",
+                    Role = Text("RoleCourseLead", "Kursleitung"),
                     CanManagePlans = true,
                     CanManageEvents = true,
                     CanManageMembers = true
@@ -117,10 +121,10 @@ public sealed class CourseService : ICourseService
     public async Task DeleteCourseAsync(string courseId, string requestingTrainerUserId)
     {
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         if (course.CreatedByTrainerUserId != requestingTrainerUserId)
-            throw new InvalidOperationException("Nur die Trainer:in, die den Kurs erstellt hat, kann ihn loeschen.");
+            throw new InvalidOperationException(Text("DeleteCourseCreatorOnly", "Nur die Trainer:in, die den Kurs erstellt hat, kann ihn loeschen."));
 
         await _repository.DeleteCourseAsync(course.Id);
     }
@@ -128,10 +132,10 @@ public sealed class CourseService : ICourseService
     public async Task<CourseEnrollmentDocument> JoinCourseAsync(string courseId, string athleteUserId)
     {
         if (string.IsNullOrWhiteSpace(athleteUserId))
-            throw new InvalidOperationException("Ein Kursbeitritt erfordert eine angemeldete Athlet:in.");
+            throw new InvalidOperationException(Text("JoinCourseAthleteRequired", "Ein Kursbeitritt erfordert eine angemeldete Athlet:in."));
 
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         var existing = await _repository.GetEnrollmentAsync(course.Id, athleteUserId);
         var enrollment = existing ?? new CourseEnrollmentDocument
@@ -154,13 +158,13 @@ public sealed class CourseService : ICourseService
     public async Task<CourseEnrollmentDocument> LeaveCourseAsync(string courseId, string athleteUserId)
     {
         if (string.IsNullOrWhiteSpace(athleteUserId))
-            throw new InvalidOperationException("Ein Kursaustritt erfordert eine angemeldete Athlet:in.");
+            throw new InvalidOperationException(Text("LeaveCourseAthleteRequired", "Ein Kursaustritt erfordert eine angemeldete Athlet:in."));
 
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         var enrollment = await _repository.GetEnrollmentAsync(course.Id, athleteUserId)
-            ?? throw new InvalidOperationException("Du bist diesem Kurs nicht beigetreten.");
+            ?? throw new InvalidOperationException(Text("LeaveCourseNotJoined", "Du bist diesem Kurs nicht beigetreten."));
 
         var cancelledAt = DateTime.UtcNow;
         enrollment.Status = CourseEnrollmentStatus.Cancelled;
@@ -175,7 +179,7 @@ public sealed class CourseService : ICourseService
     public async Task AssignTrainerAsync(string courseId, string trainerUserId, string displayName)
     {
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         course.Trainers.RemoveAll(trainer => trainer.TrainerUserId == trainerUserId);
         course.Trainers.Add(new CourseTrainerDocument
@@ -194,10 +198,10 @@ public sealed class CourseService : ICourseService
         string requestingTrainerUserId)
     {
         if (string.IsNullOrWhiteSpace(trainerUserId))
-            throw new InvalidOperationException("Bitte eine Trainer:in auswaehlen.");
+            throw new InvalidOperationException(Text("AddTrainerRequired", "Bitte eine Trainer:in auswaehlen."));
 
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequireTrainerManagement(course, requestingTrainerUserId);
 
@@ -206,7 +210,7 @@ public sealed class CourseService : ICourseService
         {
             TrainerUserId = trainerUserId,
             DisplayName = NormalizeDisplayName(displayName, trainerUserId),
-            Role = "Trainer:in",
+            Role = Text("RoleTrainer", "Trainer:in"),
             CanManagePlans = true,
             CanManageEvents = true,
             CanManageMembers = true
@@ -218,17 +222,17 @@ public sealed class CourseService : ICourseService
     public async Task RemoveTrainerAsync(string courseId, string trainerUserId, string requestingTrainerUserId)
     {
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         if (course.CreatedByTrainerUserId == trainerUserId)
-            throw new InvalidOperationException("Die Kursleitung kann den Kurs loeschen, aber nicht austreten.");
+            throw new InvalidOperationException(Text("RemoveTrainerLeadCannotLeave", "Die Kursleitung kann den Kurs loeschen, aber nicht austreten."));
 
         if (trainerUserId != requestingTrainerUserId)
             RequireTrainerManagement(course, requestingTrainerUserId);
 
         var removed = course.Trainers.RemoveAll(trainer => trainer.TrainerUserId == trainerUserId);
         if (removed == 0)
-            throw new InvalidOperationException("Diese Trainer:in ist dem Kurs nicht zugeordnet.");
+            throw new InvalidOperationException(Text("RemoveTrainerNotAssigned", "Diese Trainer:in ist dem Kurs nicht zugeordnet."));
 
         await _repository.UpsertCourseAsync(course);
     }
@@ -243,13 +247,13 @@ public sealed class CourseService : ICourseService
         string notes = "")
     {
         if (string.IsNullOrWhiteSpace(title))
-            throw new InvalidOperationException("Ein Termin braucht einen Titel.");
+            throw new InvalidOperationException(Text("DateTitleRequired", "Ein Termin braucht einen Titel."));
 
         if (endsAt <= startsAt)
-            throw new InvalidOperationException("Das Termin-Ende muss nach dem Start liegen.");
+            throw new InvalidOperationException(Text("DateEndAfterStart", "Das Termin-Ende muss nach dem Start liegen."));
 
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequireEventManagement(course, requestingTrainerUserId);
 
@@ -273,13 +277,13 @@ public sealed class CourseService : ICourseService
     public async Task RemoveCourseDateAsync(string courseId, string dateId, string requestingTrainerUserId)
     {
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequireEventManagement(course, requestingTrainerUserId);
 
         var removed = course.Dates.RemoveAll(date => date.Id == dateId);
         if (removed == 0)
-            throw new InvalidOperationException("Der Termin wurde nicht gefunden.");
+            throw new InvalidOperationException(Text("DateNotFound", "Der Termin wurde nicht gefunden."));
 
         await _repository.UpsertCourseAsync(course);
     }
@@ -287,10 +291,10 @@ public sealed class CourseService : ICourseService
     public async Task PublishTrainingPlanAsync(string courseId, string trainingPlanId, string publishedByUserId, DateTime? visibleFrom = null)
     {
         if (string.IsNullOrWhiteSpace(trainingPlanId))
-            throw new InvalidOperationException("Bitte einen Trainingsplan auswaehlen.");
+            throw new InvalidOperationException(Text("TrainingPlanRequired", "Bitte einen Trainingsplan auswaehlen."));
 
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequirePlanManagement(course, publishedByUserId);
 
@@ -321,13 +325,13 @@ public sealed class CourseService : ICourseService
     public async Task RemoveTrainingPlanPublicationAsync(string courseId, string trainingPlanId, string requestingTrainerUserId)
     {
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequirePlanManagement(course, requestingTrainerUserId);
 
         var removed = course.TrainingPlanPublications.RemoveAll(publication => publication.TrainingPlanId == trainingPlanId);
         if (removed == 0)
-            throw new InvalidOperationException("Der Trainingsplan wurde nicht gefunden.");
+            throw new InvalidOperationException(Text("TrainingPlanNotFound", "Der Trainingsplan wurde nicht gefunden."));
 
         await _repository.UpsertCourseAsync(course);
     }
@@ -349,13 +353,13 @@ public sealed class CourseService : ICourseService
         DateTime? registrationDeadline = null)
     {
         if (string.IsNullOrWhiteSpace(title))
-            throw new InvalidOperationException("Ein Event braucht einen Titel.");
+            throw new InvalidOperationException(Text("EventTitleRequired", "Ein Event braucht einen Titel."));
 
         if (endsAt <= startsAt)
-            throw new InvalidOperationException("Das Event-Ende muss nach dem Start liegen.");
+            throw new InvalidOperationException(Text("EventEndAfterStart", "Das Event-Ende muss nach dem Start liegen."));
 
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequireEventManagement(course, createdByUserId);
 
@@ -380,12 +384,12 @@ public sealed class CourseService : ICourseService
     public async Task DeleteEventAsync(string courseId, string eventId, string requestingTrainerUserId)
     {
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequireEventManagement(course, requestingTrainerUserId);
 
         var courseEvent = await _repository.GetEventAsync(courseId, eventId)
-            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("EventNotFound", "Das Event wurde nicht gefunden."));
 
         await _repository.DeleteEventAsync(course.Id, courseEvent.Id);
     }
@@ -396,12 +400,12 @@ public sealed class CourseService : ICourseService
         string requestingTrainerUserId)
     {
         var course = await _repository.GetCourseAsync(courseId)
-            ?? throw new InvalidOperationException("Der Kurs wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
 
         RequireEventManagement(course, requestingTrainerUserId);
 
         _ = await _repository.GetEventAsync(courseId, eventId)
-            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("EventNotFound", "Das Event wurde nicht gefunden."));
 
         return (await _repository.GetEventRegistrationsAsync(courseId, eventId))
             .Where(registration => registration.Status == CourseEventRegistrationStatus.Registered)
@@ -418,7 +422,7 @@ public sealed class CourseService : ICourseService
             return null;
 
         _ = await _repository.GetEventAsync(courseId, eventId)
-            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("EventNotFound", "Das Event wurde nicht gefunden."));
 
         return await _repository.GetEventRegistrationAsync(courseId, eventId, athleteUserId);
     }
@@ -426,17 +430,17 @@ public sealed class CourseService : ICourseService
     public async Task<CourseEventRegistrationDocument> RegisterForEventAsync(string courseId, string eventId, string athleteUserId)
     {
         if (string.IsNullOrWhiteSpace(athleteUserId))
-            throw new InvalidOperationException("Eine Event-Anmeldung erfordert eine angemeldete Athlet:in.");
+            throw new InvalidOperationException(Text("RegisterEventAthleteRequired", "Eine Event-Anmeldung erfordert eine angemeldete Athlet:in."));
 
         var enrollment = await _repository.GetEnrollmentAsync(courseId, athleteUserId);
         if (enrollment?.Status != CourseEnrollmentStatus.Active)
-            throw new InvalidOperationException("Du musst dem Kurs beigetreten sein, bevor du dich für Events anmeldest.");
+            throw new InvalidOperationException(Text("RegisterEventRequiresEnrollment", "Du musst dem Kurs beigetreten sein, bevor du dich fuer Events anmeldest."));
 
         var courseEvent = await _repository.GetEventAsync(courseId, eventId)
-            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("EventNotFound", "Das Event wurde nicht gefunden."));
 
         if (courseEvent.RegistrationDeadline is not null && courseEvent.RegistrationDeadline < DateTime.UtcNow)
-            throw new InvalidOperationException("Die Anmeldefrist für dieses Event ist abgelaufen.");
+            throw new InvalidOperationException(Text("RegisterEventDeadlinePassed", "Die Anmeldefrist fuer dieses Event ist abgelaufen."));
 
         var registrations = await _repository.GetEventRegistrationsAsync(courseId, eventId);
         var activeRegistrations = registrations.Count(registration =>
@@ -446,7 +450,7 @@ public sealed class CourseService : ICourseService
         {
             var existing = registrations.FirstOrDefault(registration => registration.AthleteUserId == athleteUserId);
             if (existing?.Status != CourseEventRegistrationStatus.Registered)
-                throw new InvalidOperationException("Für dieses Event sind keine freien Plätze mehr verfügbar.");
+                throw new InvalidOperationException(Text("RegisterEventFull", "Fuer dieses Event sind keine freien Plaetze mehr verfuegbar."));
         }
 
         var registration = await _repository.GetEventRegistrationAsync(courseId, eventId, athleteUserId)
@@ -471,16 +475,16 @@ public sealed class CourseService : ICourseService
     public async Task<CourseEventRegistrationDocument> CancelEventRegistrationAsync(string courseId, string eventId, string athleteUserId)
     {
         if (string.IsNullOrWhiteSpace(athleteUserId))
-            throw new InvalidOperationException("Eine Event-Abmeldung erfordert eine angemeldete Athlet:in.");
+            throw new InvalidOperationException(Text("CancelEventAthleteRequired", "Eine Event-Abmeldung erfordert eine angemeldete Athlet:in."));
 
         _ = await _repository.GetEventAsync(courseId, eventId)
-            ?? throw new InvalidOperationException("Das Event wurde nicht gefunden.");
+            ?? throw new InvalidOperationException(Text("EventNotFound", "Das Event wurde nicht gefunden."));
 
         var registration = await _repository.GetEventRegistrationAsync(courseId, eventId, athleteUserId)
-            ?? throw new InvalidOperationException("Du bist fuer dieses Event nicht angemeldet.");
+            ?? throw new InvalidOperationException(Text("CancelEventNotRegistered", "Du bist fuer dieses Event nicht angemeldet."));
 
         if (registration.Status != CourseEventRegistrationStatus.Registered)
-            throw new InvalidOperationException("Du bist fuer dieses Event nicht angemeldet.");
+            throw new InvalidOperationException(Text("CancelEventNotRegistered", "Du bist fuer dieses Event nicht angemeldet."));
 
         registration.Status = CourseEventRegistrationStatus.Cancelled;
         registration.CancelledAt = DateTime.UtcNow;
@@ -528,24 +532,33 @@ public sealed class CourseService : ICourseService
             : displayName.Trim();
     }
 
-    private static void RequireTrainerManagement(CourseDocument course, string requestingTrainerUserId)
+    private void RequireTrainerManagement(CourseDocument course, string requestingTrainerUserId)
     {
         var trainer = course.Trainers.FirstOrDefault(trainer => trainer.TrainerUserId == requestingTrainerUserId);
         if (trainer is null || !trainer.CanManageMembers)
-            throw new InvalidOperationException("Du darfst die Trainer:innen dieses Kurses nicht verwalten.");
+            throw new InvalidOperationException(Text("PermissionManageTrainers", "Du darfst die Trainer:innen dieses Kurses nicht verwalten."));
     }
 
-    private static void RequireEventManagement(CourseDocument course, string requestingTrainerUserId)
+    private void RequireEventManagement(CourseDocument course, string requestingTrainerUserId)
     {
         var trainer = course.Trainers.FirstOrDefault(trainer => trainer.TrainerUserId == requestingTrainerUserId);
         if (trainer is null || !trainer.CanManageEvents)
-            throw new InvalidOperationException("Du darfst Termine und Events dieses Kurses nicht verwalten.");
+            throw new InvalidOperationException(Text("PermissionManageEvents", "Du darfst Termine und Events dieses Kurses nicht verwalten."));
     }
 
-    private static void RequirePlanManagement(CourseDocument course, string requestingTrainerUserId)
+    private void RequirePlanManagement(CourseDocument course, string requestingTrainerUserId)
     {
         var trainer = course.Trainers.FirstOrDefault(trainer => trainer.TrainerUserId == requestingTrainerUserId);
         if (trainer is null || !trainer.CanManagePlans)
-            throw new InvalidOperationException("Du darfst Trainingsplaene dieses Kurses nicht verwalten.");
+            throw new InvalidOperationException(Text("PermissionManagePlans", "Du darfst Trainingsplaene dieses Kurses nicht verwalten."));
+    }
+
+    private string Text(string key, string fallback)
+    {
+        if (_localizer is null)
+            return fallback;
+
+        var localized = _localizer[key];
+        return localized.ResourceNotFound ? fallback : localized.Value;
     }
 }

--- a/PaceLetics.Web/Shared/DashboardNextTrainingSessionTile.razor
+++ b/PaceLetics.Web/Shared/DashboardNextTrainingSessionTile.razor
@@ -1,4 +1,6 @@
-﻿@using PaceLetics.TrainingPlanModule.CodeBase.Models
+@using PaceLetics.TrainingPlanModule.CodeBase.Models
+@inject IStringLocalizer<DashboardNextTrainingSessionTile> L
+
 <MudPaper Elevation="0"
           Class="pa-4"
           Style="border-radius:20px; border:1px solid var(--mud-palette-lines-default); background:linear-gradient(180deg, var(--mud-palette-surface), var(--mud-palette-background));">
@@ -10,15 +12,15 @@
                   Justify="Justify.SpaceBetween">
 
             <MudStack Spacing="1">
-                <MudText Typo="Typo.h6">                                                                                   
-                    @(Session?.Name ?? "Noch keine Trainingseinheit")
+                <MudText Typo="Typo.h6">
+                    @(Session?.Name ?? L["NoSessionTitle"])
                 </MudText>
 
                 <MudText Typo="Typo.body2"
                          Class="pl-dashboard-muted">
                     @if (Session is null)
                     {
-                        @("Tritt einem Kurs bei, um veröffentlichte Trainingspläne zu sehen.")
+                        @L["NoSessionDetail"]
                     }
                     else
                     {
@@ -33,7 +35,7 @@
                        Variant="Variant.Filled"
                        Color="Color.Primary"
                        StartIcon="@Icons.Material.Filled.OpenInNew">
-                @(Session is null ? "Kurse" : "Open")
+                @(Session is null ? L["Courses"] : L["Open"])
             </MudButton>
         </MudStack>
 
@@ -50,12 +52,12 @@
 
                 <MudStack Spacing="0">
                     <MudText Typo="Typo.subtitle2">
-                        Vorschau
+                        @L["PreviewTitle"]
                     </MudText>
 
                     <MudText Typo="Typo.body2"
                              Class="pl-dashboard-muted">
-                        Trainingsdetails und Struktur der Einheit.
+                        @L["PreviewDetail"]
                     </MudText>
                 </MudStack>
             </MudStack>
@@ -68,7 +70,7 @@
     [Parameter]
     public TrainingSession? Session { get; set; }
 
-    private static string GetSessionComposition(TrainingSession session)
+    private string GetSessionComposition(TrainingSession session)
     {
         var parts = new List<string>();
 
@@ -76,8 +78,8 @@
             parts.Add($"{session.PrimaryRun.TotalDistance / 1000.0:0.0} km");
 
         if (session.Workouts.Count > 0)
-            parts.Add($"{session.Workouts.Count} Workout(s)");
+            parts.Add(string.Format(L["WorkoutCount"], session.Workouts.Count));
 
-        return parts.Count == 0 ? "Trainingseinheit" : string.Join(" / ", parts);
+        return parts.Count == 0 ? L["TrainingSession"] : string.Join(" / ", parts);
     }
 }

--- a/PaceLetics.Web/Shared/DataGridView.razor
+++ b/PaceLetics.Web/Shared/DataGridView.razor
@@ -1,32 +1,33 @@
-﻿@using PaceLetics.AthleteModule.CodeBase.Models;
+@using PaceLetics.AthleteModule.CodeBase.Models;
+@inject IStringLocalizer<DataGridView> L
 
 @if (Athletes == null)
 {
-	<p><em>Loading...</em></p>
+    <p><em>@L["Loading"]</em></p>
 }
 else
 {
-	<table class="table">
-		<thead>
-			<tr>
-				<th>Name</th>
-				<th>Vdot</th>
-			</tr>
-		</thead>
-		<tbody>
-			@foreach(var athlete in Athletes)
-			{
-				<tr>
-					<td>@athlete.Name</td>
-					<td>@athlete.Vdot</td>
-				</tr>
-			}
-		</tbody>
-	</table>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>@L["Name"]</th>
+                <th>Vdot</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach(var athlete in Athletes)
+            {
+                <tr>
+                    <td>@athlete.Name</td>
+                    <td>@athlete.Vdot</td>
+                </tr>
+            }
+        </tbody>
+    </table>
 }
 
 @code {
-	[Parameter]
-	public IList<AthleteModel> Athletes{ get; set; } = new List<AthleteModel>();
+    [Parameter]
+    public IList<AthleteModel> Athletes{ get; set; } = new List<AthleteModel>();
 
 }


### PR DESCRIPTION
Fix Missing Localization

## Summary
- Localized newly introduced course and profile UI surfaces with German and English `.resx` resources.
- Replaced hard-coded user-facing course service exceptions with localizable resource lookups and safe German fallbacks.
- Added localization for remaining workout, athlete dialog, dashboard, Identity account, and small legacy view strings.

## Main Areas Changed
- Athlete course overview: `MyCourses.razor`
- Trainer course management: `CourseManagement.razor`
- Public profiles: `Profiles.razor`
- Dashboard next training tile and legacy shared views
- Identity login/register/manage PageModels and views
- Workout and athlete module residual button/fallback strings

## Verification
- `dotnet build PaceLeticsFramework.sln` succeeded.
- `dotnet test PaceLeticsFramework.sln --no-build` succeeded: 56 passed, 0 failed.

## Notes
- Build still reports existing package vulnerability warnings for `OpenMcdf` and `SharpCompress`; these are unrelated to this localization change.
- Technical configuration exceptions remain in English where they are intended for operators/developers rather than end users.
