### PR TITLE
Add running analysis module

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="MudBlazor.Extensions" Version="9.4.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Google.Apis.Drive.v3" Version="1.74.0.4135" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/PaceLetics.RunningAnalysisModule.CodeBase/PaceLetics.RunningAnalysisModule.CodeBase.csproj
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/PaceLetics.RunningAnalysisModule.CodeBase.csproj
@@ -1,0 +1,3 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+</Project>

--- a/PaceLetics.RunningAnalysisModule.CodeBase/README.md
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/README.md
@@ -1,0 +1,41 @@
+# Running Analysis Module
+
+This module owns the running-analysis workflow independently from the course module.
+The course/event system should integrate through a thin adapter that calls
+`IRunningAnalysisService.RegisterParticipantAsync` after a participant registers
+for an event of type `RunningAnalysis`.
+
+## Implemented Core Rules
+
+- A running-analysis event is created or updated from an external event id.
+- Participant provisioning starts during registration.
+- Existing participant folders can be reused through `IUserDriveFolderRegistry`.
+- New participant folders are created in one central Drive area through
+  `IRunningAnalysisStorageProvider`.
+- Participant folders are shared with participant write access.
+- Provisioning failures do not cancel the registration. The participant is stored
+  with failed folder/permission status and can be retried by a later adapter.
+- Recordings require an online connection.
+- A recording only becomes primary after a successful upload.
+- Failed uploads are stored, but they do not replace the current primary recording.
+
+## Integration Ports
+
+- `IRunningAnalysisRepository`
+  Persists analysis events, participants, and recordings.
+- `IRunningAnalysisStorageProvider`
+  Creates Drive folders, grants permissions, and uploads recordings.
+- `IUserDriveFolderRegistry`
+  Finds reusable folders from this or other modules and records newly created
+  participant folders.
+- `IRunningAnalysisClock`
+  Keeps time-dependent behavior testable.
+
+## Next Adapters
+
+- Course event adapter: call registration when an athlete registers for a running
+  analysis event.
+- Google Drive adapter: implement central root-folder creation, event folders,
+  participant folders, write permission grants, and video uploads.
+- Component module: trainer roster, browser camera capture, upload handoff, and
+  participant "My analyses" folder-link view.

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisEventStatus.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisEventStatus.cs
@@ -1,0 +1,9 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+public enum RunningAnalysisEventStatus
+{
+    Draft,
+    Prepared,
+    InProgress,
+    Completed
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisFolderStatus.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisFolderStatus.cs
@@ -1,0 +1,9 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+public enum RunningAnalysisFolderStatus
+{
+    Missing,
+    Creating,
+    Ready,
+    Failed
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisPermissionStatus.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisPermissionStatus.cs
@@ -1,0 +1,9 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+public enum RunningAnalysisPermissionStatus
+{
+    Missing,
+    Granting,
+    Granted,
+    Failed
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisUploadStatus.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Enums/RunningAnalysisUploadStatus.cs
@@ -1,0 +1,9 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+public enum RunningAnalysisUploadStatus
+{
+    Captured,
+    Uploading,
+    Uploaded,
+    Failed
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisClock.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisClock.cs
@@ -1,0 +1,6 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IRunningAnalysisClock
+{
+    DateTime UtcNow { get; }
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisRepository.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisRepository.cs
@@ -1,0 +1,26 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IRunningAnalysisRepository
+{
+    Task<RunningAnalysisEvent?> GetEventAsync(string analysisEventId, CancellationToken cancellationToken = default);
+
+    Task<RunningAnalysisEvent?> GetEventByExternalEventIdAsync(string externalEventId, CancellationToken cancellationToken = default);
+
+    Task UpsertEventAsync(RunningAnalysisEvent analysisEvent, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<RunningAnalysisParticipant>> GetParticipantsAsync(string analysisEventId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<RunningAnalysisParticipant>> GetParticipantsForAthleteAsync(string athleteUserId, CancellationToken cancellationToken = default);
+
+    Task<RunningAnalysisParticipant?> GetParticipantAsync(string analysisEventId, string athleteUserId, CancellationToken cancellationToken = default);
+
+    Task<RunningAnalysisParticipant?> GetParticipantByIdAsync(string participantId, CancellationToken cancellationToken = default);
+
+    Task UpsertParticipantAsync(RunningAnalysisParticipant participant, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<RunningAnalysisRecording>> GetRecordingsForParticipantAsync(string participantId, CancellationToken cancellationToken = default);
+
+    Task UpsertRecordingAsync(RunningAnalysisRecording recording, CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisService.cs
@@ -1,0 +1,35 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IRunningAnalysisService
+{
+    Task<RunningAnalysisParticipant> RegisterParticipantAsync(
+        RunningAnalysisRegistration registration,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<RunningAnalysisRosterItem>> GetRosterAsync(
+        string analysisEventId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<RunningAnalysisLink>> GetAnalysesForAthleteAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default);
+
+    Task<RunningAnalysisEvent> StartAnalysisAsync(
+        string analysisEventId,
+        CancellationToken cancellationToken = default);
+
+    Task<RunningAnalysisEvent> CompleteAnalysisAsync(
+        string analysisEventId,
+        CancellationToken cancellationToken = default);
+
+    Task<RunningAnalysisRecording> UploadRecordingAsync(
+        string analysisEventId,
+        string participantId,
+        string fileName,
+        string contentType,
+        Stream content,
+        bool isOnline,
+        CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisStorageProvider.cs
@@ -1,0 +1,26 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IRunningAnalysisStorageProvider
+{
+    Task<DriveFolderReference> EnsureEventFolderAsync(
+        RunningAnalysisEvent analysisEvent,
+        CancellationToken cancellationToken = default);
+
+    Task<DriveFolderReference> EnsureParticipantFolderAsync(
+        RunningAnalysisEvent analysisEvent,
+        RunningAnalysisParticipant participant,
+        DriveFolderReference eventFolder,
+        CancellationToken cancellationToken = default);
+
+    Task GrantParticipantWriteAccessAsync(
+        DriveFolderReference participantFolder,
+        string participantEmail,
+        CancellationToken cancellationToken = default);
+
+    Task<DriveFileReference> UploadRecordingAsync(
+        UploadRecordingRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderRegistry.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderRegistry.cs
@@ -1,0 +1,14 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IUserDriveFolderRegistry
+{
+    Task<DriveFolderReference?> FindReusableFolderAsync(
+        ReusableDriveFolderRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task SaveFolderReferenceAsync(
+        SaveDriveFolderReferenceRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisEvent.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisEvent.cs
@@ -1,0 +1,19 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+public sealed class RunningAnalysisEvent
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string DocumentType { get; set; } = string.Empty;
+    public string ExternalEventId { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public DateTime StartsAt { get; set; }
+    public DateTime EndsAt { get; set; }
+    public RunningAnalysisEventStatus Status { get; set; } = RunningAnalysisEventStatus.Draft;
+    public string? DriveFolderId { get; set; }
+    public string? DriveFolderUrl { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisLink.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisLink.cs
@@ -1,0 +1,13 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+public sealed record RunningAnalysisLink(
+    string AnalysisEventId,
+    string ExternalEventId,
+    string Title,
+    DateTime StartsAt,
+    RunningAnalysisEventStatus EventStatus,
+    RunningAnalysisFolderStatus FolderStatus,
+    RunningAnalysisPermissionStatus PermissionStatus,
+    string? DriveFolderUrl);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisParticipant.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisParticipant.cs
@@ -1,0 +1,22 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+public sealed class RunningAnalysisParticipant
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string DocumentType { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string AnalysisEventId { get; set; } = string.Empty;
+    public string AthleteUserId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+    public RunningAnalysisFolderStatus FolderStatus { get; set; } = RunningAnalysisFolderStatus.Missing;
+    public RunningAnalysisPermissionStatus PermissionStatus { get; set; } = RunningAnalysisPermissionStatus.Missing;
+    public string? DriveFolderId { get; set; }
+    public string? DriveFolderUrl { get; set; }
+    public string? CreatedFromRegistrationId { get; set; }
+    public DateTime RegisteredAt { get; set; } = DateTime.UtcNow;
+    public string? ProvisioningError { get; set; }
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisRecording.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisRecording.cs
@@ -1,0 +1,21 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+public sealed class RunningAnalysisRecording
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string DocumentType { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string AnalysisEventId { get; set; } = string.Empty;
+    public string ParticipantId { get; set; } = string.Empty;
+    public int AttemptNumber { get; set; }
+    public DateTime RecordedAt { get; set; } = DateTime.UtcNow;
+    public bool IsPrimary { get; set; }
+    public RunningAnalysisUploadStatus UploadStatus { get; set; } = RunningAnalysisUploadStatus.Captured;
+    public string FileName { get; set; } = string.Empty;
+    public string ContentType { get; set; } = "video/webm";
+    public string? DriveFileId { get; set; }
+    public string? DriveFileUrl { get; set; }
+    public string? ErrorMessage { get; set; }
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisRegistration.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisRegistration.cs
@@ -1,0 +1,13 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+public sealed record RunningAnalysisRegistration(
+    string ExternalEventId,
+    string CourseId,
+    string EventTitle,
+    DateTime StartsAt,
+    DateTime EndsAt,
+    string AthleteUserId,
+    string DisplayName,
+    string Email,
+    string? RegistrationId = null,
+    DateTime? RegisteredAt = null);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisRosterItem.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisRosterItem.cs
@@ -1,0 +1,13 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+public sealed record RunningAnalysisRosterItem(
+    string ParticipantId,
+    string AthleteUserId,
+    string DisplayName,
+    int SortOrder,
+    RunningAnalysisFolderStatus FolderStatus,
+    RunningAnalysisPermissionStatus PermissionStatus,
+    int RecordingCount,
+    string? PrimaryRecordingUrl);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/RunningAnalysisService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/RunningAnalysisService.cs
@@ -1,0 +1,350 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Services;
+
+public sealed class RunningAnalysisService : IRunningAnalysisService
+{
+    private readonly IRunningAnalysisRepository _repository;
+    private readonly IRunningAnalysisStorageProvider _storageProvider;
+    private readonly IUserDriveFolderRegistry _folderRegistry;
+    private readonly IRunningAnalysisClock _clock;
+
+    public RunningAnalysisService(
+        IRunningAnalysisRepository repository,
+        IRunningAnalysisStorageProvider storageProvider,
+        IUserDriveFolderRegistry folderRegistry,
+        IRunningAnalysisClock clock)
+    {
+        _repository = repository;
+        _storageProvider = storageProvider;
+        _folderRegistry = folderRegistry;
+        _clock = clock;
+    }
+
+    public async Task<RunningAnalysisParticipant> RegisterParticipantAsync(
+        RunningAnalysisRegistration registration,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRegistration(registration);
+
+        var analysisEvent = await GetOrCreateEventAsync(registration, cancellationToken);
+        var participant = await _repository.GetParticipantAsync(
+            analysisEvent.Id,
+            registration.AthleteUserId,
+            cancellationToken);
+
+        if (participant is null)
+        {
+            var participants = await _repository.GetParticipantsAsync(analysisEvent.Id, cancellationToken);
+            participant = new RunningAnalysisParticipant
+            {
+                CourseId = analysisEvent.CourseId,
+                AnalysisEventId = analysisEvent.Id,
+                AthleteUserId = registration.AthleteUserId.Trim(),
+                SortOrder = participants.Count + 1,
+                RegisteredAt = registration.RegisteredAt ?? _clock.UtcNow
+            };
+        }
+
+        participant.CourseId = analysisEvent.CourseId;
+        participant.DisplayName = Normalize(registration.DisplayName, registration.AthleteUserId);
+        participant.Email = registration.Email.Trim();
+        participant.CreatedFromRegistrationId = registration.RegistrationId;
+        await ProvisionParticipantFolderAsync(analysisEvent, participant, cancellationToken);
+        await _repository.UpsertParticipantAsync(participant, cancellationToken);
+
+        return participant;
+    }
+
+    public async Task<IReadOnlyList<RunningAnalysisRosterItem>> GetRosterAsync(
+        string analysisEventId,
+        CancellationToken cancellationToken = default)
+    {
+        var participants = await _repository.GetParticipantsAsync(analysisEventId, cancellationToken);
+        var result = new List<RunningAnalysisRosterItem>();
+
+        foreach (var participant in participants.OrderBy(participant => participant.SortOrder).ThenBy(participant => participant.DisplayName))
+        {
+            var recordings = await _repository.GetRecordingsForParticipantAsync(participant.Id, cancellationToken);
+            var primaryRecordingUrl = recordings.FirstOrDefault(recording => recording.IsPrimary)?.DriveFileUrl;
+            result.Add(new RunningAnalysisRosterItem(
+                participant.Id,
+                participant.AthleteUserId,
+                participant.DisplayName,
+                participant.SortOrder,
+                participant.FolderStatus,
+                participant.PermissionStatus,
+                recordings.Count,
+                primaryRecordingUrl));
+        }
+
+        return result;
+    }
+
+    public async Task<IReadOnlyList<RunningAnalysisLink>> GetAnalysesForAthleteAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return Array.Empty<RunningAnalysisLink>();
+
+        var participants = await _repository.GetParticipantsForAthleteAsync(athleteUserId, cancellationToken);
+        var result = new List<RunningAnalysisLink>();
+
+        foreach (var participant in participants)
+        {
+            var analysisEvent = await _repository.GetEventAsync(participant.AnalysisEventId, cancellationToken);
+            if (analysisEvent is null)
+                continue;
+
+            result.Add(new RunningAnalysisLink(
+                analysisEvent.Id,
+                analysisEvent.ExternalEventId,
+                analysisEvent.Title,
+                analysisEvent.StartsAt,
+                analysisEvent.Status,
+                participant.FolderStatus,
+                participant.PermissionStatus,
+                participant.DriveFolderUrl));
+        }
+
+        return result
+            .OrderByDescending(analysis => analysis.StartsAt)
+            .ThenBy(analysis => analysis.Title)
+            .ToList();
+    }
+
+    public async Task<RunningAnalysisEvent> StartAnalysisAsync(
+        string analysisEventId,
+        CancellationToken cancellationToken = default)
+    {
+        var analysisEvent = await RequireEventAsync(analysisEventId, cancellationToken);
+        if (analysisEvent.Status == RunningAnalysisEventStatus.Completed)
+            throw new InvalidOperationException("A completed running analysis cannot be restarted.");
+
+        analysisEvent.Status = RunningAnalysisEventStatus.InProgress;
+        analysisEvent.UpdatedAt = _clock.UtcNow;
+        await _repository.UpsertEventAsync(analysisEvent, cancellationToken);
+        return analysisEvent;
+    }
+
+    public async Task<RunningAnalysisEvent> CompleteAnalysisAsync(
+        string analysisEventId,
+        CancellationToken cancellationToken = default)
+    {
+        var analysisEvent = await RequireEventAsync(analysisEventId, cancellationToken);
+        analysisEvent.Status = RunningAnalysisEventStatus.Completed;
+        analysisEvent.UpdatedAt = _clock.UtcNow;
+        await _repository.UpsertEventAsync(analysisEvent, cancellationToken);
+        return analysisEvent;
+    }
+
+    public async Task<RunningAnalysisRecording> UploadRecordingAsync(
+        string analysisEventId,
+        string participantId,
+        string fileName,
+        string contentType,
+        Stream content,
+        bool isOnline,
+        CancellationToken cancellationToken = default)
+    {
+        if (!isOnline)
+            throw new InvalidOperationException("Running analysis recordings can only be uploaded while online.");
+
+        if (content is null)
+            throw new ArgumentNullException(nameof(content));
+
+        if (string.IsNullOrWhiteSpace(fileName))
+            throw new InvalidOperationException("A recording file name is required.");
+
+        var analysisEvent = await RequireEventAsync(analysisEventId, cancellationToken);
+        var participant = await _repository.GetParticipantByIdAsync(participantId, cancellationToken)
+            ?? throw new InvalidOperationException("The running analysis participant was not found.");
+
+        if (participant.AnalysisEventId != analysisEvent.Id)
+            throw new InvalidOperationException("The participant does not belong to this running analysis.");
+
+        if (participant.FolderStatus != RunningAnalysisFolderStatus.Ready || string.IsNullOrWhiteSpace(participant.DriveFolderId))
+            throw new InvalidOperationException("The participant folder is not ready for uploads.");
+
+        var recordings = await _repository.GetRecordingsForParticipantAsync(participant.Id, cancellationToken);
+        var recording = new RunningAnalysisRecording
+        {
+            CourseId = analysisEvent.CourseId,
+            AnalysisEventId = analysisEvent.Id,
+            ParticipantId = participant.Id,
+            AttemptNumber = recordings.Count + 1,
+            RecordedAt = _clock.UtcNow,
+            FileName = fileName.Trim(),
+            ContentType = string.IsNullOrWhiteSpace(contentType) ? "video/webm" : contentType.Trim(),
+            UploadStatus = RunningAnalysisUploadStatus.Uploading
+        };
+
+        await _repository.UpsertRecordingAsync(recording, cancellationToken);
+
+        try
+        {
+            var driveFile = await _storageProvider.UploadRecordingAsync(
+                new UploadRecordingRequest(analysisEvent, participant, recording, content),
+                cancellationToken);
+
+            recording.DriveFileId = driveFile.FileId;
+            recording.DriveFileUrl = driveFile.Url;
+            recording.UploadStatus = RunningAnalysisUploadStatus.Uploaded;
+            recording.ErrorMessage = null;
+            await SetPrimaryRecordingAsync(participant.Id, recording, cancellationToken);
+            return recording;
+        }
+        catch (Exception ex)
+        {
+            recording.UploadStatus = RunningAnalysisUploadStatus.Failed;
+            recording.ErrorMessage = ex.Message;
+            recording.IsPrimary = false;
+            await _repository.UpsertRecordingAsync(recording, cancellationToken);
+            return recording;
+        }
+    }
+
+    private async Task<RunningAnalysisEvent> GetOrCreateEventAsync(
+        RunningAnalysisRegistration registration,
+        CancellationToken cancellationToken)
+    {
+        var analysisEvent = await _repository.GetEventByExternalEventIdAsync(
+            registration.ExternalEventId,
+            cancellationToken);
+
+        if (analysisEvent is null)
+        {
+            analysisEvent = new RunningAnalysisEvent
+            {
+                ExternalEventId = registration.ExternalEventId.Trim(),
+                CourseId = registration.CourseId.Trim(),
+                CreatedAt = _clock.UtcNow
+            };
+        }
+
+        analysisEvent.Title = registration.EventTitle.Trim();
+        analysisEvent.StartsAt = registration.StartsAt;
+        analysisEvent.EndsAt = registration.EndsAt;
+        analysisEvent.UpdatedAt = _clock.UtcNow;
+        await _repository.UpsertEventAsync(analysisEvent, cancellationToken);
+        return analysisEvent;
+    }
+
+    private async Task ProvisionParticipantFolderAsync(
+        RunningAnalysisEvent analysisEvent,
+        RunningAnalysisParticipant participant,
+        CancellationToken cancellationToken)
+    {
+        participant.FolderStatus = RunningAnalysisFolderStatus.Creating;
+        participant.PermissionStatus = RunningAnalysisPermissionStatus.Missing;
+        participant.ProvisioningError = null;
+
+        try
+        {
+            var reusableFolder = await _folderRegistry.FindReusableFolderAsync(
+                new ReusableDriveFolderRequest(
+                    analysisEvent.CourseId,
+                    analysisEvent.ExternalEventId,
+                    participant.AthleteUserId,
+                    participant.Email),
+                cancellationToken);
+
+            var participantFolder = reusableFolder;
+            if (participantFolder is null)
+            {
+                var eventFolder = await _storageProvider.EnsureEventFolderAsync(analysisEvent, cancellationToken);
+                analysisEvent.DriveFolderId = eventFolder.FolderId;
+                analysisEvent.DriveFolderUrl = eventFolder.Url;
+                await _repository.UpsertEventAsync(analysisEvent, cancellationToken);
+
+                participantFolder = await _storageProvider.EnsureParticipantFolderAsync(
+                    analysisEvent,
+                    participant,
+                    eventFolder,
+                    cancellationToken);
+
+                await _folderRegistry.SaveFolderReferenceAsync(
+                    new SaveDriveFolderReferenceRequest(
+                        analysisEvent.CourseId,
+                        analysisEvent.ExternalEventId,
+                        participant.AthleteUserId,
+                        participant.Email,
+                        participantFolder.FolderId,
+                        participantFolder.Url),
+                    cancellationToken);
+            }
+
+            participant.DriveFolderId = participantFolder.FolderId;
+            participant.DriveFolderUrl = participantFolder.Url;
+            participant.FolderStatus = RunningAnalysisFolderStatus.Ready;
+            participant.PermissionStatus = RunningAnalysisPermissionStatus.Granting;
+
+            if (string.IsNullOrWhiteSpace(participant.Email))
+                throw new InvalidOperationException("A participant email is required to grant write access.");
+
+            await _storageProvider.GrantParticipantWriteAccessAsync(participantFolder, participant.Email, cancellationToken);
+            participant.PermissionStatus = RunningAnalysisPermissionStatus.Granted;
+        }
+        catch (Exception ex)
+        {
+            if (participant.FolderStatus != RunningAnalysisFolderStatus.Ready)
+                participant.FolderStatus = RunningAnalysisFolderStatus.Failed;
+
+            participant.PermissionStatus = RunningAnalysisPermissionStatus.Failed;
+            participant.ProvisioningError = ex.Message;
+        }
+    }
+
+    private async Task SetPrimaryRecordingAsync(
+        string participantId,
+        RunningAnalysisRecording primaryRecording,
+        CancellationToken cancellationToken)
+    {
+        var recordings = await _repository.GetRecordingsForParticipantAsync(participantId, cancellationToken);
+        foreach (var recording in recordings)
+        {
+            recording.IsPrimary = recording.Id == primaryRecording.Id;
+            await _repository.UpsertRecordingAsync(recording, cancellationToken);
+        }
+    }
+
+    private async Task<RunningAnalysisEvent> RequireEventAsync(
+        string analysisEventId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(analysisEventId))
+            throw new InvalidOperationException("A running analysis event id is required.");
+
+        return await _repository.GetEventAsync(analysisEventId, cancellationToken)
+            ?? throw new InvalidOperationException("The running analysis event was not found.");
+    }
+
+    private static void ValidateRegistration(RunningAnalysisRegistration registration)
+    {
+        if (string.IsNullOrWhiteSpace(registration.ExternalEventId))
+            throw new InvalidOperationException("A source event id is required.");
+
+        if (string.IsNullOrWhiteSpace(registration.CourseId))
+            throw new InvalidOperationException("A course id is required.");
+
+        if (string.IsNullOrWhiteSpace(registration.EventTitle))
+            throw new InvalidOperationException("A running analysis title is required.");
+
+        if (registration.EndsAt <= registration.StartsAt)
+            throw new InvalidOperationException("The running analysis end must be after the start.");
+
+        if (string.IsNullOrWhiteSpace(registration.AthleteUserId))
+            throw new InvalidOperationException("An athlete user id is required.");
+    }
+
+    private static string Normalize(string value, string fallback)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? fallback.Trim()
+            : value.Trim();
+    }
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/SystemRunningAnalysisClock.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/SystemRunningAnalysisClock.cs
@@ -1,0 +1,8 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Services;
+
+public sealed class SystemRunningAnalysisClock : IRunningAnalysisClock
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/DriveFileReference.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/DriveFileReference.cs
@@ -1,0 +1,3 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+public sealed record DriveFileReference(string FileId, string Url);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/DriveFolderReference.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/DriveFolderReference.cs
@@ -1,0 +1,3 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+public sealed record DriveFolderReference(string FolderId, string Url);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/ReusableDriveFolderRequest.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/ReusableDriveFolderRequest.cs
@@ -1,0 +1,7 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+public sealed record ReusableDriveFolderRequest(
+    string CourseId,
+    string ExternalEventId,
+    string AthleteUserId,
+    string Email);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/SaveDriveFolderReferenceRequest.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/SaveDriveFolderReferenceRequest.cs
@@ -1,0 +1,9 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+public sealed record SaveDriveFolderReferenceRequest(
+    string CourseId,
+    string ExternalEventId,
+    string AthleteUserId,
+    string Email,
+    string FolderId,
+    string FolderUrl);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/UploadRecordingRequest.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/UploadRecordingRequest.cs
@@ -1,0 +1,9 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+public sealed record UploadRecordingRequest(
+    RunningAnalysisEvent AnalysisEvent,
+    RunningAnalysisParticipant Participant,
+    RunningAnalysisRecording Recording,
+    Stream Content);

--- a/PaceLetics.RunningAnalysisModule.Components/PaceLetics.RunningAnalysisModule.Components.csproj
+++ b/PaceLetics.RunningAnalysisModule.Components/PaceLetics.RunningAnalysisModule.Components.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="MudBlazor" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PaceLetics.RunningAnalysisModule.CodeBase\PaceLetics.RunningAnalysisModule.CodeBase.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisCapturePanel.razor
+++ b/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisCapturePanel.razor
@@ -1,0 +1,148 @@
+@namespace PaceLetics.RunningAnalysisModule.Components
+
+<MudStack Spacing="3">
+    <MudPaper Elevation="0" Class="pa-4" Style="border:1px solid var(--mud-palette-lines-default);">
+        <MudStack Spacing="2">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                <MudText Typo="Typo.h6">@ParticipantName</MudText>
+                <MudChip T="string"
+                         Size="Size.Small"
+                         Color="@(IsOnline ? Color.Success : Color.Error)"
+                         Variant="Variant.Outlined">
+                    @(IsOnline ? "Online" : "Offline")
+                </MudChip>
+            </MudStack>
+
+            <div class="running-analysis-camera-frame">
+                @if (ChildContent is not null)
+                {
+                    @ChildContent
+                }
+                else
+                {
+                    <RunningAnalysisMediaRecorder @ref="_mediaRecorder"
+                                                  IsOnline="IsOnline"
+                                                  ShowControls="false"
+                                                  OnRecorded="OnRecorded"
+                                                  IsRecordingChanged="OnRecorderStateChangedAsync" />
+                }
+            </div>
+        </MudStack>
+    </MudPaper>
+
+    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Style="gap:8px; flex-wrap:wrap;">
+        <MudButton Variant="Variant.Text"
+                   StartIcon="@Icons.Material.Filled.ArrowBack"
+                   OnClick="OnBackToRoster">
+            List
+        </MudButton>
+
+        <MudStack Row="true" Style="gap:8px; flex-wrap:wrap;">
+            @if (!IsRecordingActive)
+            {
+                <MudButton Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           Disabled="@(!IsOnline)"
+                           StartIcon="@Icons.Material.Filled.FiberManualRecord"
+                           OnClick="StartRecordingAsync">
+                    Start
+                </MudButton>
+            }
+            else
+            {
+                <MudButton Color="Color.Error"
+                           Variant="Variant.Filled"
+                           StartIcon="@Icons.Material.Filled.Stop"
+                           OnClick="StopRecordingAsync">
+                    Stop
+                </MudButton>
+            }
+
+            <MudButton Variant="Variant.Outlined"
+                       StartIcon="@Icons.Material.Filled.Replay"
+                       OnClick="OnRetake">
+                Again
+            </MudButton>
+
+            <MudButton Color="Color.Primary"
+                       Variant="Variant.Outlined"
+                       EndIcon="@Icons.Material.Filled.ArrowForward"
+                       OnClick="OnNextParticipant">
+                Next
+            </MudButton>
+        </MudStack>
+    </MudStack>
+</MudStack>
+
+<style>
+    .running-analysis-camera-frame {
+        aspect-ratio: 16 / 9;
+        width: 100%;
+        min-height: 220px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--mud-palette-background-grey);
+        color: var(--mud-palette-text-secondary);
+        border-radius: 8px;
+        overflow: hidden;
+    }
+</style>
+
+@code {
+    private RunningAnalysisMediaRecorder? _mediaRecorder;
+    private bool _recorderIsRecording;
+
+    [Parameter] public string ParticipantName { get; set; } = string.Empty;
+    [Parameter] public bool IsOnline { get; set; } = true;
+    [Parameter] public bool IsRecording { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public EventCallback OnStartRecording { get; set; }
+    [Parameter] public EventCallback OnStopRecording { get; set; }
+    [Parameter] public EventCallback<RunningAnalysisRecordedVideo> OnRecorded { get; set; }
+    [Parameter] public EventCallback<bool> IsRecordingChanged { get; set; }
+    [Parameter] public EventCallback OnRetake { get; set; }
+    [Parameter] public EventCallback OnNextParticipant { get; set; }
+    [Parameter] public EventCallback OnBackToRoster { get; set; }
+
+    private bool IsRecordingActive => IsRecording || _recorderIsRecording;
+
+    private async Task StartRecordingAsync()
+    {
+        if (!IsOnline)
+            return;
+
+        await OnStartRecording.InvokeAsync();
+
+        if (_mediaRecorder is not null)
+        {
+            await _mediaRecorder.StartAsync();
+            return;
+        }
+
+        await OnRecorderStateChangedAsync(true);
+    }
+
+    private async Task StopRecordingAsync()
+    {
+        if (!IsRecordingActive)
+            return;
+
+        if (_mediaRecorder is not null)
+        {
+            await _mediaRecorder.StopAsync();
+        }
+        else
+        {
+            await OnRecorderStateChangedAsync(false);
+        }
+
+        await OnStopRecording.InvokeAsync();
+    }
+
+    private async Task OnRecorderStateChangedAsync(bool isRecording)
+    {
+        _recorderIsRecording = isRecording;
+        await IsRecordingChanged.InvokeAsync(isRecording);
+    }
+}

--- a/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisLinks.razor
+++ b/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisLinks.razor
@@ -1,0 +1,44 @@
+@namespace PaceLetics.RunningAnalysisModule.Components
+
+<MudStack Spacing="2">
+    @if (Items.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">No analyses available.</MudAlert>
+    }
+    else
+    {
+        @foreach (var item in Items.OrderByDescending(item => item.StartsAt))
+        {
+            <MudPaper Elevation="0" Class="pa-3" Style="border:1px solid var(--mud-palette-lines-default);">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+                    <MudStack Spacing="0" Style="min-width:0;">
+                        <MudText Typo="Typo.body1">@item.Title</MudText>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@item.StartsAt.ToString("g")</MudText>
+                    </MudStack>
+
+                    @if (!string.IsNullOrWhiteSpace(item.DriveFolderUrl)
+                         && item.FolderStatus == RunningAnalysisFolderStatus.Ready)
+                    {
+                        <MudButton Href="@item.DriveFolderUrl"
+                                   Target="_blank"
+                                   Color="Color.Primary"
+                                   Variant="Variant.Outlined"
+                                   StartIcon="@Icons.Material.Filled.FolderOpen">
+                            Open
+                        </MudButton>
+                    }
+                    else
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">
+                            @item.FolderStatus
+                        </MudChip>
+                    }
+                </MudStack>
+            </MudPaper>
+        }
+    }
+</MudStack>
+
+@code {
+    [Parameter] public IReadOnlyList<RunningAnalysisLink> Items { get; set; } = Array.Empty<RunningAnalysisLink>();
+}

--- a/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisMediaRecorder.razor
+++ b/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisMediaRecorder.razor
@@ -1,0 +1,145 @@
+@namespace PaceLetics.RunningAnalysisModule.Components
+@implements IAsyncDisposable
+@inject IJSRuntime JS
+
+<MudStack Spacing="2">
+    <div class="running-analysis-media-recorder">
+        <video @ref="_videoElement" autoplay muted playsinline></video>
+    </div>
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_errorMessage</MudAlert>
+    }
+
+    @if (ShowControls)
+    {
+        <MudStack Row="true" Justify="Justify.Center" Style="gap:8px; flex-wrap:wrap;">
+            @if (!_isRecording)
+            {
+                <MudButton Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           Disabled="@(!IsOnline)"
+                           StartIcon="@Icons.Material.Filled.FiberManualRecord"
+                           OnClick="StartAsync">
+                    Start
+                </MudButton>
+            }
+            else
+            {
+                <MudButton Color="Color.Error"
+                           Variant="Variant.Filled"
+                           StartIcon="@Icons.Material.Filled.Stop"
+                           OnClick="StopAsync">
+                    Stop
+                </MudButton>
+            }
+        </MudStack>
+    }
+</MudStack>
+
+<style>
+    .running-analysis-media-recorder {
+        aspect-ratio: 16 / 9;
+        width: 100%;
+        background: #111;
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    .running-analysis-media-recorder video {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+    }
+</style>
+
+@code {
+    private ElementReference _videoElement;
+    private IJSObjectReference? _module;
+    private bool _isRecording;
+    private string? _errorMessage;
+
+    [Parameter] public bool IsOnline { get; set; } = true;
+    [Parameter] public bool ShowControls { get; set; } = true;
+    [Parameter] public EventCallback<RunningAnalysisRecordedVideo> OnRecorded { get; set; }
+    [Parameter] public EventCallback<bool> IsRecordingChanged { get; set; }
+
+    public async Task StartAsync()
+    {
+        if (!IsOnline)
+            return;
+
+        try
+        {
+            _errorMessage = null;
+            var module = await GetModuleAsync();
+            await module.InvokeVoidAsync("startRecording", _videoElement);
+            _isRecording = true;
+            await IsRecordingChanged.InvokeAsync(true);
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = ex.Message;
+            _isRecording = false;
+            await IsRecordingChanged.InvokeAsync(false);
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        if (!_isRecording)
+            return;
+
+        try
+        {
+            var module = await GetModuleAsync();
+            var payload = await module.InvokeAsync<RecordedVideoPayload>("stopRecording", _videoElement);
+            _isRecording = false;
+            await IsRecordingChanged.InvokeAsync(false);
+            await OnRecorded.InvokeAsync(new RunningAnalysisRecordedVideo(
+                payload.Data,
+                payload.ContentType,
+                payload.FileExtension));
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = ex.Message;
+            _isRecording = false;
+            await IsRecordingChanged.InvokeAsync(false);
+        }
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync()
+    {
+        _module ??= await JS.InvokeAsync<IJSObjectReference>(
+            "import",
+            "./_content/PaceLetics.RunningAnalysisModule.Components/runningAnalysisMediaRecorder.js");
+
+        return _module;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is null)
+            return;
+
+        try
+        {
+            await _module.InvokeVoidAsync("disposeRecorder", _videoElement);
+            await _module.DisposeAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup during component disposal.
+        }
+    }
+
+    private sealed class RecordedVideoPayload
+    {
+        public byte[] Data { get; set; } = Array.Empty<byte>();
+        public string ContentType { get; set; } = "video/webm";
+        public string FileExtension { get; set; } = "webm";
+    }
+}

--- a/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisRecordedVideo.cs
+++ b/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisRecordedVideo.cs
@@ -1,0 +1,6 @@
+namespace PaceLetics.RunningAnalysisModule.Components;
+
+public sealed record RunningAnalysisRecordedVideo(
+    byte[] Data,
+    string ContentType,
+    string FileExtension);

--- a/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisRoster.razor
+++ b/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisRoster.razor
@@ -1,0 +1,78 @@
+@namespace PaceLetics.RunningAnalysisModule.Components
+
+<MudStack Spacing="2">
+    @if (Items.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">No participants registered.</MudAlert>
+    }
+    else
+    {
+        @foreach (var item in Items.OrderBy(item => item.SortOrder).ThenBy(item => item.DisplayName))
+        {
+            var selected = item.ParticipantId == SelectedParticipantId;
+            <div role="button" tabindex="0" style="cursor:pointer;" @onclick="@(() => SelectAsync(item.ParticipantId))">
+                <MudPaper Elevation="0"
+                          Class="pa-3"
+                          Style="@GetRowStyle(selected)">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                        <MudStack Spacing="0" Style="min-width:0;">
+                            <MudText Typo="Typo.body1">@item.DisplayName</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">@GetStatusText(item)</MudText>
+                        </MudStack>
+
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:6px;">
+                            @if (item.RecordingCount > 0)
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">
+                                    @item.RecordingCount
+                                </MudChip>
+                            }
+
+                            <MudIconButton Icon="@Icons.Material.Filled.Videocam"
+                                           Color="@(selected ? Color.Primary : Color.Default)"
+                                           OnClick="@(() => RecordAsync(item.ParticipantId))" />
+                        </MudStack>
+                    </MudStack>
+                </MudPaper>
+            </div>
+        }
+    }
+</MudStack>
+
+@code {
+    [Parameter] public IReadOnlyList<RunningAnalysisRosterItem> Items { get; set; } = Array.Empty<RunningAnalysisRosterItem>();
+    [Parameter] public string? SelectedParticipantId { get; set; }
+    [Parameter] public EventCallback<string> SelectedParticipantIdChanged { get; set; }
+    [Parameter] public EventCallback<string> OnRecord { get; set; }
+
+    private async Task SelectAsync(string participantId)
+    {
+        SelectedParticipantId = participantId;
+        await SelectedParticipantIdChanged.InvokeAsync(participantId);
+    }
+
+    private async Task RecordAsync(string participantId)
+    {
+        await SelectAsync(participantId);
+        await OnRecord.InvokeAsync(participantId);
+    }
+
+    private static string GetStatusText(RunningAnalysisRosterItem item)
+    {
+        if (item.FolderStatus != RunningAnalysisFolderStatus.Ready)
+            return $"Folder: {item.FolderStatus}";
+
+        if (item.PermissionStatus != RunningAnalysisPermissionStatus.Granted)
+            return $"Permission: {item.PermissionStatus}";
+
+        return item.RecordingCount == 0
+            ? "Ready"
+            : "Recorded";
+    }
+
+    private static string GetRowStyle(bool selected)
+    {
+        var borderColor = selected ? "var(--mud-palette-primary)" : "var(--mud-palette-lines-default)";
+        return $"border:1px solid {borderColor};";
+    }
+}

--- a/PaceLetics.RunningAnalysisModule.Components/_Imports.razor
+++ b/PaceLetics.RunningAnalysisModule.Components/_Imports.razor
@@ -1,0 +1,5 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.JSInterop
+@using MudBlazor
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models

--- a/PaceLetics.RunningAnalysisModule.Components/wwwroot/runningAnalysisMediaRecorder.js
+++ b/PaceLetics.RunningAnalysisModule.Components/wwwroot/runningAnalysisMediaRecorder.js
@@ -1,0 +1,111 @@
+const recorders = new WeakMap();
+
+export async function startRecording(videoElement) {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    throw new Error("Camera access is not supported by this browser.");
+  }
+
+  if (!window.MediaRecorder) {
+    throw new Error("Video recording is not supported by this browser.");
+  }
+
+  disposeRecorder(videoElement);
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    video: { facingMode: "environment" },
+    audio: false
+  });
+
+  const contentType = getSupportedContentType();
+  const chunks = [];
+  const recorder = new MediaRecorder(
+    stream,
+    contentType ? { mimeType: contentType } : undefined
+  );
+
+  recorder.addEventListener("dataavailable", event => {
+    if (event.data && event.data.size > 0) {
+      chunks.push(event.data);
+    }
+  });
+
+  videoElement.srcObject = stream;
+  await videoElement.play();
+  recorder.start();
+
+  recorders.set(videoElement, {
+    recorder,
+    stream,
+    chunks,
+    contentType: contentType || recorder.mimeType || "video/webm"
+  });
+}
+
+export async function stopRecording(videoElement) {
+  const state = recorders.get(videoElement);
+  if (!state) {
+    throw new Error("No active recording was found.");
+  }
+
+  const blob = await new Promise((resolve, reject) => {
+    state.recorder.addEventListener("stop", () => {
+      resolve(new Blob(state.chunks, { type: state.contentType }));
+    }, { once: true });
+
+    state.recorder.addEventListener("error", event => {
+      reject(event.error || new Error("Recording failed."));
+    }, { once: true });
+
+    state.recorder.stop();
+  });
+
+  stopStream(videoElement, state.stream);
+  recorders.delete(videoElement);
+
+  const contentType = blob.type || state.contentType || "video/webm";
+  const buffer = await blob.arrayBuffer();
+
+  return {
+    data: new Uint8Array(buffer),
+    contentType,
+    fileExtension: contentType.includes("mp4") ? "mp4" : "webm"
+  };
+}
+
+export function disposeRecorder(videoElement) {
+  const state = recorders.get(videoElement);
+  if (!state) {
+    return;
+  }
+
+  if (state.recorder && state.recorder.state !== "inactive") {
+    state.recorder.stop();
+  }
+
+  stopStream(videoElement, state.stream);
+  recorders.delete(videoElement);
+}
+
+function stopStream(videoElement, stream) {
+  if (stream) {
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+  }
+
+  if (videoElement) {
+    videoElement.pause();
+    videoElement.srcObject = null;
+  }
+}
+
+function getSupportedContentType() {
+  const candidates = [
+    "video/webm;codecs=vp9",
+    "video/webm;codecs=vp8",
+    "video/webm",
+    "video/mp4"
+  ];
+
+  return candidates.find(candidate => MediaRecorder.isTypeSupported(candidate)) || "";
+}

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisOptions.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisOptions.cs
@@ -1,0 +1,12 @@
+namespace PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
+
+public sealed class GoogleDriveRunningAnalysisOptions
+{
+    public const string SectionName = "RunningAnalysis:GoogleDrive";
+
+    public string ApplicationName { get; set; } = "PaceLetics";
+    public string RootFolderId { get; set; } = string.Empty;
+    public string RootFolderName { get; set; } = "PaceLetics Laufanalysen";
+    public string ServiceAccountJsonPath { get; set; } = string.Empty;
+    public string ServiceAccountJson { get; set; } = string.Empty;
+}

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
@@ -1,0 +1,237 @@
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Drive.v3;
+using Google.Apis.Drive.v3.Data;
+using Google.Apis.Services;
+using Google.Apis.Upload;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+using System.Text;
+
+namespace PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
+
+public sealed class GoogleDriveRunningAnalysisStorageProvider : IRunningAnalysisStorageProvider
+{
+    private const string FolderMimeType = "application/vnd.google-apps.folder";
+    private readonly GoogleDriveRunningAnalysisOptions _options;
+
+    public GoogleDriveRunningAnalysisStorageProvider(GoogleDriveRunningAnalysisOptions options)
+    {
+        _options = options;
+    }
+
+    public async Task<DriveFolderReference> EnsureEventFolderAsync(
+        RunningAnalysisEvent analysisEvent,
+        CancellationToken cancellationToken = default)
+    {
+        var drive = CreateDriveService();
+        var rootFolder = await EnsureRootFolderAsync(drive, cancellationToken);
+        var folderName = BuildEventFolderName(analysisEvent);
+
+        return await EnsureFolderAsync(drive, folderName, rootFolder.FolderId, cancellationToken);
+    }
+
+    public Task<DriveFolderReference> EnsureParticipantFolderAsync(
+        RunningAnalysisEvent analysisEvent,
+        RunningAnalysisParticipant participant,
+        DriveFolderReference eventFolder,
+        CancellationToken cancellationToken = default)
+    {
+        var drive = CreateDriveService();
+        var folderName = BuildParticipantFolderName(participant);
+
+        return EnsureFolderAsync(drive, folderName, eventFolder.FolderId, cancellationToken);
+    }
+
+    public async Task GrantParticipantWriteAccessAsync(
+        DriveFolderReference participantFolder,
+        string participantEmail,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(participantEmail))
+            throw new InvalidOperationException("A participant email is required to grant Drive access.");
+
+        var drive = CreateDriveService();
+        var permission = new Permission
+        {
+            Type = "user",
+            Role = "writer",
+            EmailAddress = participantEmail.Trim()
+        };
+
+        var request = drive.Permissions.Create(permission, participantFolder.FolderId);
+        request.SendNotificationEmail = false;
+        request.SupportsAllDrives = true;
+        await request.ExecuteAsync(cancellationToken);
+    }
+
+    public async Task<DriveFileReference> UploadRecordingAsync(
+        UploadRecordingRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Participant.DriveFolderId))
+            throw new InvalidOperationException("The participant Drive folder is required for uploads.");
+
+        var drive = CreateDriveService();
+        var metadata = new Google.Apis.Drive.v3.Data.File
+        {
+            Name = request.Recording.FileName,
+            Parents = new List<string> { request.Participant.DriveFolderId }
+        };
+
+        var upload = drive.Files.Create(
+            metadata,
+            request.Content,
+            string.IsNullOrWhiteSpace(request.Recording.ContentType)
+                ? "video/webm"
+                : request.Recording.ContentType);
+
+        upload.Fields = "id,webViewLink";
+        upload.SupportsAllDrives = true;
+
+        var result = await upload.UploadAsync(cancellationToken);
+        if (result.Status != UploadStatus.Completed || upload.ResponseBody is null)
+            throw result.Exception ?? new InvalidOperationException("Google Drive upload failed.");
+
+        return new DriveFileReference(upload.ResponseBody.Id, upload.ResponseBody.WebViewLink);
+    }
+
+    private DriveService CreateDriveService()
+    {
+        GoogleCredential credential;
+
+        if (!string.IsNullOrWhiteSpace(_options.ServiceAccountJson))
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(_options.ServiceAccountJson));
+            credential = ServiceAccountCredential.FromServiceAccountData(stream).ToGoogleCredential();
+        }
+        else if (!string.IsNullOrWhiteSpace(_options.ServiceAccountJsonPath))
+        {
+            using var stream = System.IO.File.OpenRead(_options.ServiceAccountJsonPath);
+            credential = ServiceAccountCredential.FromServiceAccountData(stream).ToGoogleCredential();
+        }
+        else
+        {
+            throw new InvalidOperationException("Google Drive service account credentials are not configured.");
+        }
+
+        if (credential.IsCreateScopedRequired)
+            credential = credential.CreateScoped(DriveService.Scope.Drive);
+
+        return new DriveService(new BaseClientService.Initializer
+        {
+            HttpClientInitializer = credential,
+            ApplicationName = string.IsNullOrWhiteSpace(_options.ApplicationName)
+                ? "PaceLetics"
+                : _options.ApplicationName
+        });
+    }
+
+    private async Task<DriveFolderReference> EnsureRootFolderAsync(
+        DriveService drive,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(_options.RootFolderId))
+        {
+            var get = drive.Files.Get(_options.RootFolderId);
+            get.Fields = "id,webViewLink";
+            get.SupportsAllDrives = true;
+            var existing = await get.ExecuteAsync(cancellationToken);
+            return new DriveFolderReference(existing.Id, existing.WebViewLink);
+        }
+
+        return await EnsureFolderAsync(
+            drive,
+            string.IsNullOrWhiteSpace(_options.RootFolderName)
+                ? "PaceLetics Laufanalysen"
+                : _options.RootFolderName,
+            parentFolderId: null,
+            cancellationToken);
+    }
+
+    private static async Task<DriveFolderReference> EnsureFolderAsync(
+        DriveService drive,
+        string folderName,
+        string? parentFolderId,
+        CancellationToken cancellationToken)
+    {
+        var existing = await FindFolderAsync(drive, folderName, parentFolderId, cancellationToken);
+        if (existing is not null)
+            return existing;
+
+        var metadata = new Google.Apis.Drive.v3.Data.File
+        {
+            Name = folderName,
+            MimeType = FolderMimeType
+        };
+
+        if (!string.IsNullOrWhiteSpace(parentFolderId))
+            metadata.Parents = new List<string> { parentFolderId };
+
+        var create = drive.Files.Create(metadata);
+        create.Fields = "id,webViewLink";
+        create.SupportsAllDrives = true;
+        var created = await create.ExecuteAsync(cancellationToken);
+
+        return new DriveFolderReference(created.Id, created.WebViewLink);
+    }
+
+    private static async Task<DriveFolderReference?> FindFolderAsync(
+        DriveService drive,
+        string folderName,
+        string? parentFolderId,
+        CancellationToken cancellationToken)
+    {
+        var escapedName = EscapeQueryValue(folderName);
+        var parentClause = string.IsNullOrWhiteSpace(parentFolderId)
+            ? string.Empty
+            : $" and '{EscapeQueryValue(parentFolderId)}' in parents";
+
+        var list = drive.Files.List();
+        list.Q = $"mimeType = '{FolderMimeType}' and trashed = false and name = '{escapedName}'{parentClause}";
+        list.Fields = "files(id,name,webViewLink)";
+        list.Spaces = "drive";
+        list.SupportsAllDrives = true;
+        list.IncludeItemsFromAllDrives = true;
+
+        var result = await list.ExecuteAsync(cancellationToken);
+        var folder = result.Files?.FirstOrDefault();
+
+        return folder is null
+            ? null
+            : new DriveFolderReference(folder.Id, folder.WebViewLink);
+    }
+
+    private static string BuildEventFolderName(RunningAnalysisEvent analysisEvent)
+    {
+        return $"{analysisEvent.StartsAt:yyyy-MM-dd} {SanitizeName(analysisEvent.Title)}";
+    }
+
+    private static string BuildParticipantFolderName(RunningAnalysisParticipant participant)
+    {
+        var suffix = participant.AthleteUserId.Length <= 6
+            ? participant.AthleteUserId
+            : participant.AthleteUserId[^6..];
+
+        return $"{SanitizeName(participant.DisplayName)} - {suffix}";
+    }
+
+    private static string SanitizeName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars().ToHashSet();
+        var sanitized = new string(value
+            .Trim()
+            .Select(character => invalid.Contains(character) ? '-' : character)
+            .ToArray());
+
+        return string.IsNullOrWhiteSpace(sanitized)
+            ? "Laufanalyse"
+            : sanitized;
+    }
+
+    private static string EscapeQueryValue(string value)
+    {
+        return value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("'", "\\'", StringComparison.Ordinal);
+    }
+}

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive.csproj
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Google.Apis.Drive.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PaceLetics.RunningAnalysisModule.CodeBase\PaceLetics.RunningAnalysisModule.CodeBase.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PaceLetics.Tests/CourseServiceTests.cs
+++ b/PaceLetics.Tests/CourseServiceTests.cs
@@ -515,6 +515,47 @@ public sealed class CourseServiceTests
             service.RegisterForEventAsync("course-1", "event-1", "athlete-1"));
     }
 
+    [Fact]
+    public async Task RegisterForEvent_NotifiesRunningAnalysisAdapterForRunningAnalysisEvent()
+    {
+        var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
+        var adapter = new FakeRunningAnalysisRegistrationAdapter();
+        var service = new CourseService(repository, runningAnalysisRegistrationAdapter: adapter);
+        await service.JoinCourseAsync("course-1", "athlete-1");
+        var courseEvent = await service.CreateEventAsync(
+            "course-1",
+            "Laufanalyse",
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(1).AddHours(1),
+            "trainer-1",
+            eventType: CourseEventTypes.RunningAnalysis);
+
+        await service.RegisterForEventAsync("course-1", courseEvent.Id, "athlete-1");
+
+        var notification = Assert.Single(adapter.Notifications);
+        Assert.Equal(courseEvent.Id, notification.CourseEvent.Id);
+        Assert.Equal("athlete-1", notification.Registration.AthleteUserId);
+    }
+
+    [Fact]
+    public async Task RegisterForEvent_DoesNotNotifyRunningAnalysisAdapterForGeneralEvent()
+    {
+        var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
+        var adapter = new FakeRunningAnalysisRegistrationAdapter();
+        var service = new CourseService(repository, runningAnalysisRegistrationAdapter: adapter);
+        await service.JoinCourseAsync("course-1", "athlete-1");
+        var courseEvent = await service.CreateEventAsync(
+            "course-1",
+            "Workshop",
+            DateTime.UtcNow.AddDays(1),
+            DateTime.UtcNow.AddDays(1).AddHours(1),
+            "trainer-1");
+
+        await service.RegisterForEventAsync("course-1", courseEvent.Id, "athlete-1");
+
+        Assert.Empty(adapter.Notifications);
+    }
+
     private static CourseDocument CreateCourse(string courseId, string planId)
     {
         return new CourseDocument
@@ -526,6 +567,15 @@ public sealed class CourseServiceTests
             IsPublished = true,
             StartDate = DateTime.UtcNow.AddDays(-1),
             EndDate = DateTime.UtcNow.AddDays(30),
+            CreatedByTrainerUserId = "trainer-1",
+            Trainers = new List<CourseTrainerDocument>
+            {
+                new()
+                {
+                    TrainerUserId = "trainer-1",
+                    DisplayName = "Coach"
+                }
+            },
             TrainingPlanPublications = new List<CourseTrainingPlanPublicationDocument>
             {
                 new()
@@ -654,4 +704,24 @@ public sealed class CourseServiceTests
             return Task.CompletedTask;
         }
     }
+
+    private sealed class FakeRunningAnalysisRegistrationAdapter : ICourseRunningAnalysisRegistrationAdapter
+    {
+        public List<Notification> Notifications { get; } = new();
+
+        public Task OnRegisteredAsync(
+            CourseDocument course,
+            CourseEventDocument courseEvent,
+            CourseEventRegistrationDocument registration,
+            CancellationToken cancellationToken = default)
+        {
+            Notifications.Add(new Notification(course, courseEvent, registration));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record Notification(
+        CourseDocument Course,
+        CourseEventDocument CourseEvent,
+        CourseEventRegistrationDocument Registration);
 }

--- a/PaceLetics.Tests/PaceLetics.Tests.csproj
+++ b/PaceLetics.Tests/PaceLetics.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PaceLetics.CoreModule.Infrastructure\PaceLetics.CoreModule.Infrastructure.csproj" />
     <ProjectReference Include="..\PaceLetics.Web\PaceLetics.Web.csproj" />
+    <ProjectReference Include="..\PaceLetics.RunningAnalysisModule.CodeBase\PaceLetics.RunningAnalysisModule.CodeBase.csproj" />
     <ProjectReference Include="..\PaceLetics.TrainingPlanModule.CodeBase\PaceLetics.TrainingPlanModule.CodeBase.csproj" />
     <ProjectReference Include="..\PaceLetics.TrainingModule.CodeBase\PaceLetics.TrainingModule.CodeBase.csproj" />
     <ProjectReference Include="..\PaceLetics.TrainingModule.Components\PaceLetics.TrainingModule.Components.csproj" />

--- a/PaceLetics.Tests/RunningAnalysisServiceTests.cs
+++ b/PaceLetics.Tests/RunningAnalysisServiceTests.cs
@@ -1,0 +1,371 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Services;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.Tests;
+
+public sealed class RunningAnalysisServiceTests
+{
+    [Fact]
+    public async Task RegisterParticipant_CreatesFolderAndGrantsWriteAccess()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var storage = new FakeRunningAnalysisStorageProvider();
+        var registry = new FakeUserDriveFolderRegistry();
+        var service = CreateService(repository, storage, registry);
+
+        var participant = await service.RegisterParticipantAsync(CreateRegistration());
+
+        Assert.Equal(RunningAnalysisFolderStatus.Ready, participant.FolderStatus);
+        Assert.Equal(RunningAnalysisPermissionStatus.Granted, participant.PermissionStatus);
+        Assert.Equal("runner@example.com", Assert.Single(storage.GrantedEmails));
+        Assert.NotNull(participant.DriveFolderId);
+        Assert.NotNull(participant.DriveFolderUrl);
+        Assert.Single(registry.SavedReferences);
+    }
+
+    [Fact]
+    public async Task RegisterParticipant_ReusesExistingFolderFromRegistry()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var storage = new FakeRunningAnalysisStorageProvider();
+        var registry = new FakeUserDriveFolderRegistry
+        {
+            ReusableFolder = new DriveFolderReference("existing-folder", "https://drive.test/existing-folder")
+        };
+        var service = CreateService(repository, storage, registry);
+
+        var participant = await service.RegisterParticipantAsync(CreateRegistration());
+
+        Assert.Equal("existing-folder", participant.DriveFolderId);
+        Assert.Equal(0, storage.CreatedParticipantFolderCount);
+        Assert.Empty(registry.SavedReferences);
+        Assert.Equal(RunningAnalysisPermissionStatus.Granted, participant.PermissionStatus);
+    }
+
+    [Fact]
+    public async Task RegisterParticipant_KeepsRegistrationWhenProvisioningFails()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var storage = new FakeRunningAnalysisStorageProvider { FailFolderCreation = true };
+        var service = CreateService(repository, storage, new FakeUserDriveFolderRegistry());
+
+        var participant = await service.RegisterParticipantAsync(CreateRegistration());
+
+        Assert.Equal(RunningAnalysisFolderStatus.Failed, participant.FolderStatus);
+        Assert.Equal(RunningAnalysisPermissionStatus.Failed, participant.PermissionStatus);
+        Assert.Contains("folder failed", participant.ProvisioningError);
+
+        var analysisEvent = Assert.Single(repository.Events.Values);
+        var storedParticipant = await repository.GetParticipantAsync(analysisEvent.Id, "runner-1");
+        Assert.NotNull(storedParticipant);
+    }
+
+    [Fact]
+    public async Task UploadRecording_MarksOnlySuccessfulLatestUploadAsPrimary()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var storage = new FakeRunningAnalysisStorageProvider();
+        var service = CreateService(repository, storage, new FakeUserDriveFolderRegistry());
+        var participant = await service.RegisterParticipantAsync(CreateRegistration());
+        var analysisEvent = Assert.Single(repository.Events.Values);
+
+        var first = await service.UploadRecordingAsync(
+            analysisEvent.Id,
+            participant.Id,
+            "first.webm",
+            "video/webm",
+            new MemoryStream([1, 2, 3]),
+            isOnline: true);
+        var second = await service.UploadRecordingAsync(
+            analysisEvent.Id,
+            participant.Id,
+            "second.webm",
+            "video/webm",
+            new MemoryStream([4, 5, 6]),
+            isOnline: true);
+
+        var recordings = await repository.GetRecordingsForParticipantAsync(participant.Id);
+        Assert.False(recordings.Single(recording => recording.Id == first.Id).IsPrimary);
+        Assert.True(recordings.Single(recording => recording.Id == second.Id).IsPrimary);
+        Assert.Equal(RunningAnalysisUploadStatus.Uploaded, second.UploadStatus);
+    }
+
+    [Fact]
+    public async Task UploadRecording_DoesNotPromoteFailedUploadToPrimary()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var storage = new FakeRunningAnalysisStorageProvider();
+        var service = CreateService(repository, storage, new FakeUserDriveFolderRegistry());
+        var participant = await service.RegisterParticipantAsync(CreateRegistration());
+        var analysisEvent = Assert.Single(repository.Events.Values);
+
+        var first = await service.UploadRecordingAsync(
+            analysisEvent.Id,
+            participant.Id,
+            "first.webm",
+            "video/webm",
+            new MemoryStream([1]),
+            isOnline: true);
+        storage.FailUpload = true;
+
+        var failed = await service.UploadRecordingAsync(
+            analysisEvent.Id,
+            participant.Id,
+            "failed.webm",
+            "video/webm",
+            new MemoryStream([2]),
+            isOnline: true);
+
+        var recordings = await repository.GetRecordingsForParticipantAsync(participant.Id);
+        Assert.True(recordings.Single(recording => recording.Id == first.Id).IsPrimary);
+        Assert.False(recordings.Single(recording => recording.Id == failed.Id).IsPrimary);
+        Assert.Equal(RunningAnalysisUploadStatus.Failed, failed.UploadStatus);
+    }
+
+    [Fact]
+    public async Task UploadRecording_RequiresOnlineConnection()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var storage = new FakeRunningAnalysisStorageProvider();
+        var service = CreateService(repository, storage, new FakeUserDriveFolderRegistry());
+        var participant = await service.RegisterParticipantAsync(CreateRegistration());
+        var analysisEvent = Assert.Single(repository.Events.Values);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.UploadRecordingAsync(
+            analysisEvent.Id,
+            participant.Id,
+            "offline.webm",
+            "video/webm",
+            new MemoryStream([1]),
+            isOnline: false));
+    }
+
+    [Fact]
+    public async Task StartAndCompleteAnalysis_UpdatesEventStatus()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var service = CreateService(repository, new FakeRunningAnalysisStorageProvider(), new FakeUserDriveFolderRegistry());
+        await service.RegisterParticipantAsync(CreateRegistration());
+        var analysisEvent = Assert.Single(repository.Events.Values);
+
+        await service.StartAnalysisAsync(analysisEvent.Id);
+        Assert.Equal(RunningAnalysisEventStatus.InProgress, analysisEvent.Status);
+
+        var completed = await service.CompleteAnalysisAsync(analysisEvent.Id);
+
+        Assert.Equal(RunningAnalysisEventStatus.Completed, completed.Status);
+    }
+
+    [Fact]
+    public async Task GetAnalysesForAthlete_ReturnsFolderLinksForParticipant()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var service = CreateService(
+            repository,
+            new FakeRunningAnalysisStorageProvider(),
+            new FakeUserDriveFolderRegistry());
+
+        var participant = await service.RegisterParticipantAsync(CreateRegistration());
+
+        var analyses = await service.GetAnalysesForAthleteAsync("runner-1");
+
+        var analysis = Assert.Single(analyses);
+        Assert.Equal(participant.DriveFolderUrl, analysis.DriveFolderUrl);
+        Assert.Equal(RunningAnalysisFolderStatus.Ready, analysis.FolderStatus);
+        Assert.Equal(RunningAnalysisPermissionStatus.Granted, analysis.PermissionStatus);
+    }
+
+    private static RunningAnalysisService CreateService(
+        InMemoryRunningAnalysisRepository repository,
+        FakeRunningAnalysisStorageProvider storage,
+        FakeUserDriveFolderRegistry registry)
+    {
+        return new RunningAnalysisService(
+            repository,
+            storage,
+            registry,
+            new FixedRunningAnalysisClock(new DateTime(2026, 6, 5, 10, 0, 0, DateTimeKind.Utc)));
+    }
+
+    private static RunningAnalysisRegistration CreateRegistration()
+    {
+        return new RunningAnalysisRegistration(
+            ExternalEventId: "course-event-1",
+            CourseId: "course-1",
+            EventTitle: "Running analysis",
+            StartsAt: new DateTime(2026, 6, 5, 18, 0, 0, DateTimeKind.Utc),
+            EndsAt: new DateTime(2026, 6, 5, 20, 0, 0, DateTimeKind.Utc),
+            AthleteUserId: "runner-1",
+            DisplayName: "Runner One",
+            Email: "runner@example.com",
+            RegistrationId: "registration-1");
+    }
+
+    private sealed record FixedRunningAnalysisClock(DateTime UtcNow) : IRunningAnalysisClock;
+
+    private sealed class FakeUserDriveFolderRegistry : IUserDriveFolderRegistry
+    {
+        public DriveFolderReference? ReusableFolder { get; set; }
+        public List<SaveDriveFolderReferenceRequest> SavedReferences { get; } = new();
+
+        public Task<DriveFolderReference?> FindReusableFolderAsync(
+            ReusableDriveFolderRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ReusableFolder);
+        }
+
+        public Task SaveFolderReferenceAsync(
+            SaveDriveFolderReferenceRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            SavedReferences.Add(request);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeRunningAnalysisStorageProvider : IRunningAnalysisStorageProvider
+    {
+        public bool FailFolderCreation { get; set; }
+        public bool FailUpload { get; set; }
+        public int CreatedParticipantFolderCount { get; private set; }
+        public List<string> GrantedEmails { get; } = new();
+
+        public Task<DriveFolderReference> EnsureEventFolderAsync(
+            RunningAnalysisEvent analysisEvent,
+            CancellationToken cancellationToken = default)
+        {
+            if (FailFolderCreation)
+                throw new InvalidOperationException("folder failed");
+
+            return Task.FromResult(new DriveFolderReference("event-folder", "https://drive.test/event-folder"));
+        }
+
+        public Task<DriveFolderReference> EnsureParticipantFolderAsync(
+            RunningAnalysisEvent analysisEvent,
+            RunningAnalysisParticipant participant,
+            DriveFolderReference eventFolder,
+            CancellationToken cancellationToken = default)
+        {
+            CreatedParticipantFolderCount++;
+            return Task.FromResult(new DriveFolderReference(
+                $"participant-folder-{CreatedParticipantFolderCount}",
+                $"https://drive.test/participant-folder-{CreatedParticipantFolderCount}"));
+        }
+
+        public Task GrantParticipantWriteAccessAsync(
+            DriveFolderReference participantFolder,
+            string participantEmail,
+            CancellationToken cancellationToken = default)
+        {
+            GrantedEmails.Add(participantEmail);
+            return Task.CompletedTask;
+        }
+
+        public Task<DriveFileReference> UploadRecordingAsync(
+            UploadRecordingRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (FailUpload)
+                throw new InvalidOperationException("upload failed");
+
+            return Task.FromResult(new DriveFileReference(
+                $"file-{request.Recording.AttemptNumber}",
+                $"https://drive.test/file-{request.Recording.AttemptNumber}"));
+        }
+    }
+
+    private sealed class InMemoryRunningAnalysisRepository : IRunningAnalysisRepository
+    {
+        public Dictionary<string, RunningAnalysisEvent> Events { get; } = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, RunningAnalysisParticipant> _participants = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, RunningAnalysisRecording> _recordings = new(StringComparer.OrdinalIgnoreCase);
+
+        public Task<RunningAnalysisEvent?> GetEventAsync(
+            string analysisEventId,
+            CancellationToken cancellationToken = default)
+        {
+            Events.TryGetValue(analysisEventId, out var analysisEvent);
+            return Task.FromResult(analysisEvent);
+        }
+
+        public Task<RunningAnalysisEvent?> GetEventByExternalEventIdAsync(
+            string externalEventId,
+            CancellationToken cancellationToken = default)
+        {
+            var analysisEvent = Events.Values.FirstOrDefault(analysisEvent =>
+                analysisEvent.ExternalEventId == externalEventId);
+            return Task.FromResult(analysisEvent);
+        }
+
+        public Task UpsertEventAsync(
+            RunningAnalysisEvent analysisEvent,
+            CancellationToken cancellationToken = default)
+        {
+            Events[analysisEvent.Id] = analysisEvent;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<RunningAnalysisParticipant>> GetParticipantsAsync(
+            string analysisEventId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<RunningAnalysisParticipant>>(
+                _participants.Values.Where(participant => participant.AnalysisEventId == analysisEventId).ToList());
+        }
+
+        public Task<IReadOnlyList<RunningAnalysisParticipant>> GetParticipantsForAthleteAsync(
+            string athleteUserId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<RunningAnalysisParticipant>>(
+                _participants.Values.Where(participant => participant.AthleteUserId == athleteUserId).ToList());
+        }
+
+        public Task<RunningAnalysisParticipant?> GetParticipantAsync(
+            string analysisEventId,
+            string athleteUserId,
+            CancellationToken cancellationToken = default)
+        {
+            var participant = _participants.Values.FirstOrDefault(participant =>
+                participant.AnalysisEventId == analysisEventId
+                && participant.AthleteUserId == athleteUserId);
+            return Task.FromResult(participant);
+        }
+
+        public Task<RunningAnalysisParticipant?> GetParticipantByIdAsync(
+            string participantId,
+            CancellationToken cancellationToken = default)
+        {
+            _participants.TryGetValue(participantId, out var participant);
+            return Task.FromResult(participant);
+        }
+
+        public Task UpsertParticipantAsync(
+            RunningAnalysisParticipant participant,
+            CancellationToken cancellationToken = default)
+        {
+            _participants[participant.Id] = participant;
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<RunningAnalysisRecording>> GetRecordingsForParticipantAsync(
+            string participantId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<RunningAnalysisRecording>>(
+                _recordings.Values.Where(recording => recording.ParticipantId == participantId).ToList());
+        }
+
+        public Task UpsertRecordingAsync(
+            RunningAnalysisRecording recording,
+            CancellationToken cancellationToken = default)
+        {
+            _recordings[recording.Id] = recording;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/PaceLetics.Web/PaceLetics.Web.csproj
+++ b/PaceLetics.Web/PaceLetics.Web.csproj
@@ -38,6 +38,9 @@
     <ProjectReference Include="..\AthleteDataAccessLibrary\AthleteDataAccessLibrary.csproj" />
     <ProjectReference Include="..\PaceLetics.AthleteModule.Components\PaceLetics.AthleteModule.Components.csproj" />
     <ProjectReference Include="..\PaceLetics.CoreModule.Infrastructure\PaceLetics.CoreModule.Infrastructure.csproj" />
+    <ProjectReference Include="..\PaceLetics.RunningAnalysisModule.CodeBase\PaceLetics.RunningAnalysisModule.CodeBase.csproj" />
+    <ProjectReference Include="..\PaceLetics.RunningAnalysisModule.Components\PaceLetics.RunningAnalysisModule.Components.csproj" />
+    <ProjectReference Include="..\PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive\PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive.csproj" />
     <ProjectReference Include="..\PaceLetics.TrainingPlanModule.CodeBase\PaceLetics.TrainingPlanModule.CodeBase.csproj" />
     <ProjectReference Include="..\PaceLetics.TrainingModule.CodeBase\PaceLetics.TrainingModule.CodeBase.csproj" />
     <ProjectReference Include="..\PaceLetics.TrainingModule.Components\PaceLetics.TrainingModule.Components.csproj" />

--- a/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
@@ -258,7 +258,15 @@
                                                     <MudPaper Elevation="0" Class="pa-2" Style="border:1px solid var(--mud-palette-lines-default);">
                                                         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
                                                             <MudStack Spacing="0" Style="min-width:0;">
-                                                                <MudText Typo="Typo.body2">@courseEvent.Title</MudText>
+                                                                <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:6px; flex-wrap:wrap;">
+                                                                    <MudText Typo="Typo.body2">@courseEvent.Title</MudText>
+                                                                    <MudChip T="string"
+                                                                             Size="Size.Small"
+                                                                             Color="@GetCourseEventTypeColor(courseEvent.EventType)"
+                                                                             Variant="Variant.Outlined">
+                                                                        @FormatCourseEventType(courseEvent.EventType)
+                                                                    </MudChip>
+                                                                </MudStack>
                                                                 <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatDateRange(courseEvent.StartsAt, courseEvent.EndsAt)</MudText>
                                                                 @if (!string.IsNullOrWhiteSpace(courseEvent.Location))
                                                                 {
@@ -311,6 +319,15 @@
                                                 </MudItem>
                                                 <MudItem xs="12" md="6">
                                                     <MudTextField Label="@L["Location"]" @bind-Value="_eventLocation" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudSelect T="string"
+                                                               Label="@L["EventType"]"
+                                                               @bind-Value="_eventType"
+                                                               Variant="Variant.Outlined">
+                                                        <MudSelectItem T="string" Value="@CourseEventTypes.General">@L["EventType_General"]</MudSelectItem>
+                                                        <MudSelectItem T="string" Value="@CourseEventTypes.RunningAnalysis">@L["EventType_RunningAnalysis"]</MudSelectItem>
+                                                    </MudSelect>
                                                 </MudItem>
                                                 <MudItem xs="12">
                                                     <MudTextField Label="@L["Description"]" @bind-Value="_eventDescription" Variant="Variant.Outlined" Lines="2" />
@@ -431,6 +448,7 @@
     private string _eventTitle = string.Empty;
     private string _eventDescription = string.Empty;
     private string _eventLocation = string.Empty;
+    private string _eventType = CourseEventTypes.General;
     private DateTime? _eventStartDate = DateTime.Today;
     private string _eventStartTime = "18:00";
     private string _eventEndTime = "19:30";
@@ -721,7 +739,8 @@
                 _eventDescription,
                 _eventLocation,
                 _eventCapacity,
-                _eventRegistrationDeadline?.Date);
+                _eventRegistrationDeadline?.Date,
+                _eventType);
 
             Snackbar.Add(L["AddEventSuccess"], Severity.Success);
             ResetEventForm();
@@ -836,6 +855,7 @@
         _eventTitle = string.Empty;
         _eventDescription = string.Empty;
         _eventLocation = string.Empty;
+        _eventType = CourseEventTypes.General;
         _eventStartDate = DateTime.Today;
         _eventStartTime = "18:00";
         _eventEndTime = "19:30";
@@ -861,6 +881,20 @@
     private string FormatDateRange(DateTime startsAt, DateTime endsAt)
     {
         return string.Format(L["DateRange"], startsAt, endsAt);
+    }
+
+    private string FormatCourseEventType(string? eventType)
+    {
+        return string.Equals(eventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase)
+            ? L["EventType_RunningAnalysis"]
+            : L["EventType_General"];
+    }
+
+    private Color GetCourseEventTypeColor(string? eventType)
+    {
+        return string.Equals(eventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase)
+            ? Color.Primary
+            : Color.Default;
     }
 
     private string GetTrainingPlanName(string trainingPlanId)

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -17,6 +17,7 @@ using PaceLetics.AthleteModule.CodeBase.Services;
 using PaceLetics.AthleteModule.CodeBase.Interfaces;
 using PaceLetics.CoreModule.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.Options;
 using PaceLetics.Web.Configuration;
 using PaceLetics.TrainingModule.CodeBase.Workouts.Models;
 using PaceLetics.TrainingModule.CodeBase.Workouts.Repositories;
@@ -24,7 +25,11 @@ using PaceLetics.Web.ViewModels.Workouts;
 using PaceLetics.Web.Services.DashboardMessages;
 using PaceLetics.CoreModule.Infrastructure.Services;
 using PaceLetics.Web.Services.Courses;
+using PaceLetics.Web.Services.RunningAnalysis;
 using PaceLetics.Web.Services.Theming;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Services;
+using PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -96,6 +101,17 @@ builder.Services.Configure<TrainerVerificationOptions>(options =>
 });
 builder.Services.AddTransient<IEmailSender, SmtpEmailSender>();
 builder.Services.AddScoped<ICourseRepository, CosmosCourseRepository>();
+builder.Services.Configure<GoogleDriveRunningAnalysisOptions>(
+    builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.SectionName));
+builder.Services.AddScoped<CosmosRunningAnalysisRepository>();
+builder.Services.AddScoped<IRunningAnalysisRepository>(x => x.GetRequiredService<CosmosRunningAnalysisRepository>());
+builder.Services.AddScoped<IUserDriveFolderRegistry>(x => x.GetRequiredService<CosmosRunningAnalysisRepository>());
+builder.Services.AddSingleton<IRunningAnalysisClock, SystemRunningAnalysisClock>();
+builder.Services.AddScoped<IRunningAnalysisStorageProvider>(x =>
+    new GoogleDriveRunningAnalysisStorageProvider(
+        x.GetRequiredService<IOptions<GoogleDriveRunningAnalysisOptions>>().Value));
+builder.Services.AddScoped<IRunningAnalysisService, RunningAnalysisService>();
+builder.Services.AddScoped<ICourseRunningAnalysisRegistrationAdapter, CourseRunningAnalysisRegistrationAdapter>();
 builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddScoped<ITrainingPlanService, TrainingPlanService>();
 builder.Services.AddScoped<ThemePreferenceService>();

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
@@ -35,6 +35,9 @@
   <data name="NoParticipants" xml:space="preserve"><value>Noch keine Teilnehmenden registriert.</value></data>
   <data name="Capacity" xml:space="preserve"><value>Kapazitaet</value></data>
   <data name="RegistrationDeadline" xml:space="preserve"><value>Anmeldefrist</value></data>
+  <data name="EventType" xml:space="preserve"><value>Eventtyp</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>Allgemein</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Laufanalyse</value></data>
   <data name="AddEvent" xml:space="preserve"><value>Event hinzufuegen</value></data>
   <data name="TrainingPlans" xml:space="preserve"><value>Trainingsplaene</value></data>
   <data name="NoPublishedPlan" xml:space="preserve"><value>Noch kein Plan veroeffentlicht.</value></data>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.en.resx
@@ -35,6 +35,9 @@
   <data name="NoParticipants" xml:space="preserve"><value>No participants registered yet.</value></data>
   <data name="Capacity" xml:space="preserve"><value>Capacity</value></data>
   <data name="RegistrationDeadline" xml:space="preserve"><value>Registration deadline</value></data>
+  <data name="EventType" xml:space="preserve"><value>Event type</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>General</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Running analysis</value></data>
   <data name="AddEvent" xml:space="preserve"><value>Add event</value></data>
   <data name="TrainingPlans" xml:space="preserve"><value>Training plans</value></data>
   <data name="NoPublishedPlan" xml:space="preserve"><value>No plan published yet.</value></data>

--- a/PaceLetics.Web/Services/Courses/CourseDocuments.cs
+++ b/PaceLetics.Web/Services/Courses/CourseDocuments.cs
@@ -22,6 +22,12 @@ public static class CourseEventRegistrationStatus
     public const string Cancelled = "cancelled";
 }
 
+public static class CourseEventTypes
+{
+    public const string General = "general";
+    public const string RunningAnalysis = "runningAnalysis";
+}
+
 public enum CourseLevel
 {
     Level0 = 0,
@@ -143,6 +149,7 @@ public sealed class CourseEventDocument : IQueryItem
     public string Id { get; set; } = string.Empty;
     public string CourseId { get; set; } = string.Empty;
     public string DocumentType { get; set; } = CourseDocumentTypes.Event;
+    public string EventType { get; set; } = CourseEventTypes.General;
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public DateTime StartsAt { get; set; }

--- a/PaceLetics.Web/Services/Courses/CourseService.cs
+++ b/PaceLetics.Web/Services/Courses/CourseService.cs
@@ -6,11 +6,16 @@ public sealed class CourseService : ICourseService
 {
     private readonly ICourseRepository _repository;
     private readonly IStringLocalizer<CourseService>? _localizer;
+    private readonly ICourseRunningAnalysisRegistrationAdapter? _runningAnalysisRegistrationAdapter;
 
-    public CourseService(ICourseRepository repository, IStringLocalizer<CourseService>? localizer = null)
+    public CourseService(
+        ICourseRepository repository,
+        IStringLocalizer<CourseService>? localizer = null,
+        ICourseRunningAnalysisRegistrationAdapter? runningAnalysisRegistrationAdapter = null)
     {
         _repository = repository;
         _localizer = localizer;
+        _runningAnalysisRegistrationAdapter = runningAnalysisRegistrationAdapter;
     }
 
     public async Task<IReadOnlyList<CourseOverview>> GetCoursesForAthleteAsync(string athleteUserId)
@@ -350,7 +355,8 @@ public sealed class CourseService : ICourseService
         string description = "",
         string location = "",
         int? capacity = null,
-        DateTime? registrationDeadline = null)
+        DateTime? registrationDeadline = null,
+        string eventType = CourseEventTypes.General)
     {
         if (string.IsNullOrWhiteSpace(title))
             throw new InvalidOperationException(Text("EventTitleRequired", "Ein Event braucht einen Titel."));
@@ -369,6 +375,7 @@ public sealed class CourseService : ICourseService
             Title = title,
             StartsAt = startsAt,
             EndsAt = endsAt,
+            EventType = string.IsNullOrWhiteSpace(eventType) ? CourseEventTypes.General : eventType,
             Description = description,
             Location = location,
             Capacity = capacity,
@@ -469,6 +476,7 @@ public sealed class CourseService : ICourseService
             registration.RegisteredAt = DateTime.UtcNow;
 
         await _repository.UpsertEventRegistrationAsync(registration);
+        await NotifyRunningAnalysisRegistrationAsync(courseEvent, registration);
         return registration;
     }
 
@@ -507,6 +515,22 @@ public sealed class CourseService : ICourseService
             registration.CancelledAt = cancelledAt;
             await _repository.UpsertEventRegistrationAsync(registration);
         }
+    }
+
+    private async Task NotifyRunningAnalysisRegistrationAsync(
+        CourseEventDocument courseEvent,
+        CourseEventRegistrationDocument registration)
+    {
+        if (_runningAnalysisRegistrationAdapter is null)
+            return;
+
+        if (!string.Equals(courseEvent.EventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var course = await _repository.GetCourseAsync(courseEvent.CourseId)
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "Der Kurs wurde nicht gefunden."));
+
+        await _runningAnalysisRegistrationAdapter.OnRegisteredAsync(course, courseEvent, registration);
     }
 
     private static string CreateCourseId(string name)

--- a/PaceLetics.Web/Services/Courses/ICourseRunningAnalysisRegistrationAdapter.cs
+++ b/PaceLetics.Web/Services/Courses/ICourseRunningAnalysisRegistrationAdapter.cs
@@ -1,0 +1,10 @@
+namespace PaceLetics.Web.Services.Courses;
+
+public interface ICourseRunningAnalysisRegistrationAdapter
+{
+    Task OnRegisteredAsync(
+        CourseDocument course,
+        CourseEventDocument courseEvent,
+        CourseEventRegistrationDocument registration,
+        CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.Web/Services/Courses/ICourseService.cs
+++ b/PaceLetics.Web/Services/Courses/ICourseService.cs
@@ -50,7 +50,8 @@ public interface ICourseService
         string description = "",
         string location = "",
         int? capacity = null,
-        DateTime? registrationDeadline = null);
+        DateTime? registrationDeadline = null,
+        string eventType = CourseEventTypes.General);
 
     Task DeleteEventAsync(string courseId, string eventId, string requestingTrainerUserId);
 

--- a/PaceLetics.Web/Services/RunningAnalysis/CosmosRunningAnalysisRepository.cs
+++ b/PaceLetics.Web/Services/RunningAnalysis/CosmosRunningAnalysisRepository.cs
@@ -1,0 +1,155 @@
+using AthleteDataAccessLibrary;
+using AthleteDataAccessLibrary.Contracts;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.Web.Services.RunningAnalysis;
+
+public sealed class CosmosRunningAnalysisRepository : IRunningAnalysisRepository, IUserDriveFolderRegistry
+{
+    private readonly IDataAccess _db;
+    private readonly AthleteDataOptions _options;
+
+    public CosmosRunningAnalysisRepository(IDataAccess db, AthleteDataOptions options)
+    {
+        _db = db;
+        _options = options;
+        _options.Validate();
+    }
+
+    public async Task<RunningAnalysisEvent?> GetEventAsync(string analysisEventId, CancellationToken cancellationToken = default)
+    {
+        var events = await LoadAllAsync<RunningAnalysisEvent>(RunningAnalysisDocumentTypes.Event);
+        return events.FirstOrDefault(analysisEvent => analysisEvent.Id == analysisEventId);
+    }
+
+    public async Task<RunningAnalysisEvent?> GetEventByExternalEventIdAsync(string externalEventId, CancellationToken cancellationToken = default)
+    {
+        var events = await LoadAllAsync<RunningAnalysisEvent>(RunningAnalysisDocumentTypes.Event);
+        return events.FirstOrDefault(analysisEvent => analysisEvent.ExternalEventId == externalEventId);
+    }
+
+    public Task UpsertEventAsync(RunningAnalysisEvent analysisEvent, CancellationToken cancellationToken = default)
+    {
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            WithDocumentType(analysisEvent, RunningAnalysisDocumentTypes.Event),
+            analysisEvent.CourseId);
+    }
+
+    public async Task<IReadOnlyList<RunningAnalysisParticipant>> GetParticipantsAsync(string analysisEventId, CancellationToken cancellationToken = default)
+    {
+        var participants = await LoadAllAsync<RunningAnalysisParticipant>(RunningAnalysisDocumentTypes.Participant);
+        return participants
+            .Where(participant => participant.AnalysisEventId == analysisEventId)
+            .OrderBy(participant => participant.SortOrder)
+            .ThenBy(participant => participant.DisplayName)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<RunningAnalysisParticipant>> GetParticipantsForAthleteAsync(string athleteUserId, CancellationToken cancellationToken = default)
+    {
+        var participants = await LoadAllAsync<RunningAnalysisParticipant>(RunningAnalysisDocumentTypes.Participant);
+        return participants
+            .Where(participant => participant.AthleteUserId == athleteUserId)
+            .ToList();
+    }
+
+    public async Task<RunningAnalysisParticipant?> GetParticipantAsync(string analysisEventId, string athleteUserId, CancellationToken cancellationToken = default)
+    {
+        var participants = await GetParticipantsAsync(analysisEventId, cancellationToken);
+        return participants.FirstOrDefault(participant => participant.AthleteUserId == athleteUserId);
+    }
+
+    public async Task<RunningAnalysisParticipant?> GetParticipantByIdAsync(string participantId, CancellationToken cancellationToken = default)
+    {
+        var participants = await LoadAllAsync<RunningAnalysisParticipant>(RunningAnalysisDocumentTypes.Participant);
+        return participants.FirstOrDefault(participant => participant.Id == participantId);
+    }
+
+    public Task UpsertParticipantAsync(RunningAnalysisParticipant participant, CancellationToken cancellationToken = default)
+    {
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            WithDocumentType(participant, RunningAnalysisDocumentTypes.Participant),
+            participant.CourseId);
+    }
+
+    public async Task<IReadOnlyList<RunningAnalysisRecording>> GetRecordingsForParticipantAsync(string participantId, CancellationToken cancellationToken = default)
+    {
+        var recordings = await LoadAllAsync<RunningAnalysisRecording>(RunningAnalysisDocumentTypes.Recording);
+        return recordings
+            .Where(recording => recording.ParticipantId == participantId)
+            .OrderBy(recording => recording.AttemptNumber)
+            .ToList();
+    }
+
+    public Task UpsertRecordingAsync(RunningAnalysisRecording recording, CancellationToken cancellationToken = default)
+    {
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            WithDocumentType(recording, RunningAnalysisDocumentTypes.Recording),
+            recording.CourseId);
+    }
+
+    public async Task<DriveFolderReference?> FindReusableFolderAsync(
+        ReusableDriveFolderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var references = await LoadAllAsync<RunningAnalysisDriveFolderReferenceDocument>(RunningAnalysisDocumentTypes.FolderReference);
+        var reference = references
+            .OrderByDescending(reference => reference.UpdatedAt)
+            .FirstOrDefault(reference =>
+                reference.CourseId == request.CourseId
+                && reference.ExternalEventId == request.ExternalEventId
+                && reference.AthleteUserId == request.AthleteUserId);
+
+        return reference is null
+            ? null
+            : new DriveFolderReference(reference.FolderId, reference.FolderUrl);
+    }
+
+    public Task SaveFolderReferenceAsync(
+        SaveDriveFolderReferenceRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var document = new RunningAnalysisDriveFolderReferenceDocument
+        {
+            Id = FolderReferenceId(request.CourseId, request.ExternalEventId, request.AthleteUserId),
+            CourseId = request.CourseId,
+            ExternalEventId = request.ExternalEventId,
+            AthleteUserId = request.AthleteUserId,
+            Email = request.Email,
+            FolderId = request.FolderId,
+            FolderUrl = request.FolderUrl,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            document,
+            document.CourseId);
+    }
+
+    private Task<List<T>> LoadAllAsync<T>(string documentType)
+    {
+        return _db.LoadData<T>(_options.DatabaseName, _options.CourseContainerName, documentType);
+    }
+
+    private static T WithDocumentType<T>(T item, string documentType)
+    {
+        var property = typeof(T).GetProperty("DocumentType");
+        property?.SetValue(item, documentType);
+        return item;
+    }
+
+    private static string FolderReferenceId(string courseId, string externalEventId, string athleteUserId)
+    {
+        return $"running-analysis-folder:{courseId}:{externalEventId}:{athleteUserId}";
+    }
+}

--- a/PaceLetics.Web/Services/RunningAnalysis/CourseRunningAnalysisRegistrationAdapter.cs
+++ b/PaceLetics.Web/Services/RunningAnalysis/CourseRunningAnalysisRegistrationAdapter.cs
@@ -1,0 +1,79 @@
+using AthleteDataAccessLibrary.Contracts;
+using Microsoft.AspNetCore.Identity;
+using PaceLetics.AthleteModule.CodeBase.Models;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+using PaceLetics.Web.Data;
+using PaceLetics.Web.Services.Courses;
+
+namespace PaceLetics.Web.Services.RunningAnalysis;
+
+public sealed class CourseRunningAnalysisRegistrationAdapter : ICourseRunningAnalysisRegistrationAdapter
+{
+    private readonly IRunningAnalysisService _runningAnalysisService;
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IAthleteData _athleteData;
+    private readonly ILogger<CourseRunningAnalysisRegistrationAdapter> _logger;
+
+    public CourseRunningAnalysisRegistrationAdapter(
+        IRunningAnalysisService runningAnalysisService,
+        UserManager<ApplicationUser> userManager,
+        IAthleteData athleteData,
+        ILogger<CourseRunningAnalysisRegistrationAdapter> logger)
+    {
+        _runningAnalysisService = runningAnalysisService;
+        _userManager = userManager;
+        _athleteData = athleteData;
+        _logger = logger;
+    }
+
+    public async Task OnRegisteredAsync(
+        CourseDocument course,
+        CourseEventDocument courseEvent,
+        CourseEventRegistrationDocument registration,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var user = await _userManager.FindByIdAsync(registration.AthleteUserId);
+            var athlete = await _athleteData.GetAthlete(registration.AthleteUserId);
+            var email = user?.Email ?? string.Empty;
+
+            await _runningAnalysisService.RegisterParticipantAsync(
+                new RunningAnalysisRegistration(
+                    ExternalEventId: courseEvent.Id,
+                    CourseId: course.Id,
+                    EventTitle: courseEvent.Title,
+                    StartsAt: courseEvent.StartsAt,
+                    EndsAt: courseEvent.EndsAt,
+                    AthleteUserId: registration.AthleteUserId,
+                    DisplayName: GetDisplayName(athlete, user?.UserName ?? registration.AthleteUserId),
+                    Email: email,
+                    RegistrationId: registration.Id,
+                    RegisteredAt: registration.RegisteredAt),
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Running analysis provisioning failed for event {EventId} and athlete {AthleteUserId}.",
+                courseEvent.Id,
+                registration.AthleteUserId);
+        }
+    }
+
+    private static string GetDisplayName(AthleteModel? athlete, string fallback)
+    {
+        if (!string.IsNullOrWhiteSpace(athlete?.PublicProfile?.PublicUserName)
+            && athlete.PublicProfile.PublicUserName != "NA")
+        {
+            return athlete.PublicProfile.PublicUserName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(athlete?.Name) && athlete.Name != "NA")
+            return athlete.Name;
+
+        return fallback;
+    }
+}

--- a/PaceLetics.Web/Services/RunningAnalysis/RunningAnalysisDocumentTypes.cs
+++ b/PaceLetics.Web/Services/RunningAnalysis/RunningAnalysisDocumentTypes.cs
@@ -1,0 +1,9 @@
+namespace PaceLetics.Web.Services.RunningAnalysis;
+
+public static class RunningAnalysisDocumentTypes
+{
+    public const string Event = "runningAnalysisEvent";
+    public const string Participant = "runningAnalysisParticipant";
+    public const string Recording = "runningAnalysisRecording";
+    public const string FolderReference = "runningAnalysisFolderReference";
+}

--- a/PaceLetics.Web/Services/RunningAnalysis/RunningAnalysisDriveFolderReferenceDocument.cs
+++ b/PaceLetics.Web/Services/RunningAnalysis/RunningAnalysisDriveFolderReferenceDocument.cs
@@ -1,0 +1,16 @@
+using PaceLetics.CoreModule.Infrastructure.Interfaces;
+
+namespace PaceLetics.Web.Services.RunningAnalysis;
+
+public sealed class RunningAnalysisDriveFolderReferenceDocument : IQueryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string ExternalEventId { get; set; } = string.Empty;
+    public string AthleteUserId { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string FolderId { get; set; } = string.Empty;
+    public string FolderUrl { get; set; } = string.Empty;
+    public string DocumentType { get; set; } = RunningAnalysisDocumentTypes.FolderReference;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/PaceLetics.Web/appsettings.json
+++ b/PaceLetics.Web/appsettings.json
@@ -14,6 +14,15 @@
   "TrainerVerification": {
     "Code": ""
   },
+  "RunningAnalysis": {
+    "GoogleDrive": {
+      "ApplicationName": "PaceLetics",
+      "RootFolderId": "",
+      "RootFolderName": "PaceLetics Laufanalysen",
+      "ServiceAccountJsonPath": "",
+      "ServiceAccountJson": ""
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/PaceLeticsFramework.sln
+++ b/PaceLeticsFramework.sln
@@ -29,6 +29,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaceLetics.TrainingModule.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaceLetics.TrainingModule.Components", "PaceLetics.TrainingModule.Components\PaceLetics.TrainingModule.Components.csproj", "{0C151744-DF00-4EAC-8658-87501F3A8497}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaceLetics.RunningAnalysisModule.CodeBase", "PaceLetics.RunningAnalysisModule.CodeBase\PaceLetics.RunningAnalysisModule.CodeBase.csproj", "{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaceLetics.RunningAnalysisModule.Components", "PaceLetics.RunningAnalysisModule.Components\PaceLetics.RunningAnalysisModule.Components.csproj", "{4E92E785-2C83-41D7-B4A3-FBF1209CC915}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive", "PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive\PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive.csproj", "{C20614EF-D6F2-4EA6-9187-FA38911210CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -159,6 +165,42 @@ Global
 		{0C151744-DF00-4EAC-8658-87501F3A8497}.Release|x64.Build.0 = Release|Any CPU
 		{0C151744-DF00-4EAC-8658-87501F3A8497}.Release|x86.ActiveCfg = Release|Any CPU
 		{0C151744-DF00-4EAC-8658-87501F3A8497}.Release|x86.Build.0 = Release|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Debug|x64.Build.0 = Debug|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Debug|x86.Build.0 = Debug|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Release|x64.ActiveCfg = Release|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Release|x64.Build.0 = Release|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Release|x86.ActiveCfg = Release|Any CPU
+		{5941817A-7694-4FC5-B1F2-A4C58A3EC3FE}.Release|x86.Build.0 = Release|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Release|x64.Build.0 = Release|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E92E785-2C83-41D7-B4A3-FBF1209CC915}.Release|x86.Build.0 = Release|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Debug|x64.Build.0 = Debug|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Debug|x86.Build.0 = Debug|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Release|x64.ActiveCfg = Release|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Release|x64.Build.0 = Release|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Release|x86.ActiveCfg = Release|Any CPU
+		{C20614EF-D6F2-4EA6-9187-FA38911210CE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
PR Summary
Title: Add standalone running analysis module with Drive adapters and browser recording

Summary:

Added a standalone running analysis core module with events, participants, recordings, Drive folder reuse, online-only uploads, and primary recording handling.
Added Google Drive infrastructure for event/participant folders, writer permissions, and video uploads.
Integrated Cosmos persistence and course registration adapters so runningAnalysis course events provision participant analysis folders on registration.
Added Blazor components for roster, capture flow, athlete links, and a MediaRecorder-backed camera recorder.
Added event type selection and labels in course management so trainers can create running analysis events.
Added tests for registration provisioning, folder reuse, upload behavior, online-only recording, athlete links, and course adapter notification.