### PR TITLE
Add theme management and refine course UI

### DIFF
--- a/PR_REPORT.md
+++ b/PR_REPORT.md
@@ -1,22 +1,27 @@
-# PR Report: Missing Localization
+# PR Report: Theme Management and Course UI Improvements
 
 ## Summary
-- Localized newly introduced course and profile UI surfaces with German and English `.resx` resources.
-- Replaced hard-coded user-facing course service exceptions with localizable resource lookups and safe German fallbacks.
-- Added localization for remaining workout, athlete dialog, dashboard, Identity account, and small legacy view strings.
+- Added full app theme management with selectable theme presets and Light/Dark/System color schemes.
+- Added centralized theme persistence via `localStorage` and system dark-mode observation.
+- Improved athlete course UI with smaller joined-course cards and icon-only registration/deregistration actions.
+- Reworked course levels to use a `CourseLevel` enum for creation while keeping stored course documents backward-compatible.
+- Improved the training-plan empty state with a localized message box and icon link to course selection.
 
 ## Main Areas Changed
-- Athlete course overview: `MyCourses.razor`
-- Trainer course management: `CourseManagement.razor`
-- Public profiles: `Profiles.razor`
-- Dashboard next training tile and legacy shared views
-- Identity login/register/manage PageModels and views
-- Workout and athlete module residual button/fallback strings
+- Theme service and presets: `PaceLetics.Web/Services/Theming/*`
+- App shell theme menu: `PaceLetics.Web/Shared/MainLayout.razor`
+- Theme localization: `PaceLetics.Web/Resources/Shared/MainLayout.*.resx`
+- Course overview UI: `PaceLetics.Web/Pages/Athletes/MyCourses.razor`
+- Trainer course creation: `PaceLetics.Web/Pages/Trainers/CourseManagement.razor`
+- Course level model and formatting: `PaceLetics.Web/Services/Courses/CourseDocuments.cs`
+- Course creation normalization: `PaceLetics.Web/Services/Courses/CourseService.cs`
+- Training-plan empty state localization: `PaceLetics.Web/Pages/Athletes/TrainingPlanPage.razor`
 
 ## Verification
-- `dotnet build PaceLeticsFramework.sln` succeeded.
-- `dotnet test PaceLeticsFramework.sln --no-build` succeeded: 56 passed, 0 failed.
+- `dotnet build PaceLetics.Web\PaceLetics.Web.csproj --no-restore -p:OutputPath=..\artifacts\verify-build\PaceLetics.Web\` succeeded.
+- `dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore --filter CourseServiceTests -p:OutputPath=..\artifacts\verify-test\bin\ -p:BaseIntermediateOutputPath=..\artifacts\verify-test\obj\` succeeded.
 
 ## Notes
-- Build still reports existing package vulnerability warnings for `OpenMcdf` and `SharpCompress`; these are unrelated to this localization change.
-- Technical configuration exceptions remain in English where they are intended for operators/developers rather than end users.
+- Standard build/test output paths can be locked while the local `PaceLetics.Web` dev server is running, so verification used isolated output folders.
+- Existing package vulnerability warnings for `OpenMcdf` and `SharpCompress` remain unrelated to this change.
+- Browser smoke testing reached the local app, but unauthenticated requests redirect to the Identity login page because the local Identity database was unavailable.

--- a/PaceLetics.Tests/CourseServiceTests.cs
+++ b/PaceLetics.Tests/CourseServiceTests.cs
@@ -27,6 +27,36 @@ public sealed class CourseServiceTests
     }
 
     [Fact]
+    public async Task CreateCourse_StoresFormattedCourseLevel()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Testkurs",
+                Level = CourseLevel.Level3,
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        Assert.Equal("Level 3", course.Level);
+    }
+
+    [Theory]
+    [InlineData("1", "Level 1")]
+    [InlineData("Level 2", "Level 2")]
+    [InlineData("level 5", "Level 5")]
+    [InlineData("Advanced", "Advanced")]
+    public void CourseLevelFormatting_FormatsKnownLevelsAndPreservesUnknownValues(string level, string expected)
+    {
+        Assert.Equal(expected, CourseLevelFormatting.Format(level));
+    }
+
+    [Fact]
     public async Task DeleteCourse_RequiresCreator()
     {
         var repository = new InMemoryCourseRepository();

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -44,16 +44,16 @@
                         var nextDate = GetUpcomingDates(course).FirstOrDefault();
 
                         <MudPaper Elevation="@(isSelected ? 4 : 1)"
-                                  Class="pa-3"
+                                  Class="pa-2"
                                   Style="@GetCourseCardStyle(isSelected)"
                                   @onclick="@(() => SelectCourse(course.Id))">
                             <MudStack Spacing="2" Style="height:100%;">
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="width:100%; gap:8px;">
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@course.Level</MudChip>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@FormatCourseLevel(course.Level)</MudChip>
                                     <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Small" />
                                 </MudStack>
 
-                                <MudText Typo="Typo.subtitle2" Style="line-height:1.25; min-height:40px; overflow:hidden;">
+                                <MudText Typo="Typo.body2" Style="line-height:1.25; min-height:34px; overflow:hidden;">
                                     @course.Name
                                 </MudText>
 
@@ -66,13 +66,15 @@
 
                                 <MudSpacer />
 
-                                <MudButton Size="Size.Small"
-                                           Color="Color.Default"
-                                           Variant="Variant.Outlined"
-                                           StartIcon="@Icons.Material.Filled.Logout"
-                                           OnClick="@(() => LeaveCourseAsync(course.Id, course.Name))">
-                                    @L["Leave"]
-                                </MudButton>
+                                <MudStack Row="true" Justify="Justify.FlexEnd" Style="width:100%;">
+                                    <MudTooltip Text="@L["Leave"]">
+                                        <MudIconButton Size="Size.Small"
+                                                       Color="Color.Default"
+                                                       Icon="@Icons.Material.Filled.Logout"
+                                                       OnClick="@(() => LeaveCourseAsync(course.Id, course.Name))"
+                                                       aria-label="@L["Leave"]" />
+                                    </MudTooltip>
+                                </MudStack>
                             </MudStack>
                         </MudPaper>
                     }
@@ -120,20 +122,20 @@
                                                     <MudStack Spacing="1" Style="min-width:0;">
                                                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="flex-wrap:wrap;">
                                                             <MudText Typo="Typo.subtitle2">@course.Name</MudText>
-                                                            <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@course.Level</MudChip>
+                                                            <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@FormatCourseLevel(course.Level)</MudChip>
                                                         </MudStack>
                                                         <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatShortPeriod(course)</MudText>
                                                         <MudText Typo="Typo.caption" Color="Color.Secondary">
                                                             @FormatUpcomingDate(nextDate)
                                                         </MudText>
                                                     </MudStack>
-                                                    <MudButton Size="Size.Small"
-                                                               Color="Color.Primary"
-                                                               Variant="Variant.Filled"
-                                                               StartIcon="@Icons.Material.Filled.HowToReg"
-                                                               OnClick="@(() => JoinCourseAsync(course.Id))">
-                                                        @L["Join"]
-                                                    </MudButton>
+                                                    <MudTooltip Text="@L["Join"]">
+                                                        <MudIconButton Size="Size.Small"
+                                                                       Color="Color.Primary"
+                                                                       Icon="@Icons.Material.Filled.HowToReg"
+                                                                       OnClick="@(() => JoinCourseAsync(course.Id))"
+                                                                       aria-label="@L["Join"]" />
+                                                    </MudTooltip>
                                                 </MudStack>
                                             </div>
                                         }
@@ -158,7 +160,7 @@
                             <MudStack Spacing="1" Style="min-width:0;">
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="flex-wrap:wrap;">
                                     <MudText Typo="Typo.h6">@course.Name</MudText>
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@course.Level</MudChip>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">@FormatCourseLevel(course.Level)</MudChip>
                                     <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Filled">@L["Joined"]</MudChip>
                                 </MudStack>
                                 <MudText Typo="Typo.body2" Color="Color.Secondary" Style="display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden;">
@@ -232,23 +234,23 @@
                                                 </div>
                                                 @if (IsRegisteredForEvent(courseEvent.Id))
                                                 {
-                                                    <MudButton Size="Size.Small"
-                                                               Color="Color.Default"
-                                                               Variant="Variant.Outlined"
-                                                               StartIcon="@Icons.Material.Filled.EventBusy"
-                                                               OnClick="@(() => CancelEventRegistrationAsync(course.Id, courseEvent.Id))">
-                                                        @L["CancelRegistration"]
-                                                    </MudButton>
+                                                    <MudTooltip Text="@L["CancelRegistration"]">
+                                                        <MudIconButton Size="Size.Small"
+                                                                       Color="Color.Default"
+                                                                       Icon="@Icons.Material.Filled.Logout"
+                                                                       OnClick="@(() => CancelEventRegistrationAsync(course.Id, courseEvent.Id))"
+                                                                       aria-label="@L["CancelRegistration"]" />
+                                                    </MudTooltip>
                                                 }
                                                 else
                                                 {
-                                                    <MudButton Size="Size.Small"
-                                                               Color="Color.Primary"
-                                                               Variant="Variant.Filled"
-                                                               StartIcon="@Icons.Material.Filled.EventAvailable"
-                                                               OnClick="@(() => RegisterForEventAsync(course.Id, courseEvent.Id))">
-                                                        @L["Register"]
-                                                    </MudButton>
+                                                    <MudTooltip Text="@L["Register"]">
+                                                        <MudIconButton Size="Size.Small"
+                                                                       Color="Color.Primary"
+                                                                       Icon="@Icons.Material.Filled.HowToReg"
+                                                                       OnClick="@(() => RegisterForEventAsync(course.Id, courseEvent.Id))"
+                                                                       aria-label="@L["Register"]" />
+                                                    </MudTooltip>
                                                 }
                                             </div>
                                         }
@@ -509,12 +511,17 @@
             ? "2px solid var(--mud-palette-primary)"
             : "1px solid var(--mud-palette-lines-default)";
 
-        return $"flex:0 0 244px; width:244px; min-height:178px; scroll-snap-align:start; cursor:pointer; border-radius:8px; border:{border};";
+        return $"flex:0 0 176px; width:176px; min-height:132px; scroll-snap-align:start; cursor:pointer; border-radius:8px; border:{border};";
     }
 
     private static string GetAddCourseCardStyle()
     {
-        return "flex:0 0 132px; width:132px; min-height:178px; scroll-snap-align:start; cursor:pointer; border-radius:8px; border:1px dashed var(--mud-palette-primary);";
+        return "flex:0 0 104px; width:104px; min-height:132px; scroll-snap-align:start; cursor:pointer; border-radius:8px; border:1px dashed var(--mud-palette-primary);";
+    }
+
+    private static string FormatCourseLevel(string level)
+    {
+        return CourseLevelFormatting.Format(level);
     }
 
     private string FormatPeriod(CourseDocument course)

--- a/PaceLetics.Web/Pages/Athletes/TrainingPlanPage.razor
+++ b/PaceLetics.Web/Pages/Athletes/TrainingPlanPage.razor
@@ -25,7 +25,20 @@
 <MudStack Spacing="2" Class="mb-4">
     @if (_plans == null || !_plans.Any())
     {
-        <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoPlans"]</MudText>
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+            <MudStack Row="true"
+                      AlignItems="AlignItems.Center"
+                      Justify="Justify.SpaceBetween"
+                      Style="width:100%; gap:12px;">
+                <MudText Typo="Typo.body2">@L["NoPlans"]</MudText>
+                <MudTooltip Text="@L["CourseSelectionLink"]">
+                    <MudIconButton Href="/Athletes/courses"
+                                   Icon="@Icons.Material.Filled.School"
+                                   Color="Color.Primary"
+                                   aria-label="@L["CourseSelectionLink"]" />
+                </MudTooltip>
+            </MudStack>
+        </MudAlert>
     }
     else
     {
@@ -44,12 +57,12 @@
 </MudStack>
 
 <!-- Timeline -->
-<div style="height: calc(100vh - 300px); overflow:auto; -webkit-overflow-scrolling:touch; padding:0 12px 12px 12px;">
-    <MudTimeline TimelineOrientation="TimelineOrientation.Vertical"
-                 TimelinePosition="TimelinePosition.Left">
+@if (Plan is not null)
+{
+    <div style="height: calc(100vh - 300px); overflow:auto; -webkit-overflow-scrolling:touch; padding:0 12px 12px 12px;">
+        <MudTimeline TimelineOrientation="TimelineOrientation.Vertical"
+                     TimelinePosition="TimelinePosition.Left">
 
-        @if (Plan is not null)
-        {
             @foreach (var session in Plan.Sessions)
             {
                 var isNext = session.Id == _nextSessionId;
@@ -79,10 +92,9 @@
 
                 </MudTimelineItem>
             }
-        }
-    </MudTimeline>
-</div>
-
+        </MudTimeline>
+    </div>
+}
 @if (_detailsOpen)
 {
     <div style="position:fixed; inset:0; background: rgba(0,0,0,0.35); z-index:1300;"

--- a/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
@@ -42,7 +42,15 @@
                             <MudTextField Label="@L["Name"]" @bind-Value="_courseName" Variant="Variant.Outlined" />
                         </MudItem>
                         <MudItem xs="12" md="6">
-                            <MudTextField Label="@L["Level"]" @bind-Value="_courseLevel" Variant="Variant.Outlined" />
+                            <MudSelect T="CourseLevel"
+                                       Label="@L["Level"]"
+                                       @bind-Value="_courseLevel"
+                                       Variant="Variant.Outlined">
+                                @foreach (var level in CourseLevelFormatting.All)
+                                {
+                                    <MudSelectItem T="CourseLevel" Value="@level">@CourseLevelFormatting.Format(level)</MudSelectItem>
+                                }
+                            </MudSelect>
                         </MudItem>
                         <MudItem xs="12">
                             <MudTextField Label="@L["Description"]"
@@ -409,7 +417,7 @@
 
     private string _courseName = string.Empty;
     private string _courseDescription = string.Empty;
-    private string _courseLevel = string.Empty;
+    private CourseLevel _courseLevel = CourseLevel.Level1;
     private DateTime? _courseStartDate = DateTime.Today;
     private DateTime? _courseEndDate = DateTime.Today.AddMonths(3);
 
@@ -808,7 +816,7 @@
     {
         _courseName = string.Empty;
         _courseDescription = string.Empty;
-        _courseLevel = string.Empty;
+        _courseLevel = CourseLevel.Level1;
         _courseStartDate = DateTime.Today;
         _courseEndDate = DateTime.Today.AddMonths(3);
     }

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -24,6 +24,7 @@ using PaceLetics.Web.ViewModels.Workouts;
 using PaceLetics.Web.Services.DashboardMessages;
 using PaceLetics.CoreModule.Infrastructure.Services;
 using PaceLetics.Web.Services.Courses;
+using PaceLetics.Web.Services.Theming;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -97,6 +98,7 @@ builder.Services.AddTransient<IEmailSender, SmtpEmailSender>();
 builder.Services.AddScoped<ICourseRepository, CosmosCourseRepository>();
 builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddScoped<ITrainingPlanService, TrainingPlanService>();
+builder.Services.AddScoped<ThemePreferenceService>();
 builder.Services.AddSingleton<DashboardMessageFeedOptions>();
 builder.Services.AddScoped<IAthleteMessageProvider, ReferenceRunDashboardMessageProvider>();
 builder.Services.AddScoped<IAthleteMessageProvider, UpcomingTrainingDashboardMessageProvider>();

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.de.resx
@@ -6,7 +6,8 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Title" xml:space="preserve"><value>Dein Trainingsplan</value></data>
   <data name="Subtitle" xml:space="preserve"><value>Der Trainingsplan für das laufende Sportsemester..</value></data>
-  <data name="NoPlans" xml:space="preserve"><value>Keine Trainingspläne gefunden.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>Keine Trainingspläne vorhanden. Tritt einem Kurs bei, um einen Trainingsplan zu erhalten.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>Zur Kursauswahl</value></data>
   <data name="SelectPlan" xml:space="preserve"><value>Trainingsplan wählen</value></data>
   <data name="NoDetails" xml:space="preserve"><value>Keine Details geladen.</value></data>
   <data name="Session" xml:space="preserve"><value>Session</value></data>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.en.resx
@@ -6,7 +6,8 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Title" xml:space="preserve"><value>Your Training Plan</value></data>
   <data name="Subtitle" xml:space="preserve"><value>The training plan for the current sports semester.</value></data>
-  <data name="NoPlans" xml:space="preserve"><value>No training plans found.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>No training plans available. Join a course to receive a training plan.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>Go to course selection</value></data>
   <data name="SelectPlan" xml:space="preserve"><value>Select training plan</value></data>
   <data name="NoDetails" xml:space="preserve"><value>No details loaded.</value></data>
   <data name="Session" xml:space="preserve"><value>Session</value></data>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.de.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.de.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Theme" xml:space="preserve"><value>Theme</value></data>
+  <data name="ColorScheme" xml:space="preserve"><value>Farbschema</value></data>
+  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
+  <data name="Theme_Ocean" xml:space="preserve"><value>Ocean</value></data>
+  <data name="Theme_Forest" xml:space="preserve"><value>Forest</value></data>
+  <data name="Theme_HighContrast" xml:space="preserve"><value>Hoher Kontrast</value></data>
+  <data name="Scheme_Light" xml:space="preserve"><value>Hell</value></data>
+  <data name="Scheme_Dark" xml:space="preserve"><value>Dunkel</value></data>
+  <data name="Scheme_System" xml:space="preserve"><value>System</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.en.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.en.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Theme" xml:space="preserve"><value>Theme</value></data>
+  <data name="ColorScheme" xml:space="preserve"><value>Color scheme</value></data>
+  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
+  <data name="Theme_Ocean" xml:space="preserve"><value>Ocean</value></data>
+  <data name="Theme_Forest" xml:space="preserve"><value>Forest</value></data>
+  <data name="Theme_HighContrast" xml:space="preserve"><value>High contrast</value></data>
+  <data name="Scheme_Light" xml:space="preserve"><value>Light</value></data>
+  <data name="Scheme_Dark" xml:space="preserve"><value>Dark</value></data>
+  <data name="Scheme_System" xml:space="preserve"><value>System</value></data>
+</root>

--- a/PaceLetics.Web/Services/Courses/CourseDocuments.cs
+++ b/PaceLetics.Web/Services/Courses/CourseDocuments.cs
@@ -22,6 +22,54 @@ public static class CourseEventRegistrationStatus
     public const string Cancelled = "cancelled";
 }
 
+public enum CourseLevel
+{
+    Level0 = 0,
+    Level1 = 1,
+    Level2 = 2,
+    Level3 = 3,
+    Level4 = 4,
+    Level5 = 5
+}
+
+public static class CourseLevelFormatting
+{
+    public static IReadOnlyList<CourseLevel> All { get; } = Enum.GetValues<CourseLevel>();
+
+    public static string Format(CourseLevel level)
+    {
+        return $"Level {(int)level}";
+    }
+
+    public static string Format(string? level)
+    {
+        return TryParse(level, out var parsed)
+            ? Format(parsed)
+            : level?.Trim() ?? string.Empty;
+    }
+
+    public static bool TryParse(string? level, out CourseLevel parsed)
+    {
+        parsed = default;
+
+        if (string.IsNullOrWhiteSpace(level))
+            return false;
+
+        var value = level.Trim();
+        if (value.StartsWith("Level", StringComparison.OrdinalIgnoreCase))
+            value = value["Level".Length..].Trim();
+
+        if (!int.TryParse(value, out var numericLevel))
+            return false;
+
+        if (!Enum.IsDefined(typeof(CourseLevel), numericLevel))
+            return false;
+
+        parsed = (CourseLevel)numericLevel;
+        return true;
+    }
+}
+
 public sealed class CourseDocument : IQueryItem
 {
     public string Id { get; set; } = string.Empty;
@@ -45,7 +93,7 @@ public sealed class CourseCreateRequest
 {
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public string Level { get; set; } = string.Empty;
+    public CourseLevel Level { get; set; } = CourseLevel.Level1;
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
     public bool IsPublished { get; set; } = true;

--- a/PaceLetics.Web/Services/Courses/CourseService.cs
+++ b/PaceLetics.Web/Services/Courses/CourseService.cs
@@ -94,7 +94,7 @@ public sealed class CourseService : ICourseService
             Slug = courseId,
             Name = request.Name.Trim(),
             Description = request.Description?.Trim() ?? string.Empty,
-            Level = request.Level?.Trim() ?? string.Empty,
+            Level = CourseLevelFormatting.Format(request.Level),
             StartDate = request.StartDate.Date,
             EndDate = request.EndDate.Date,
             CreatedByTrainerUserId = creatorTrainerUserId,

--- a/PaceLetics.Web/Services/Theming/AppColorScheme.cs
+++ b/PaceLetics.Web/Services/Theming/AppColorScheme.cs
@@ -1,0 +1,8 @@
+namespace PaceLetics.Web.Services.Theming;
+
+public enum AppColorScheme
+{
+    Light,
+    Dark,
+    System
+}

--- a/PaceLetics.Web/Services/Theming/AppThemeCatalog.cs
+++ b/PaceLetics.Web/Services/Theming/AppThemeCatalog.cs
@@ -1,0 +1,191 @@
+using MudBlazor;
+
+namespace PaceLetics.Web.Services.Theming;
+
+public static class AppThemeCatalog
+{
+    public static IReadOnlyList<AppThemeDefinition> Themes { get; } =
+    [
+        new(AppThemeName.PaceLetics, CreatePaceLeticsTheme(), Icons.Material.Filled.DirectionsRun),
+        new(AppThemeName.Ocean, CreateOceanTheme(), Icons.Material.Filled.Waves),
+        new(AppThemeName.Forest, CreateForestTheme(), Icons.Material.Filled.Park),
+        new(AppThemeName.HighContrast, CreateHighContrastTheme(), Icons.Material.Filled.Contrast)
+    ];
+
+    public static MudTheme GetTheme(AppThemeName name)
+    {
+        return Themes.FirstOrDefault(theme => theme.Name == name)?.Theme
+            ?? Themes[0].Theme;
+    }
+
+    private static MudTheme CreatePaceLeticsTheme()
+    {
+        return CreateTheme(
+            light: new PaletteLight
+            {
+                Primary = "#1E7B5F",
+                Secondary = "#F2A541",
+                Tertiary = "#2F80ED",
+                Background = "#F7FAF8",
+                BackgroundGray = "#EEF4F1",
+                Surface = "#FFFFFF",
+                AppbarBackground = "#163D34",
+                AppbarText = "#FFFFFF",
+                DrawerBackground = "#FFFFFF",
+                DrawerText = "#26322F",
+                TextPrimary = "#1F2A27",
+                TextSecondary = "#60746E"
+            },
+            dark: new PaletteDark
+            {
+                Primary = "#55D6A8",
+                Secondary = "#F6BE67",
+                Tertiary = "#7AB7FF",
+                Background = "#101715",
+                BackgroundGray = "#17211E",
+                Surface = "#1B2622",
+                AppbarBackground = "#0B1210",
+                AppbarText = "#EAF8F2",
+                DrawerBackground = "#121B18",
+                DrawerText = "#DDEBE6",
+                TextPrimary = "#EDF8F4",
+                TextSecondary = "#A7BBB4"
+            });
+    }
+
+    private static MudTheme CreateOceanTheme()
+    {
+        return CreateTheme(
+            light: new PaletteLight
+            {
+                Primary = "#006C80",
+                Secondary = "#6C5CE7",
+                Tertiary = "#FFB703",
+                Background = "#F3FBFD",
+                BackgroundGray = "#E6F3F7",
+                Surface = "#FFFFFF",
+                AppbarBackground = "#004E64",
+                AppbarText = "#FFFFFF",
+                DrawerBackground = "#FFFFFF",
+                DrawerText = "#183238",
+                TextPrimary = "#173037",
+                TextSecondary = "#587078"
+            },
+            dark: new PaletteDark
+            {
+                Primary = "#35C2DC",
+                Secondary = "#A49BFF",
+                Tertiary = "#FFD166",
+                Background = "#0C171D",
+                BackgroundGray = "#13232B",
+                Surface = "#182A33",
+                AppbarBackground = "#071116",
+                AppbarText = "#EAF9FC",
+                DrawerBackground = "#101E25",
+                DrawerText = "#D7EDF2",
+                TextPrimary = "#EDF9FB",
+                TextSecondary = "#9DB9C1"
+            });
+    }
+
+    private static MudTheme CreateForestTheme()
+    {
+        return CreateTheme(
+            light: new PaletteLight
+            {
+                Primary = "#2E7D32",
+                Secondary = "#8E5A2A",
+                Tertiary = "#C2410C",
+                Background = "#F8FAF3",
+                BackgroundGray = "#EFF3E6",
+                Surface = "#FFFFFF",
+                AppbarBackground = "#24452B",
+                AppbarText = "#FFFFFF",
+                DrawerBackground = "#FFFFFF",
+                DrawerText = "#283323",
+                TextPrimary = "#263122",
+                TextSecondary = "#68735F"
+            },
+            dark: new PaletteDark
+            {
+                Primary = "#78C86B",
+                Secondary = "#C9975D",
+                Tertiary = "#F08A5D",
+                Background = "#11170E",
+                BackgroundGray = "#1A2216",
+                Surface = "#202A1C",
+                AppbarBackground = "#0C120A",
+                AppbarText = "#EEF8EA",
+                DrawerBackground = "#151D12",
+                DrawerText = "#E0EBD9",
+                TextPrimary = "#F0F8EC",
+                TextSecondary = "#B3C1AA"
+            });
+    }
+
+    private static MudTheme CreateHighContrastTheme()
+    {
+        return CreateTheme(
+            light: new PaletteLight
+            {
+                Primary = "#000000",
+                Secondary = "#005FCC",
+                Tertiary = "#D00000",
+                Background = "#FFFFFF",
+                BackgroundGray = "#F0F0F0",
+                Surface = "#FFFFFF",
+                AppbarBackground = "#000000",
+                AppbarText = "#FFFFFF",
+                DrawerBackground = "#FFFFFF",
+                DrawerText = "#000000",
+                TextPrimary = "#000000",
+                TextSecondary = "#222222",
+                LinesDefault = "#000000",
+                Divider = "#000000"
+            },
+            dark: new PaletteDark
+            {
+                Primary = "#FFFFFF",
+                Secondary = "#00D9FF",
+                Tertiary = "#FFD400",
+                Background = "#000000",
+                BackgroundGray = "#111111",
+                Surface = "#080808",
+                AppbarBackground = "#000000",
+                AppbarText = "#FFFFFF",
+                DrawerBackground = "#000000",
+                DrawerText = "#FFFFFF",
+                TextPrimary = "#FFFFFF",
+                TextSecondary = "#E5E5E5",
+                LinesDefault = "#FFFFFF",
+                Divider = "#FFFFFF"
+            });
+    }
+
+    private static MudTheme CreateTheme(PaletteLight light, PaletteDark dark)
+    {
+        return new MudTheme
+        {
+            PaletteLight = light,
+            PaletteDark = dark,
+            LayoutProperties = new LayoutProperties
+            {
+                DrawerWidthLeft = "260px",
+                DrawerWidthRight = "300px"
+            },
+            Typography = new Typography
+            {
+                H1 = new H1Typography { FontSize = "2.5rem" },
+                H2 = new H2Typography { FontSize = "2rem" },
+                H3 = new H3Typography { FontSize = "1.6rem" },
+                H4 = new H4Typography { FontSize = "1.3rem" },
+                H5 = new H5Typography { FontSize = "1.1rem" },
+                H6 = new H6Typography { FontSize = "1rem" },
+                Subtitle1 = new Subtitle1Typography { FontSize = "0.95rem" },
+                Subtitle2 = new Subtitle2Typography { FontSize = "0.85rem" },
+                Body1 = new Body1Typography { FontSize = "0.9rem" },
+                Body2 = new Body2Typography { FontSize = "0.8rem" }
+            }
+        };
+    }
+}

--- a/PaceLetics.Web/Services/Theming/AppThemeDefinition.cs
+++ b/PaceLetics.Web/Services/Theming/AppThemeDefinition.cs
@@ -1,0 +1,8 @@
+using MudBlazor;
+
+namespace PaceLetics.Web.Services.Theming;
+
+public sealed record AppThemeDefinition(
+    AppThemeName Name,
+    MudTheme Theme,
+    string Icon);

--- a/PaceLetics.Web/Services/Theming/AppThemeName.cs
+++ b/PaceLetics.Web/Services/Theming/AppThemeName.cs
@@ -1,0 +1,9 @@
+namespace PaceLetics.Web.Services.Theming;
+
+public enum AppThemeName
+{
+    PaceLetics,
+    Ocean,
+    Forest,
+    HighContrast
+}

--- a/PaceLetics.Web/Services/Theming/ThemePreferenceService.cs
+++ b/PaceLetics.Web/Services/Theming/ThemePreferenceService.cs
@@ -1,0 +1,114 @@
+using Microsoft.JSInterop;
+using MudBlazor;
+
+namespace PaceLetics.Web.Services.Theming;
+
+public sealed class ThemePreferenceService
+{
+    private const string ThemeKey = "paceletics.theme.name";
+    private const string SchemeKey = "paceletics.theme.scheme";
+    private readonly IJSRuntime _js;
+
+    public ThemePreferenceService(IJSRuntime js)
+    {
+        _js = js;
+    }
+
+    public event Action? Changed;
+
+    public AppThemeName ThemeName { get; private set; } = AppThemeName.PaceLetics;
+    public AppColorScheme ColorScheme { get; private set; } = AppColorScheme.System;
+    public bool SystemPrefersDarkMode { get; private set; }
+    public IReadOnlyList<AppThemeDefinition> Themes => AppThemeCatalog.Themes;
+    public MudTheme CurrentTheme => AppThemeCatalog.GetTheme(ThemeName);
+
+    public bool IsDarkMode => ColorScheme switch
+    {
+        AppColorScheme.Dark => true,
+        AppColorScheme.Light => false,
+        _ => SystemPrefersDarkMode
+    };
+
+    public async Task InitializeAsync(bool systemPrefersDarkMode)
+    {
+        SystemPrefersDarkMode = systemPrefersDarkMode;
+
+        var storedTheme = await GetLocalStorageItemAsync(ThemeKey);
+        if (Enum.TryParse(storedTheme, ignoreCase: true, out AppThemeName themeName))
+            ThemeName = themeName;
+
+        var storedScheme = await GetLocalStorageItemAsync(SchemeKey);
+        if (Enum.TryParse(storedScheme, ignoreCase: true, out AppColorScheme colorScheme))
+            ColorScheme = colorScheme;
+
+        NotifyChanged();
+    }
+
+    public Task SetSystemPrefersDarkModeAsync(bool systemPrefersDarkMode)
+    {
+        if (SystemPrefersDarkMode == systemPrefersDarkMode)
+            return Task.CompletedTask;
+
+        SystemPrefersDarkMode = systemPrefersDarkMode;
+
+        if (ColorScheme == AppColorScheme.System)
+            NotifyChanged();
+
+        return Task.CompletedTask;
+    }
+
+    public async Task SetThemeAsync(AppThemeName themeName)
+    {
+        if (ThemeName == themeName)
+            return;
+
+        ThemeName = themeName;
+        await SetLocalStorageItemAsync(ThemeKey, themeName.ToString());
+        NotifyChanged();
+    }
+
+    public async Task SetColorSchemeAsync(AppColorScheme colorScheme)
+    {
+        if (ColorScheme == colorScheme)
+            return;
+
+        ColorScheme = colorScheme;
+        await SetLocalStorageItemAsync(SchemeKey, colorScheme.ToString());
+        NotifyChanged();
+    }
+
+    private async Task<string?> GetLocalStorageItemAsync(string key)
+    {
+        try
+        {
+            return await _js.InvokeAsync<string?>("localStorage.getItem", key);
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+        catch (JSException)
+        {
+            return null;
+        }
+    }
+
+    private async Task SetLocalStorageItemAsync(string key, string value)
+    {
+        try
+        {
+            await _js.InvokeVoidAsync("localStorage.setItem", key, value);
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (JSException)
+        {
+        }
+    }
+
+    private void NotifyChanged()
+    {
+        Changed?.Invoke();
+    }
+}

--- a/PaceLetics.Web/Shared/MainLayout.razor
+++ b/PaceLetics.Web/Shared/MainLayout.razor
@@ -1,11 +1,16 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
+@implements IDisposable
 @using MudBlazor
+@inject ThemePreferenceService ThemePreferences
+@inject IStringLocalizer<MainLayout> L
 
-<MudThemeProvider Theme="@_theme" IsDarkMode="false" />
+<MudThemeProvider @ref="_themeProvider"
+                  Theme="@ThemePreferences.CurrentTheme"
+                  IsDarkMode="@ThemePreferences.IsDarkMode" />
 
 <MudDialogProvider />
 <MudSnackbarProvider />
-<MudPopoverProvider />   
+<MudPopoverProvider />
 
 <PageTitle>PaceLetics</PageTitle>
 
@@ -18,6 +23,47 @@
                        OnClick="@((e) => DrawerToggle())" />
         <MudText Align="Align.Start">PaceLetics - Team Running</MudText>
         <MudSpacer />
+        <MudMenu Icon="@GetThemeMenuIcon()"
+                 Color="Color.Inherit"
+                 AnchorOrigin="Origin.BottomRight"
+                 TransformOrigin="Origin.TopRight">
+            <MudMenuItem Disabled="true">
+                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["Theme"]</MudText>
+            </MudMenuItem>
+            @foreach (var theme in ThemePreferences.Themes)
+            {
+                <MudMenuItem OnClick="@(() => ThemePreferences.SetThemeAsync(theme.Name))">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="min-width:180px;">
+                        <MudIcon Icon="@theme.Icon" Size="Size.Small" />
+                        <MudText>@GetThemeName(theme.Name)</MudText>
+                        <MudSpacer />
+                        @if (ThemePreferences.ThemeName == theme.Name)
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" />
+                        }
+                    </MudStack>
+                </MudMenuItem>
+            }
+
+            <MudDivider />
+            <MudMenuItem Disabled="true">
+                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["ColorScheme"]</MudText>
+            </MudMenuItem>
+            @foreach (var scheme in Enum.GetValues<AppColorScheme>())
+            {
+                <MudMenuItem OnClick="@(() => ThemePreferences.SetColorSchemeAsync(scheme))">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="min-width:180px;">
+                        <MudIcon Icon="@GetColorSchemeIcon(scheme)" Size="Size.Small" />
+                        <MudText>@GetColorSchemeName(scheme)</MudText>
+                        <MudSpacer />
+                        @if (ThemePreferences.ColorScheme == scheme)
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" />
+                        }
+                    </MudStack>
+                </MudMenuItem>
+            }
+        </MudMenu>
         <CultureSelector />
         <LoginDisplay />
 
@@ -35,38 +81,79 @@
 </MudLayout>
 
 @code {
-    bool _drawerOpen = false;
+    private bool _drawerOpen;
+    private MudThemeProvider? _themeProvider;
 
-    void DrawerToggle()
+    protected override void OnInitialized()
+    {
+        ThemePreferences.Changed += OnThemePreferenceChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || _themeProvider is null)
+            return;
+
+        var systemPrefersDarkMode = await _themeProvider.GetSystemDarkModeAsync();
+        await ThemePreferences.InitializeAsync(systemPrefersDarkMode);
+        await _themeProvider.WatchSystemDarkModeAsync(ThemePreferences.SetSystemPrefersDarkModeAsync);
+    }
+
+    private void DrawerToggle()
     {
         _drawerOpen = !_drawerOpen;
     }
 
-    MudTheme MyCustomTheme = new()
+    private string GetThemeMenuIcon()
     {
-        LayoutProperties = new LayoutProperties()
+        return ThemePreferences.ColorScheme switch
         {
-            DrawerWidthLeft = "260px",
-            DrawerWidthRight = "300px"
-        }
-    };
-
-    private MudTheme _theme = new()
-    {
-        Typography = new Typography()
-        {
-            H1 = new H1Typography() { FontSize = "2.5rem" },
-            H2 = new H2Typography() { FontSize = "2rem" },
-            H3 = new H3Typography() { FontSize = "1.6rem" },
-            H4 = new H4Typography() { FontSize = "1.3rem" },
-            H5 = new H5Typography() { FontSize = "1.1rem" },
-            H6 = new H6Typography() { FontSize = "1rem" },
-
-            Subtitle1 = new Subtitle1Typography() { FontSize = "0.95rem" },
-            Subtitle2 = new Subtitle2Typography() { FontSize = "0.85rem" },
-            Body1 = new Body1Typography() { FontSize = "0.9rem" },
-            Body2 = new Body2Typography() { FontSize = "0.8rem" }
-        }
-    };
-
+            AppColorScheme.Light => Icons.Material.Filled.LightMode,
+            AppColorScheme.Dark => Icons.Material.Filled.DarkMode,
+            _ => Icons.Material.Filled.Palette
+        };
     }
+
+    private string GetColorSchemeIcon(AppColorScheme scheme)
+    {
+        return scheme switch
+        {
+            AppColorScheme.Light => Icons.Material.Filled.LightMode,
+            AppColorScheme.Dark => Icons.Material.Filled.DarkMode,
+            _ => Icons.Material.Filled.SettingsSuggest
+        };
+    }
+
+    private string GetThemeName(AppThemeName themeName)
+    {
+        return themeName switch
+        {
+            AppThemeName.PaceLetics => L["Theme_PaceLetics"],
+            AppThemeName.Ocean => L["Theme_Ocean"],
+            AppThemeName.Forest => L["Theme_Forest"],
+            AppThemeName.HighContrast => L["Theme_HighContrast"],
+            _ => themeName.ToString()
+        };
+    }
+
+    private string GetColorSchemeName(AppColorScheme scheme)
+    {
+        return scheme switch
+        {
+            AppColorScheme.Light => L["Scheme_Light"],
+            AppColorScheme.Dark => L["Scheme_Dark"],
+            AppColorScheme.System => L["Scheme_System"],
+            _ => scheme.ToString()
+        };
+    }
+
+    private void OnThemePreferenceChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        ThemePreferences.Changed -= OnThemePreferenceChanged;
+    }
+}

--- a/PaceLetics.Web/_Imports.razor
+++ b/PaceLetics.Web/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.JSInterop
 @using PaceLetics.Web
 @using PaceLetics.Web.Data
+@using PaceLetics.Web.Services.Theming
 @using PaceLetics.Web.Shared
 @using PaceLetics.Web.ViewModels.Workouts
 @using MudBlazor


### PR DESCRIPTION
# PR Report: Theme Management and Course UI Improvements

## Summary
- Added full app theme management with selectable theme presets and Light/Dark/System color schemes.
- Added centralized theme persistence via `localStorage` and system dark-mode observation.
- Improved athlete course UI with smaller joined-course cards and icon-only registration/deregistration actions.
- Reworked course levels to use a `CourseLevel` enum for creation while keeping stored course documents backward-compatible.
- Improved the training-plan empty state with a localized message box and icon link to course selection.

## Verification
- `dotnet build PaceLetics.Web\PaceLetics.Web.csproj --no-restore -p:OutputPath=..\artifacts\verify-build\PaceLetics.Web\` succeeded.
- `dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore --filter CourseServiceTests -p:OutputPath=..\artifacts\verify-test\bin\ -p:BaseIntermediateOutputPath=..\artifacts\verify-test\obj\` succeeded.

## Notes
- Standard build/test output paths can be locked while the local `PaceLetics.Web` dev server is running, so verification used isolated output folders.
- Existing package vulnerability warnings for `OpenMcdf` and `SharpCompress` remain unrelated.
- Browser smoke testing reached the local app, but unauthenticated requests redirect to Identity login because the local Identity database was unavailable.