### PR TITLE
Harmonize athlete UI and complete localization

### DIFF
--- a/PaceLetics.AthleteModule.Components/PaceInfo.razor
+++ b/PaceLetics.AthleteModule.Components/PaceInfo.razor
@@ -6,40 +6,29 @@
 
     @foreach (var p in Items)
     {
-        <MudCard Class="pa-4 rounded-lg" Elevation="1">
+        <MudPaper Class="@($"pa-4 pl-pace-card pl-metric-{p.Accent}")" Elevation="0">
 
-            <!-- Header mit Icon + PaceKey + Pacezeiten -->
-            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
 
-                <MudStack Spacing="0">
+                <MudStack Spacing="1" Style="min-width:0;">
                     <MudText Typo="Typo.subtitle1" Class="fw-bold">@p.Title</MudText>
 
                     <MudText Typo="Typo.body2" Color="Color.Secondary">
-                        @p.Upper.ToString("mm':'ss") – @p.Lower.ToString("mm':'ss") min/km
+                        @p.Upper.ToString("mm':'ss") - @p.Lower.ToString("mm':'ss") min/km
+                    </MudText>
+
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                        @p.Description
                     </MudText>
                 </MudStack>
 
-                <MudAvatar Size="Size.Large">
-                    <MudImage Src="@p.Icon"/>
-                </MudAvatar>
+                <div class="pl-pace-icon">
+                    <MudImage Src="@p.Icon" Width="30" Height="30" />
+                </div>
 
             </MudStack>
 
-            <!-- Expandable Infos -->
-            <MudExpansionPanels MultiExpansion="true" Elevation="0" Class="mt-2">
-                <MudExpansionPanel Class="rounded-lg">
-                    <TitleContent>
-                        <MudText Color="Color.Primary">@L["PaceInfo_MoreInfo"]</MudText>
-                    </TitleContent>
-                    <ChildContent>
-                        <MudText Typo="Typo.body2" Class="pt-2">
-                            @p.Description
-                        </MudText>
-                    </ChildContent>
-                </MudExpansionPanel>
-            </MudExpansionPanels>
-
-        </MudCard>
+        </MudPaper>
     }
 
 </MudStack>

--- a/PaceLetics.AthleteModule.Components/PaceInfo.razor.cs
+++ b/PaceLetics.AthleteModule.Components/PaceInfo.razor.cs
@@ -10,7 +10,8 @@ namespace PaceLetics.AthleteModule.Components
          string Icon,
          TimeSpan Upper,
          TimeSpan Lower,
-         string Description
+         string Description,
+         string Accent
      );
 
         [Parameter] public TimeSpan EPaceLow { get; set; }
@@ -36,23 +37,28 @@ namespace PaceLetics.AthleteModule.Components
         {
             new(L["PaceInfo_EPace_Title"], "/images/icons/epace.png",
                 Upper: EPaceHigh, Lower: EPaceLow,
-                Description: L["PaceInfo_EPace_Description"]),
+                Description: L["PaceInfo_EPace_Description"],
+                Accent: "green"),
 
             new(L["PaceInfo_MPace_Title"], "/images/icons/mpace.png",
                 Upper: MPaceHigh, Lower: MPaceLow,
-                Description: L["PaceInfo_MPace_Description"]),
+                Description: L["PaceInfo_MPace_Description"],
+                Accent: "blue"),
 
             new(L["PaceInfo_TPace_Title"], "/images/icons/tpace.png",
                 Upper: TPaceHigh, Lower: TPaceLow,
-                Description: L["PaceInfo_TPace_Description"]),
+                Description: L["PaceInfo_TPace_Description"],
+                Accent: "orange"),
 
             new(L["PaceInfo_IPace_Title"], "/images/icons/ipace.png",
                 Upper: IPaceHigh, Lower: IPaceLow,
-                Description: L["PaceInfo_IPace_Description"]),
+                Description: L["PaceInfo_IPace_Description"],
+                Accent: "red"),
 
             new(L["PaceInfo_RPace_Title"], "/images/icons/rpace.png",
                 Upper: RPaceHigh, Lower: RPaceLow,
-                Description: L["PaceInfo_RPace_Description"])
+                Description: L["PaceInfo_RPace_Description"],
+                Accent: "orange")
         };
         }
     }

--- a/PaceLetics.AthleteModule.Components/RaceCard.razor
+++ b/PaceLetics.AthleteModule.Components/RaceCard.razor
@@ -4,25 +4,34 @@
 @namespace PaceLetics.AthleteModule.Components
 @inject IStringLocalizer<AthleteResources> L
 
-<MudCard>
-    <MudCardHeader>
-        <CardHeaderContent>
-            <MudExGrid>
-                <MudAvatar>
-                    <MudImage Src="@GetImagePath(Model?.Type)"></MudImage>
-                </MudAvatar>
-                <MudText>@Model?.Date.ToString("dd-MM-yyyy").Replace("-",".")</MudText>
-            </MudExGrid>
-        </CardHeaderContent>
-        <CardHeaderActions>
-            <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" OnClick="OnEditRaceCard"/>
-        </CardHeaderActions>
-    </MudCardHeader>
-    <MudCardContent>
-        <MudText>@Model?.Id</MudText>
-        <MudText>
+<MudPaper Elevation="0" Class="pa-4 pl-race-card">
+    <MudStack Spacing="3">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="min-width:0;">
+                <div class="pl-race-icon">
+                    <MudImage Src="@GetImagePath(Model?.Type)" Width="30" Height="30" />
+                </div>
+
+                <MudStack Spacing="0" Style="min-width:0;">
+                    <MudText Typo="Typo.subtitle2">@Model?.Id</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                        @Model?.Date.ToString("dd.MM.yyyy")
+                    </MudText>
+                </MudStack>
+            </MudStack>
+
+            <MudTooltip Text="@L["RaceCard_Edit"]">
+                <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                               Color="Color.Primary"
+                               OnClick="HandleEditCard"
+                               aria-label="@L["RaceCard_Edit"]" />
+            </MudTooltip>
+        </MudStack>
+
+        <MudDivider />
+
+        <MudText Typo="Typo.body2">
             @L["RaceCard_Result"] <b>@Model?.Time.ToString()</b>
         </MudText>
-    </MudCardContent>
-</MudCard>
-
+    </MudStack>
+</MudPaper>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.ar.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.ar.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>VDOT الخاص بك</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>رائع! من سباقك المرجعي يمكننا تحديد قيمة VDOT الخاصة بك. وهذا هو أساس مناطق تدريبك الشخصية.</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>النتيجة:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>تعديل السباق</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>مزيد من المعلومات</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>الوتيرة السهلة (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>وتيرة الجري السهل لديك. اركض بهذه الوتيرة للاستشفاء أو التدريب السهل. تبني التحمل الهوائي وتساعد التعافي.</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>وتيرة الماراثون (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>وتيرة الماراثون لديك. التدريب في هذه المنطقة يحسن قدرتك على الحفاظ على وتيرة ثابتة لمسافات طويلة.</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>وتيرة العتبة (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>وتيرة العتبة لديك. التدريب في هذه المنطقة يحسن عتبة اللاكتات ويساعدك على الجري أسرع دون تراكم الكثير من حمض اللاكتيك.</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>وتيرة الفواصل (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>وتيرة الفواصل لديك. الجهود القصيرة والمكثفة في هذه المنطقة تحسن الحد الأقصى لاستهلاك الأكسجين (VO2max).</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>وتيرة التكرار (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>وتيرة التكرار لديك. الجريات القصيرة جدًا والسريعة بهذه الوتيرة تحسن اقتصاد الجري والسرعة.</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>سباق جديد</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>الاسم</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>المسافة</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>وقت السباق</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>التاريخ</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>تنبيه</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>يرجى التأكد من أن وقت السباق بالتنسيق الصحيح (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>حسنًا</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.da.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.da.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>Din VDOT</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>Godt! Ud fra dit referenceløb kan vi beregne din individuelle VDOT. Den danner grundlag for dine personlige træningszoner.</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>Resultat:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Rediger løb</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>Mere info</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Let tempo (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Dit lette løbetempo. Løb i dette tempo til restitution eller let træning. Det opbygger aerob udholdenhed og hjælper restitution.</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>Maratontempo (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>Dit maratontempo. Træning i denne zone forbedrer din evne til at holde et stabilt tempo over lange distancer.</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>Tærskeltempo (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>Dit tærskeltempo. Træning i denne zone forbedrer din laktattærskel og hjælper dig med at løbe hurtigere uden for meget mælkesyre.</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>Intervaltempo (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>Dit intervaltempo. Korte, intensive indsatser i denne zone forbedrer din maksimale iltoptagelse (VO2max).</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>Gentagelsestempo (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>Dit gentagelsestempo. Meget korte, hurtige løb i dette tempo forbedrer din løbeøkonomi og hastighed.</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>Nyt løb</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>Navn</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>Distance</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>Løbstid</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>Dato</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>Bemærk</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>Kontrollér, at løbstiden er i korrekt format (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>Ok</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.de.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.de.resx
@@ -7,6 +7,7 @@
   <data name="VdotCard_Title" xml:space="preserve"><value>Deine VDOT</value></data>
   <data name="VdotCard_Description" xml:space="preserve"><value>Super! Aus dem Referenzlauf können wir deine individuelle VDOT bestimmen. Diese bildet die Grundlage für deine persönlichen Trainingsbereiche.</value></data>
   <data name="RaceCard_Result" xml:space="preserve"><value>Ergebnis:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Lauf bearbeiten</value></data>
   <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>Mehr Infos</value></data>
   <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Easy Pace (E-Pace)</value></data>
   <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Dein lockerer Dauerlauf. Laufe in diesem Tempo, wenn du regenerativ oder locker trainierst. Es fördert die Grundlagenausdauer und hilft bei der Erholung.</value></data>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.en.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.en.resx
@@ -7,6 +7,7 @@
   <data name="VdotCard_Title" xml:space="preserve"><value>Your VDOT</value></data>
   <data name="VdotCard_Description" xml:space="preserve"><value>Great! From your reference race we can determine your individual VDOT. This forms the basis for your personal training zones.</value></data>
   <data name="RaceCard_Result" xml:space="preserve"><value>Result:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Edit race</value></data>
   <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>More info</value></data>
   <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Easy Pace (E-Pace)</value></data>
   <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Your easy run pace. Run at this pace for recovery or easy training. It builds aerobic endurance and aids recovery.</value></data>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.es.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.es.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>Tu VDOT</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>¡Genial! A partir de tu carrera de referencia podemos determinar tu VDOT individual. Es la base de tus zonas de entrenamiento personales.</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>Resultado:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Editar carrera</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>Más información</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Ritmo fácil (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Tu ritmo fácil. Corre a este ritmo para recuperación o entrenamiento suave. Mejora la resistencia aeróbica y ayuda a recuperar.</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>Ritmo de maratón (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>Tu ritmo de maratón. Entrenar en esta zona mejora tu capacidad de mantener un ritmo constante en largas distancias.</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>Ritmo umbral (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>Tu ritmo umbral. Entrenar en esta zona mejora tu umbral de lactato y te ayuda a correr más rápido sin acumular demasiado ácido láctico.</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>Ritmo de intervalos (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>Tu ritmo de intervalos. Esfuerzos cortos e intensos en esta zona mejoran tu consumo máximo de oxígeno (VO2max).</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>Ritmo de repetición (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>Tu ritmo de repetición. Carreras muy cortas y rápidas a este ritmo mejoran tu economía de carrera y velocidad.</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>Nueva carrera</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>Nombre</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>Distancia</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>Tiempo de carrera</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>Fecha</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>Atención</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>Comprueba que el tiempo de carrera tenga el formato correcto (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>Aceptar</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.fa.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.fa.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>VDOT شما</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>عالی! از مسابقه مرجع شما می‌توانیم VDOT اختصاصی شما را تعیین کنیم. این پایه محدوده‌های تمرینی شخصی شماست.</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>نتیجه:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>ویرایش مسابقه</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>اطلاعات بیشتر</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>پیس آسان (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>پیس دویدن آسان شما. برای ریکاوری یا تمرین آسان با این پیس بدوید. استقامت هوازی را می‌سازد و به ریکاوری کمک می‌کند.</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>پیس ماراتن (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>پیس ماراتن شما. تمرین در این محدوده توانایی حفظ پیس ثابت در مسافت‌های طولانی را بهبود می‌دهد.</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>پیس آستانه (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>پیس آستانه شما. تمرین در این محدوده آستانه لاکتات را بهتر می‌کند و کمک می‌کند بدون تجمع زیاد اسید لاکتیک سریع‌تر بدوید.</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>پیس اینتروال (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>پیس اینتروال شما. تلاش‌های کوتاه و شدید در این محدوده جذب اکسیژن حداکثری (VO2max) را بهبود می‌دهد.</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>پیس تکرار (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>پیس تکرار شما. دویدن‌های بسیار کوتاه و سریع با این پیس اقتصاد دویدن و سرعت شما را بهتر می‌کند.</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>مسابقه جدید</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>نام</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>مسافت</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>زمان مسابقه</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>تاریخ</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>توجه</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>لطفاً بررسی کنید زمان مسابقه با قالب درست وارد شده باشد (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>باشه</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.fr.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.fr.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>Votre VDOT</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>Parfait ! À partir de votre course de référence, nous pouvons déterminer votre VDOT individuel. C’est la base de vos zones d’entraînement personnelles.</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>Résultat :</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Modifier la course</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>Plus d’infos</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Allure facile (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Votre allure facile. Courez à cette allure pour récupérer ou vous entraîner facilement. Elle développe l’endurance aérobie et aide la récupération.</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>Allure marathon (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>Votre allure marathon. L’entraînement dans cette zone améliore votre capacité à tenir une allure régulière sur de longues distances.</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>Allure seuil (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>Votre allure seuil. L’entraînement dans cette zone améliore votre seuil lactique et vous aide à courir plus vite sans trop accumuler d’acide lactique.</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>Allure intervalle (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>Votre allure d’intervalle. Des efforts courts et intenses dans cette zone améliorent votre VO2max.</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>Allure répétition (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>Votre allure de répétition. Des courses très courtes et rapides à cette allure améliorent l’économie de course et la vitesse.</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>Nouvelle course</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>Nom</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>Distance</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>Temps de course</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>Attention</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>Veuillez vérifier que le temps de course est au bon format (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>OK</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.resx
@@ -7,6 +7,7 @@
   <data name="VdotCard_Title" xml:space="preserve"><value>Your VDOT</value></data>
   <data name="VdotCard_Description" xml:space="preserve"><value>Great! From your reference race we can determine your individual VDOT. This forms the basis for your personal training zones.</value></data>
   <data name="RaceCard_Result" xml:space="preserve"><value>Result:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Edit race</value></data>
   <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>More info</value></data>
   <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Easy Pace (E-Pace)</value></data>
   <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Your easy run pace. Run at this pace for recovery or easy training. It builds aerobic endurance and aids recovery.</value></data>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.ru.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.ru.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>Ваш VDOT</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>Отлично! По контрольному забегу мы можем определить ваш индивидуальный VDOT. Это основа ваших личных тренировочных зон.</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>Результат:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Редактировать забег</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>Подробнее</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Легкий темп (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Ваш легкий беговой темп. Бегайте в этом темпе для восстановления или легкой тренировки. Он развивает аэробную выносливость и помогает восстановлению.</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>Марафонский темп (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>Ваш марафонский темп. Тренировки в этой зоне улучшают способность держать ровный темп на длинных дистанциях.</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>Пороговый темп (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>Ваш пороговый темп. Тренировки в этой зоне улучшают лактатный порог и помогают бежать быстрее без чрезмерного накопления молочной кислоты.</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>Интервальный темп (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>Ваш интервальный темп. Короткие интенсивные отрезки в этой зоне улучшают максимальное потребление кислорода (VO2max).</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>Темп повторений (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>Ваш темп повторений. Очень короткие быстрые отрезки в этом темпе улучшают экономичность бега и скорость.</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>Новый забег</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>Имя</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>Дистанция</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>Время забега</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>Дата</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>Внимание</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>Проверьте, что время забега указано в правильном формате (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>ОК</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.tr.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.tr.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>VDOT değerin</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>Harika! Referans yarışından bireysel VDOT değerini belirleyebiliriz. Bu, kişisel antrenman bölgelerinin temelidir.</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>Sonuç:</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>Yarışı düzenle</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>Daha fazla bilgi</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>Kolay tempo (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>Kolay koşu tempon. Bu tempoda toparlanma veya rahat antrenman yap. Aerobik dayanıklılığı geliştirir ve toparlanmaya yardımcı olur.</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>Maraton temposu (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>Maraton tempon. Bu bölgede antrenman uzun mesafelerde sabit tempo koruma becerini geliştirir.</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>Eşik temposu (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>Eşik tempon. Bu bölgede antrenman laktat eşiğini geliştirir ve fazla laktik asit biriktirmeden daha hızlı koşmana yardımcı olur.</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>İnterval temposu (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>İnterval tempon. Bu bölgede kısa ve yoğun eforlar maksimum oksijen alımını (VO2max) geliştirir.</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>Tekrar temposu (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>Tekrar tempon. Bu tempoda çok kısa ve hızlı koşular koşu ekonomini ve hızını geliştirir.</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>Yeni yarış</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>Ad</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>Mesafe</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>Yarış süresi</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>Tarih</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>Dikkat</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>Lütfen yarış süresinin doğru formatta olduğundan emin ol (hh:mm:ss).</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>Tamam</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/Resources/AthleteResources.zh.resx
+++ b/PaceLetics.AthleteModule.Components/Resources/AthleteResources.zh.resx
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="VdotCard_Title" xml:space="preserve"><value>你的 VDOT</value></data>
+  <data name="VdotCard_Description" xml:space="preserve"><value>太好了！通过参考比赛，我们可以确定你的个人 VDOT。这是个人训练区间的基础。</value></data>
+  <data name="RaceCard_Result" xml:space="preserve"><value>结果：</value></data>
+  <data name="RaceCard_Edit" xml:space="preserve"><value>编辑比赛</value></data>
+  <data name="PaceInfo_MoreInfo" xml:space="preserve"><value>更多信息</value></data>
+  <data name="PaceInfo_EPace_Title" xml:space="preserve"><value>轻松配速 (E-Pace)</value></data>
+  <data name="PaceInfo_EPace_Description" xml:space="preserve"><value>你的轻松跑配速。以此配速进行恢复或轻松训练，可建立有氧耐力并帮助恢复。</value></data>
+  <data name="PaceInfo_MPace_Title" xml:space="preserve"><value>马拉松配速 (M-Pace)</value></data>
+  <data name="PaceInfo_MPace_Description" xml:space="preserve"><value>你的马拉松配速。在该区间训练可提升长距离保持稳定配速的能力。</value></data>
+  <data name="PaceInfo_TPace_Title" xml:space="preserve"><value>阈值配速 (T-Pace)</value></data>
+  <data name="PaceInfo_TPace_Description" xml:space="preserve"><value>你的阈值配速。该区间训练可提高乳酸阈值，帮助你在不过度堆积乳酸的情况下跑得更快。</value></data>
+  <data name="PaceInfo_IPace_Title" xml:space="preserve"><value>间歇配速 (I-Pace)</value></data>
+  <data name="PaceInfo_IPace_Description" xml:space="preserve"><value>你的间歇配速。该区间短而强的努力可提升最大摄氧量 (VO2max)。</value></data>
+  <data name="PaceInfo_RPace_Title" xml:space="preserve"><value>重复配速 (R-Pace)</value></data>
+  <data name="PaceInfo_RPace_Description" xml:space="preserve"><value>你的重复配速。以此配速进行很短的快速跑可改善跑步经济性和速度。</value></data>
+  <data name="AddRaceDialog_Title" xml:space="preserve"><value>新比赛</value></data>
+  <data name="AddRaceDialog_Name" xml:space="preserve"><value>名称</value></data>
+  <data name="AddRaceDialog_Distance" xml:space="preserve"><value>距离</value></data>
+  <data name="AddRaceDialog_Time" xml:space="preserve"><value>比赛时间</value></data>
+  <data name="AddRaceDialog_TimeHelper" xml:space="preserve"><value>hh:mm:ss</value></data>
+  <data name="AddRaceDialog_Date" xml:space="preserve"><value>日期</value></data>
+  <data name="AddRaceDialog_Warning_Title" xml:space="preserve"><value>注意</value></data>
+  <data name="AddRaceDialog_Warning_Message" xml:space="preserve"><value>请检查比赛时间格式是否正确 (hh:mm:ss)。</value></data>
+  <data name="AddRaceDialog_Ok" xml:space="preserve"><value>确定</value></data>
+</root>

--- a/PaceLetics.AthleteModule.Components/VdotCard.razor
+++ b/PaceLetics.AthleteModule.Components/VdotCard.razor
@@ -3,7 +3,7 @@
 @namespace PaceLetics.AthleteModule.Components
 @inject IStringLocalizer<AthleteResources> L
 
-<MudCard Class="d-flex flex-column align-center pa-4" Style="text-align:center;">
+<MudPaper Elevation="0" Class="d-flex flex-column align-center pa-4 pl-vdot-card">
 
     <div class="d-flex justify-center">
         <MudChart T="double"
@@ -44,7 +44,7 @@
     <MudText Align="Align.Center" Class="mt-4">
         @L["VdotCard_Description"]
     </MudText>
-</MudCard>
+</MudPaper>
 
 
 

--- a/PaceLetics.Tests/ComponentLocalizationTests.cs
+++ b/PaceLetics.Tests/ComponentLocalizationTests.cs
@@ -3,10 +3,16 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using PaceLetics.AthleteModule.Components;
 using PaceLetics.TrainingModule.Components.Running;
 using PaceLetics.TrainingModule.Components.Workouts;
+using PaceLetics.Web.Areas.Identity.Pages.Account;
+using PaceLetics.Web.Areas.Identity.Pages.Account.Manage;
 using PaceLetics.Web.Localization;
 using PaceLetics.Web.Pages;
+using PaceLetics.Web.Pages.Athletes;
+using PaceLetics.Web.Pages.Trainers;
+using PaceLetics.Web.Services.Courses;
 using PaceLetics.Web.Shared;
 
 namespace PaceLetics.Tests;
@@ -16,8 +22,8 @@ public sealed class ComponentLocalizationTests
     [Theory]
     [InlineData("de", "DifficultyDialog_Start", "Starten")]
     [InlineData("en", "DifficultyDialog_Start", "Start")]
-    [InlineData("tr", "DifficultyDialog_Start", "Start")]
-    [InlineData("ar", "DifficultyDialog_Start", "Start")]
+    [InlineData("tr", "DifficultyDialog_Start", "Başlat")]
+    [InlineData("ar", "DifficultyDialog_Start", "ابدأ")]
     public void WorkoutResources_ResolveKnownKeysWithAppResourcePath(
         string culture,
         string key,
@@ -32,7 +38,7 @@ public sealed class ComponentLocalizationTests
     [Theory]
     [InlineData("de", "TrainingCard_Title", "Training")]
     [InlineData("en", "TrainingCard_Title", "Training")]
-    [InlineData("fa", "TrainingCard_Title", "Training")]
+    [InlineData("fa", "TrainingCard_Title", "تمرین")]
     public void RunningResources_ResolveKnownKeysWithAppResourcePath(
         string culture,
         string key,
@@ -42,6 +48,73 @@ public sealed class ComponentLocalizationTests
 
         Assert.False(value.ResourceNotFound);
         Assert.Equal(expectedValue, value.Value);
+    }
+
+    [Theory]
+    [InlineData("tr", "WelcomeText", "Merhaba {0}, işte güncel antrenman durumun.")]
+    [InlineData("es", "Title", "Panel")]
+    public void DashboardResources_ResolveTranslatedKeysForNewCultures(
+        string culture,
+        string key,
+        string expectedValue)
+    {
+        var value = GetLocalizedString<Dashboard>(culture, key);
+
+        Assert.False(value.ResourceNotFound);
+        Assert.Equal(expectedValue, value.Value);
+    }
+
+    [Theory]
+    [InlineData("es", "VdotCard_Title", "Tu VDOT")]
+    [InlineData("fr", "RaceCard_Edit", "Modifier la course")]
+    public void AthleteResources_ResolveTranslatedKeysForNewCultures(
+        string culture,
+        string key,
+        string expectedValue)
+    {
+        var value = GetLocalizedString<AthleteResources>(culture, key);
+
+        Assert.False(value.ResourceNotFound);
+        Assert.Equal(expectedValue, value.Value);
+    }
+
+    [Fact]
+    public void TrainerPageResources_ResolveTranslatedKeysForNewCultures()
+    {
+        var value = GetLocalizedString<CourseManagement>("fr", "Title");
+
+        Assert.False(value.ResourceNotFound);
+        Assert.Equal("Gérer les cours", value.Value);
+    }
+
+    [Fact]
+    public void CourseServiceResources_ResolveTranslatedKeysForNewCultures()
+    {
+        var value = GetLocalizedString<CourseService>("zh", "CourseNotFound");
+
+        Assert.False(value.ResourceNotFound);
+        Assert.Equal("未找到课程。", value.Value);
+    }
+
+    [Fact]
+    public void IdentityModelResources_ResolveTranslatedKeysForNewCultures()
+    {
+        var invalidLogin = GetLocalizedString<LoginModel>("es", "InvalidLoginAttempt");
+        var rememberMe = GetLocalizedString<LoginModel>("es", "RememberMe");
+        var passwordMatch = GetLocalizedString<RegisterModel>("fr", "ValidationPasswordMatch");
+        var newPasswordMatch = GetLocalizedString<ChangePasswordModel>("es", "ValidationNewPasswordMatch");
+
+        Assert.False(invalidLogin.ResourceNotFound);
+        Assert.Equal("Intento de inicio de sesión no válido.", invalidLogin.Value);
+
+        Assert.False(rememberMe.ResourceNotFound);
+        Assert.Equal("¿Recordarme?", rememberMe.Value);
+
+        Assert.False(passwordMatch.ResourceNotFound);
+        Assert.Equal("Le mot de passe et sa confirmation ne correspondent pas.", passwordMatch.Value);
+
+        Assert.False(newPasswordMatch.ResourceNotFound);
+        Assert.Equal("La nueva contraseña y la confirmación no coinciden.", newPasswordMatch.Value);
     }
 
     [Theory]

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.ar.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.ar.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>فاصل</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>جري</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>تدريب</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.da.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.da.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>Interval</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>Løb</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Træning</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.es.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.es.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>Intervalo</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>Carrera</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Entrenamiento</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.fa.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.fa.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>اینتروال</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>دویدن</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>تمرین</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.fr.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.fr.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>Intervalle</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>Course</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Entraînement</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.ru.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.ru.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>Интервал</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>Бег</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Тренировка</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.tr.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.tr.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>İnterval</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>Koşu</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Antrenman</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.zh.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Running/RunningResources.zh.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="MiniCard_Interval" xml:space="preserve"><value>间歇</value></data>
+  <data name="MiniCard_Run" xml:space="preserve"><value>跑步</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>训练</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.ar.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.ar.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>استعد!</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>بدّل الجانب!</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>ابدأ!</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>متوقف مؤقتًا!</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>استراحة تمرين!</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>التفاصيل</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>التسلسل</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>لا يوجد تمرين.</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>التنفيذ</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>لا توجد خطوات متاحة.</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>انقر للمعاينة.</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>عرض فقط أثناء الجري (بدون تخطي).</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>الآن</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>عدد التكرارات</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>مستويات الصعوبة المتاحة</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>ابدأ</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>إلغاء</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>اختر الصعوبة</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>إجمالي التكرارات</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>فتح</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>مزيد من المعلومات</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>المدة:</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>تبديل الجانب:</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>نعم</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>لا</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>معلومات التمرين غير متاحة.</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>التفاصيل والتسلسل</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>سهل</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>متوسط</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>متقدم</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>ملحمي</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>ابدأ</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>إيقاف مؤقت</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>إعادة تعيين</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>لم يتم تحميل أي تمرين.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>نعم!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>تدريب</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.da.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.da.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>Gør dig klar!</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>Skift side!</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>Start!</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>Sat på pause!</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>Øvelsespause!</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>Detaljer</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>Rækkefølge</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>Ingen øvelse.</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>Udførelse</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>Ingen trin tilgængelige.</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>Tryk for forhåndsvisning.</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>Kun visning under løb (ingen spring).</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>Nu</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>Antal gentagelser</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>Tilgængelige sværhedsgrader</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>Annuller</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>Vælg sværhedsgrad</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>Samlede gentagelser</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>Åbn</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>Mere info</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>Varighed:</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>Sideskift:</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>ja</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>nej</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>Øvelsesinformation er ikke tilgængelig.</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>DETALJER OG RÆKKEFØLGE</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Let</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Moderat</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Avanceret</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Episk</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>Pause</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>Nulstil</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>Ingen workout indlæst.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>Ja!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Træning</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.es.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.es.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>¡Prepárate!</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>¡Cambia de lado!</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>¡Vamos!</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>¡En pausa!</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>¡Pausa de ejercicio!</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>Detalles</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>Secuencia</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>Sin ejercicio.</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>Ejecución</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>No hay pasos disponibles.</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>Toca para previsualizar.</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>Solo vista durante la carrera (sin saltos).</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>Ahora</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>Número de repeticiones</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>Niveles de dificultad disponibles</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>Iniciar</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>Elegir dificultad</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>Repeticiones totales</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>Abrir</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>Más información</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>Duración:</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>Cambio de lado:</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>sí</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>no</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>La información del ejercicio no está disponible.</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>DETALLES Y SECUENCIA</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Fácil</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Moderado</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Avanzado</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Épico</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>Iniciar</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>Pausa</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>Restablecer</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>No hay entrenamiento cargado.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>¡Sí!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Entrenamiento</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.fa.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.fa.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>آماده شوید!</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>سمت را عوض کنید!</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>شروع!</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>متوقف شد!</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>استراحت تمرین!</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>جزئیات</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>توالی</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>تمرینی وجود ندارد.</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>اجرا</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>مرحله‌ای در دسترس نیست.</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>برای پیش‌نمایش لمس کنید.</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>فقط هنگام دویدن نمایش داده شود (بدون پرش).</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>اکنون</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>تعداد تکرارها</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>سطوح دشواری موجود</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>شروع</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>لغو</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>انتخاب دشواری</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>مجموع تکرارها</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>باز کردن</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>اطلاعات بیشتر</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>مدت:</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>تعویض سمت:</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>بله</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>نه</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>اطلاعات تمرین در دسترس نیست.</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>جزئیات و توالی</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>آسان</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>متوسط</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>پیشرفته</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>حماسی</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>شروع</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>مکث</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>بازنشانی</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>تمرینی بارگذاری نشده است.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>بله!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>تمرین</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.fr.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.fr.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>Préparez-vous !</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>Changez de côté !</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>C’est parti !</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>En pause !</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>Pause d’exercice !</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>Détails</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>Séquence</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>Aucun exercice.</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>Exécution</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>Aucune étape disponible.</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>Touchez pour prévisualiser.</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>Affichage uniquement pendant la course (pas de saut).</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>Maintenant</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>Nombre de répétitions</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>Niveaux de difficulté disponibles</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>Démarrer</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>Annuler</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>Choisir la difficulté</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>Répétitions totales</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>Ouvrir</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>Plus d’infos</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>Durée :</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>Changement de côté :</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>oui</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>non</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>Les informations sur l’exercice ne sont pas disponibles.</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>DÉTAILS ET SÉQUENCE</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Facile</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Modéré</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Avancé</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Épique</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>Démarrer</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>Pause</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>Réinitialiser</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>Aucun entraînement chargé.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>Oui !</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Entraînement</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.ru.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.ru.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>Приготовьтесь!</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>Смените сторону!</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>Поехали!</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>Пауза!</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>Перерыв в упражнении!</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>Детали</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>Последовательность</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>Нет упражнения.</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>Выполнение</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>Шаги недоступны.</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>Нажмите для предпросмотра.</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>Просмотр только во время бега (без пропуска).</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>Сейчас</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>Количество повторений</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>Доступные уровни сложности</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>Старт</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>Отмена</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>Выберите сложность</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>Всего повторений</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>Открыть</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>Подробнее</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>Длительность:</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>Смена стороны:</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>да</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>нет</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>Информация об упражнении недоступна.</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>ДЕТАЛИ И ПОСЛЕДОВАТЕЛЬНОСТЬ</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Легкий</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Средний</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Продвинутый</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Эпический</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>Старт</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>Пауза</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>Сброс</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>Тренировка не загружена.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>Да!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Тренировка</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.tr.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.tr.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>Hazır ol!</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>Taraf değiştir!</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>Başla!</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>Duraklatıldı!</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>Egzersiz molası!</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>Detaylar</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>Sıra</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>Egzersiz yok.</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>Uygulama</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>Adım yok.</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>Önizlemek için dokun.</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>Yalnızca koşu sırasında görüntüle (atlama yok).</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>Şimdi</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>Tekrar sayısı</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>Mevcut zorluk seviyeleri</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>Başlat</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>İptal</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>Zorluk seç</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>Toplam tekrar</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>Aç</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>Daha fazla bilgi</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>Süre:</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>Taraf değişimi:</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>evet</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>hayır</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>Egzersiz bilgisi mevcut değil.</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>DETAYLAR VE SIRA</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Kolay</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Orta</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>İleri</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Epik</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>Başlat</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>Duraklat</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>Sıfırla</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>Antrenman yüklenmedi.</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>Evet!</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>Antrenman</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.zh.resx
+++ b/PaceLetics.TrainingModule.Components/Resources/Workouts/WorkoutResources.zh.resx
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="TopBar_GetReady" xml:space="preserve"><value>准备好！</value></data>
+  <data name="TopBar_SideSwitch" xml:space="preserve"><value>换边！</value></data>
+  <data name="TopBar_Execution" xml:space="preserve"><value>开始！</value></data>
+  <data name="TopBar_Paused" xml:space="preserve"><value>已暂停！</value></data>
+  <data name="TopBar_ExercisePause" xml:space="preserve"><value>练习休息！</value></data>
+  <data name="BottomSheet_Details" xml:space="preserve"><value>详情</value></data>
+  <data name="BottomSheet_Sequence" xml:space="preserve"><value>顺序</value></data>
+  <data name="BottomSheet_NoExercise" xml:space="preserve"><value>没有练习。</value></data>
+  <data name="BottomSheet_Execution" xml:space="preserve"><value>执行</value></data>
+  <data name="BottomSheet_NoSteps" xml:space="preserve"><value>没有可用步骤。</value></data>
+  <data name="BottomSheet_TapToPreview" xml:space="preserve"><value>点击预览。</value></data>
+  <data name="BottomSheet_RunningViewOnly" xml:space="preserve"><value>仅在跑步时查看（不能跳过）。</value></data>
+  <data name="BottomSheet_Now" xml:space="preserve"><value>现在</value></data>
+  <data name="DifficultyDialog_Reps" xml:space="preserve"><value>重复次数</value></data>
+  <data name="DifficultyDialog_AvailableLevels" xml:space="preserve"><value>可用难度等级</value></data>
+  <data name="DifficultyDialog_Start" xml:space="preserve"><value>开始</value></data>
+  <data name="DifficultyDialog_Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="DifficultyDialog_SelectDifficulty" xml:space="preserve"><value>选择难度</value></data>
+  <data name="Preview_TotalReps" xml:space="preserve"><value>总次数</value></data>
+  <data name="Preview_Open" xml:space="preserve"><value>打开</value></data>
+  <data name="Preview_MoreInfo" xml:space="preserve"><value>更多信息</value></data>
+  <data name="ExerciseInfo_Duration" xml:space="preserve"><value>时长：</value></data>
+  <data name="ExerciseInfo_SideSwitch" xml:space="preserve"><value>换边：</value></data>
+  <data name="ExerciseInfo_Yes" xml:space="preserve"><value>是</value></data>
+  <data name="ExerciseInfo_No" xml:space="preserve"><value>否</value></data>
+  <data name="ExerciseInfo_NotAvailable" xml:space="preserve"><value>练习信息不可用。</value></data>
+  <data name="WorkoutNow_Details" xml:space="preserve"><value>详情与顺序</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>简单</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>中等</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>高级</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>史诗级</value></data>
+  <data name="TopBar_Start" xml:space="preserve"><value>开始</value></data>
+  <data name="TopBar_Pause" xml:space="preserve"><value>暂停</value></data>
+  <data name="TopBar_Reset" xml:space="preserve"><value>重置</value></data>
+  <data name="WorkoutView_NoWorkout" xml:space="preserve"><value>未加载训练。</value></data>
+  <data name="FinishedDialog_Confirm" xml:space="preserve"><value>是！</value></data>
+  <data name="TrainingCard_Title" xml:space="preserve"><value>训练</value></data>
+</root>

--- a/PaceLetics.TrainingModule.Components/Running/RunningSessionMiniCard.razor
+++ b/PaceLetics.TrainingModule.Components/Running/RunningSessionMiniCard.razor
@@ -3,15 +3,10 @@
 @namespace PaceLetics.TrainingModule.Components.Running
 @inject IStringLocalizer<RunningResources> L
 
-<MudCard Elevation="0"
-         Style="
-            background-color: transparent;
-            border: none;
-            min-width:320px;
-            width:100%;
-            margin-left:8px;
-         ">
-    <MudCardContent Style="padding:12px 16px;">
+<MudPaper Elevation="0"
+          Class="@CardClass"
+          Style="min-width:320px; width:100%; margin-left:8px;">
+    <div style="padding:12px 16px;">
 
         <MudStack Spacing="1">
 
@@ -37,9 +32,9 @@
 
         </MudStack>
 
-    </MudCardContent>
+    </div>
 
-</MudCard>
+</MudPaper>
 
 @code {
     [Parameter, EditorRequired] public RunningSession Session { get; set; } = default!;
@@ -53,5 +48,9 @@
 	private Color TextColor => IsHighlighted ? Color.Primary : Color.Inherit;
 
     private Color TypeColor => IsInterval ? Color.Error : Color.Success;
+
+    private string CardClass => IsHighlighted
+        ? "pl-metric-tile pl-metric-green"
+        : "pl-surface-card";
 
 }

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Login.cshtml
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Login.cshtml
@@ -24,7 +24,7 @@
             <span asp-validation-for="Input.UserNameOrEmail" class="text-danger"></span>
         </div>
         <div class="form-floating mb-3">
-            <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password" />
+            <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="@Localizer["Password"]" />
             <label asp-for="Input.Password" class="form-label">@Localizer["Password"]</label>
             <span asp-validation-for="Input.Password" class="text-danger"></span>
         </div>

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -74,22 +74,24 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required]
+            [Required(ErrorMessage = "ValidationRequired")]
+            [Display(Name = "UserNameOrEmail")]
             public string UserNameOrEmail { get; set; }
 
             /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required]
+            [Required(ErrorMessage = "ValidationRequired")]
             [DataType(DataType.Password)]
+            [Display(Name = "Password")]
             public string Password { get; set; }
 
             /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Display(Name = "Remember me?")]
+            [Display(Name = "RememberMe")]
             public bool RememberMe { get; set; }
         }
 

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -57,19 +57,19 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required]
+            [Required(ErrorMessage = "ValidationRequired")]
             [DataType(DataType.Password)]
-            [Display(Name = "Aktuelles Passwort")]
+            [Display(Name = "CurrentPassword")]
             public string OldPassword { get; set; }
 
             /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required]
-            [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+            [Required(ErrorMessage = "ValidationRequired")]
+            [StringLength(100, ErrorMessage = "ValidationStringLength", MinimumLength = 6)]
             [DataType(DataType.Password)]
-            [Display(Name = "Neues Passwort")]
+            [Display(Name = "NewPassword")]
             public string NewPassword { get; set; }
 
             /// <summary>
@@ -77,8 +77,8 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account.Manage
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
             [DataType(DataType.Password)]
-            [Display(Name = "Neues Passwort bestätigen")]
-            [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
+            [Display(Name = "ConfirmNewPassword")]
+            [Compare("NewPassword", ErrorMessage = "ValidationNewPasswordMatch")]
             public string ConfirmPassword { get; set; }
         }
 

--- a/PaceLetics.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/PaceLetics.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -84,17 +84,17 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
             /// This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             /// directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required]
-            [RegularExpression(@"[A-Za-z0-9._-]+", ErrorMessage = "Der Benutzername darf nur Buchstaben, Zahlen, Punkte, Unterstriche und Bindestriche enthalten.")]
+            [Required(ErrorMessage = "ValidationRequired")]
+            [RegularExpression(@"[A-Za-z0-9._-]+", ErrorMessage = "ValidationUserNameCharacters")]
             [DataType(DataType.Text)]
-            [Display(Name = "Benutzername")]
+            [Display(Name = "Username")]
             public string Name { get; set; }
 
             /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [EmailAddress]
+            [EmailAddress(ErrorMessage = "ValidationEmail")]
             [Display(Name = "Email")]
             public string Email { get; set; }
 
@@ -102,8 +102,8 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required]
-            [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+            [Required(ErrorMessage = "ValidationRequired")]
+            [StringLength(100, ErrorMessage = "ValidationStringLength", MinimumLength = 6)]
             [DataType(DataType.Password)]
             [Display(Name = "Password")]
             public string Password { get; set; }
@@ -113,8 +113,8 @@ namespace PaceLetics.Web.Areas.Identity.Pages.Account
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
             [DataType(DataType.Password)]
-            [Display(Name = "Confirm password")]
-            [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+            [Display(Name = "ConfirmPassword")]
+            [Compare("Password", ErrorMessage = "ValidationPasswordMatch")]
             public string ConfirmPassword { get; set; }
         }
 

--- a/PaceLetics.Web/Pages/Athletes/Dashboard.razor
+++ b/PaceLetics.Web/Pages/Athletes/Dashboard.razor
@@ -14,7 +14,6 @@
 @inject AuthenticationStateProvider GetAuthenticationStateAsync
 @inject IStringLocalizer<Dashboard> L
 @inject ITrainingPlanService TrainingPlanService
-@inject IAthleteMessageFeedService AthleteMessageFeedService
 
 <PageTitle>@L["PageTitle"]</PageTitle>
 
@@ -51,23 +50,11 @@
                                          Accent="green"
                                          Href="/Athletes/trainingplanpage" />
                 </MudItem>
-
-                <MudItem xs="12" sm="6" lg="4">
-                    <DashboardMetricTile Label="@L["Metric_Messages"]"
-                                         Value="@_messages.Count.ToString()"
-                                         Detail="@L["Metric_MessagesDetail"]"
-                                         Icon="@Icons.Material.Filled.NotificationsActive"
-                                         Accent="orange" />
-                </MudItem>
             </MudGrid>
 
             <MudGrid Spacing="3">
                 <MudItem xs="12">
 					<DashboardNextTrainingSessionTile Session="_nextSession" />
-                </MudItem>
-
-                <MudItem xs="12">
-                        <DashboardMessageFeed Messages="_messages" />
                 </MudItem>
             </MudGrid>
         </MudStack>
@@ -83,7 +70,6 @@
     bool _isLoading = true;
     AthleteModel? Athlete;
     string _name = String.Empty;
-    IReadOnlyList<AthleteMessage> _messages = Array.Empty<AthleteMessage>();
     IReadOnlyList<TrainingPlan> _trainingPlans = Array.Empty<TrainingPlan>();
     TrainingPlan? _activePlan;
     TrainingSession? _nextSession;
@@ -111,13 +97,6 @@
         _activePlan = ResolveActivePlan(_trainingPlans, Athlete);
         _nextSession = ResolveNextSession(_activePlan, _trainingPlans);
         _referenceResult = Athlete?.ActiveReferenceResult;
-        _messages = AthleteMessageFeedService.Build(new AthleteMessageContext(
-            Athlete?.AthleteId ?? Athlete?.Id,
-            _name,
-            Athlete?.Vdot ?? 0,
-            Athlete?.ActiveReferenceResult,
-            Athlete?.SelectedTrainingPlanId,
-            DateTime.Today));
         _isLoading = false;
         await base.OnInitializedAsync();
     }

--- a/PaceLetics.Web/Pages/Athletes/Konfigurations.razor
+++ b/PaceLetics.Web/Pages/Athletes/Konfigurations.razor
@@ -1,6 +1,12 @@
 @inject IStringLocalizer<Konfigurations> L
 
-<h3>@L["Title"]</h3>
+<PageTitle>@L["Title"]</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
+    <PageHeader Title="@L["Title"]" />
+
+    <MudDivider Class="my-4" />
+</MudContainer>
 
 @code {
 

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -153,7 +153,7 @@
                         .OrderBy(publication => publication.TrainingPlanId)
                         .ToList();
 
-                    <MudPaper Elevation="1" Class="pa-4">
+                    <MudPaper Elevation="0" Class="pa-4 pl-course-detail">
                         <MudStack Spacing="3">
                             <MudStack Spacing="1" Style="min-width:0;">
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1" Style="flex-wrap:wrap;">

--- a/PaceLetics.Web/Pages/Athletes/TrainingIntervalls.razor
+++ b/PaceLetics.Web/Pages/Athletes/TrainingIntervalls.razor
@@ -1,4 +1,4 @@
-@page "/Athletes/trainingintervalls"
+ï»¿@page "/Athletes/trainingintervalls"
 
 @using AthleteDataAccessLibrary.Contracts
 @using MudBlazor
@@ -44,23 +44,62 @@
             }
             else
             {
-                <MudPaper Class="pa-4 rounded-xl" Elevation="2">
-                    <MudStack Spacing="2">
+                <MudPaper Class="pa-4 pl-training-panel" Elevation="0">
+                    <MudStack Spacing="3">
 
-                        <MudStack Spacing="1">
-                            <MudText Typo="Typo.h5" Class="fw-bold">
-                                @_currentTraining.Name
-                            </MudText>
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                ID: @_currentTraining.Id · @L["PlannedOn"] @_currentTraining.Date.ToString("dd.MM.yyyy")
-                            </MudText>
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="min-width:0;">
+                                <div class="pl-training-icon">
+                                    <MudIcon Icon="@Icons.Material.Filled.Timeline" Size="Size.Medium" />
+                                </div>
+
+                                <MudStack Spacing="0" Style="min-width:0;">
+                                    <MudText Typo="Typo.h6">
+                                        @_currentTraining.Name
+                                    </MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        ID: @_currentTraining.Id / @L["PlannedOn"] @_currentTraining.Date.ToString("dd.MM.yyyy")
+                                    </MudText>
+                                </MudStack>
+                            </MudStack>
+                        </MudStack>
+
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                            <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
+                                @_currentTraining.Sets Set(s)
+                            </MudChip>
+                            <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">
+                                @($"{_currentTraining.TotalDistance / 1000.0:0.0} km")
+                            </MudChip>
+                            <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">
+                                @_currentTraining.Distances.Count Intervall(e)
+                            </MudChip>
                         </MudStack>
 
                         <MudDivider />
 
-           
-                        <MudDivider />
+                        <MudStack Spacing="0">
+                            @foreach (var row in TableRows)
+                            {
+                                <div class="@GetIntervalRowClass(row)">
+                                    <div class="pl-training-icon">
+                                        <MudIcon Icon="@(row.IsPause ? Icons.Material.Filled.SelfImprovement : Icons.Material.Filled.Speed)"
+                                                 Size="Size.Small" />
+                                    </div>
 
+                                    <MudStack Spacing="0" Style="min-width:0;">
+                                        <MudText Typo="Typo.body2">@GetRowTitle(row)</MudText>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                            @(row.IsPause ? "Recovery" : "Intervall")
+                                        </MudText>
+                                    </MudStack>
+
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                        @($"{GetRowDistance(row)} m")
+                                    </MudText>
+                                </div>
+                            }
+                        </MudStack>
                     </MudStack>
                 </MudPaper>
             }
@@ -75,16 +114,8 @@
     private AthleteModel? _athlete;
     private IntervallSession? _currentTraining;
 
-    /// <summary>
-    /// Indizes der Intervalle für das aktuelle Training, für das MudTable-Items-Binding.
-    /// </summary>
-    private IEnumerable<int> IntervalIndices =>
-        _currentTraining is null
-            ? Enumerable.Empty<int>()
-            : Enumerable.Range(0, _currentTraining.Distances.Count);
-
-
     private record TableRow(bool IsPause, int Index);
+
     private IEnumerable<TableRow> TableRows =>
         Enumerable.Range(0, _currentTraining!.Distances.Count)
             .SelectMany(i =>
@@ -94,6 +125,27 @@
                     list.Add(new(true, i));
                 return list;
             });
+
+    private string GetIntervalRowClass(TableRow row)
+    {
+        return row.IsPause
+            ? "pl-interval-row pl-interval-row-muted"
+            : "pl-interval-row";
+    }
+
+    private int GetRowDistance(TableRow row)
+    {
+        return row.IsPause
+            ? _currentTraining!.Recovery[row.Index]
+            : _currentTraining!.Distances[row.Index];
+    }
+
+    private string GetRowTitle(TableRow row)
+    {
+        return row.IsPause
+            ? "Pause"
+            : _currentTraining!.PaceKeys[row.Index];
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/PaceLetics.Web/Pages/Athletes/TrainingPlanPage.razor
+++ b/PaceLetics.Web/Pages/Athletes/TrainingPlanPage.razor
@@ -1,4 +1,4 @@
-@page "/Athletes/trainingplanpage"
+ï»¿@page "/Athletes/trainingplanpage"
 @using AthleteDataAccessLibrary.Contracts
 @using PaceLetics.AthleteModule.CodeBase.Models
 @using PaceLetics.CoreModule.Infrastructure.Models
@@ -42,17 +42,19 @@
     }
     else
     {
-        <MudSelect T="string" Label="@L["SelectPlan"]"
-                   Value="_selectedPlanId"
-                   ValueChanged="@(async (string id) => await OnPlanChanged(id))"
-                   Dense="true"
-                   Variant="Variant.Outlined"
-                   Immediate="true">
-            @foreach (var p in _plans)
-            {
-                <MudSelectItem T="string" Value="@p.Id">@p.Name</MudSelectItem>
-            }
-        </MudSelect>
+        <MudPaper Class="pa-3 pl-panel" Elevation="0">
+            <MudSelect T="string" Label="@L["SelectPlan"]"
+                       Value="_selectedPlanId"
+                       ValueChanged="@(async (string id) => await OnPlanChanged(id))"
+                       Dense="true"
+                       Variant="Variant.Outlined"
+                       Immediate="true">
+                @foreach (var p in _plans)
+                {
+                    <MudSelectItem T="string" Value="@p.Id">@p.Name</MudSelectItem>
+                }
+            </MudSelect>
+        </MudPaper>
     }
 </MudStack>
 
@@ -81,10 +83,10 @@
                         }
                         else
                         {
-                            <MudPaper Elevation="1" Class="pa-3">
+                            <MudPaper Elevation="0" Class="pa-3 pl-surface-card">
                                 <MudText Typo="Typo.subtitle2">@session.Name</MudText>
                                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                    @session.Date.ToString("dd.MM.yyyy") · @($"{session.Workouts.Count} Workout(s)")
+                                    @session.Date.ToString("dd.MM.yyyy") Â· @($"{session.Workouts.Count} Workout(s)")
                                 </MudText>
                             </MudPaper>
                         }
@@ -127,12 +129,12 @@
                     @_selectedTrainingSession.Date.ToString("dd.MM.yyyy")
                     @if (_resolved is not null)
                     {
-                        @(" · ")
+                        @(" Â· ")
                         @($"{_resolved.TotalDistance / 1000.0:0.0} km")
                     }
                     @if (_selectedTrainingSession.Workouts.Count > 0)
                     {
-                        @(" · ")
+                        @(" Â· ")
                         @($"{_selectedTrainingSession.Workouts.Count} Workout(s)")
                     }
                 </MudText>
@@ -157,7 +159,7 @@
                                 <MudStack Spacing="1">
                                     <MudText Typo="Typo.subtitle2">@(!string.IsNullOrWhiteSpace(workout.Name) ? workout.Name : workout.WorkoutId)</MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        @($"{workout.Sets} Set(s) · {workout.Rounds} Round(s)")
+                                        @($"{workout.Sets} Set(s) Â· {workout.Rounds} Round(s)")
                                     </MudText>
                                 </MudStack>
                             </MudPaper>
@@ -174,7 +176,7 @@
 
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">
                                         @(rs.Segment.Distance > 0 ? $"{rs.Segment.Distance} m" : "-")
-                                        @(" · ")
+                                        @(" Â· ")
                                         @(rs.Pace is null ? "-" : $"{rs.Pace:mm\\:ss}/km")
                                     </MudText>
 
@@ -182,7 +184,7 @@
                                     {
                                         <MudText Typo="Typo.caption" Color="Color.Secondary">
                                             @(rs.SegmentTime is null ? "" : $"Segment: {rs.SegmentTime:hh\\:mm\\:ss}".Trim())
-                                            @(rs.SegmentTime is not null && rs.LapTime is not null ? " · " : "")
+                                            @(rs.SegmentTime is not null && rs.LapTime is not null ? " Â· " : "")
                                             @(rs.LapTime is null ? "" : $"Lap: {rs.LapTime:mm\\:ss}")
                                         </MudText>
                                     }
@@ -232,7 +234,7 @@
 
             _plans = (await TrainingPlanService.LoadTrainingPlansForUserAsync(userID)).ToList();
 
-            // Auswahl: gespeicherter Plan wenn vorhanden (Server-Athlete.SelectedTrainingPlanId), sonst Browser localStorage, sonst nächster oder erster Plan
+            // Auswahl: gespeicherter Plan wenn vorhanden (Server-Athlete.SelectedTrainingPlanId), sonst Browser localStorage, sonst nÃ¤chster oder erster Plan
             string? storedPlan = null;
 
             if (_athlete?.SelectedTrainingPlanId is not null && _plans.Any(p => p.Id == _athlete.SelectedTrainingPlanId))
@@ -260,7 +262,7 @@
                 }
                 else
                 {
-                    // nächster Plan finden
+                    // nÃ¤chster Plan finden
                     var today = DateTime.Today;
                     var next = _plans
                         .Where(p => p.Sessions.Any())
@@ -276,7 +278,7 @@
                 }
             }
 
-            // Setze aktuell gewählten Plan
+            // Setze aktuell gewÃ¤hlten Plan
             Plan = _plans.FirstOrDefault(p => p.Id == _selectedPlanId);
 
             if (Plan is not null)

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -56,7 +56,11 @@ builder.Services.AddDefaultIdentity<ApplicationUser>(
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddRazorPages()
     .AddViewLocalization()
-    .AddDataAnnotationsLocalization();
+    .AddDataAnnotationsLocalization(options =>
+    {
+        options.DataAnnotationLocalizerProvider = (modelType, factory) =>
+            factory.Create(modelType.DeclaringType ?? modelType);
+    });
 builder.Services.AddServerSideBlazor();
 builder.Services.AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuthenticationStateProvider<ApplicationUser>>();
 var webRootPath = !string.IsNullOrWhiteSpace(builder.Environment.WebRootPath)

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.ar.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>إشعار قانوني</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>معلومات وفقًا للمادة 5 من قانون الخدمات الرقمية الألماني (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>مزود الخدمة</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>ألمانيا</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>الهاتف</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>البريد الإلكتروني</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>المسؤول عن المحتوى</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>الشخص المسؤول عن محتوى هذا الموقع هو</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>معلومات التسجيل والضرائب</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>رقم تعريف ضريبة القيمة المضافة</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>غير مخصص أو غير قابل للتطبيق.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>قيد السجل التجاري</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>لا يوجد قيد في السجل التجاري.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>تسوية نزاعات المستهلكين</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>مزود الخدمة غير مستعد وغير ملزم بالمشاركة في إجراءات تسوية النزاعات أمام هيئة تحكيم للمستهلكين، ما لم يكن هناك التزام قانوني إلزامي.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>المسؤولية عن المحتوى والروابط</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>تم إعداد المحتوى على هذا الموقع بعناية معقولة. وبصفته مزود خدمة، يكون المزود مسؤولًا عن محتواه الخاص وفقًا للقوانين العامة.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>قد يحتوي هذا الموقع على روابط لمواقع خارجية تابعة لأطراف ثالثة. لا يملك المزود أي تأثير على محتواها الحالي أو المستقبلي. تتم مراجعة الصفحات المرتبطة عند إنشاء الرابط بحثًا عن انتهاكات قانونية واضحة. وإذا أصبحت الانتهاكات معروفة، فستتم إزالة هذه الروابط فورًا.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>حقوق النشر</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>يخضع المحتوى والأعمال التي أنشأها المزود على هذا الموقع لقانون حقوق النشر الألماني. يتطلب النسخ أو التحرير أو التوزيع أو أي استخدام يتجاوز حدود حقوق النشر موافقة مسبقة، ما لم يكن الاستخدام مسموحًا به صراحة بموجب القانون.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>الخصوصية</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>لا يحل هذا الإشعار القانوني محل سياسة الخصوصية. تتوفر معلومات معالجة البيانات الشخصية في سياسة الخصوصية لهذا الموقع.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.da.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Juridisk meddelelse</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Oplysninger i henhold til § 5 i den tyske lov om digitale tjenester (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Tjenesteudbyder</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Tyskland</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Ansvarlig for indhold</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>Den person, der er ansvarlig for indholdet på dette website, er</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Register- og skatteoplysninger</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Momsregistreringsnummer</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Ikke tildelt eller ikke relevant.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Registrering i handelsregister</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Ingen registrering i handelsregister.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Forbrugerklageløsning</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Tjenesteudbyderen er hverken villig eller forpligtet til at deltage i tvistbilæggelse ved et forbrugerklagenævn, medmindre en obligatorisk lovpligtig forpligtelse gælder.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Ansvar for indhold og links</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Indholdet på dette website er udarbejdet med rimelig omhu. Som tjenesteudbyder er udbyderen ansvarlig for eget indhold i henhold til de almindelige love.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Dette website kan indeholde links til eksterne tredjepartswebsites. Udbyderen har ingen indflydelse på deres nuværende eller fremtidige indhold. Linkede sider kontrolleres for åbenlyse juridiske overtrædelser, når linket oprettes. Hvis juridiske overtrædelser bliver kendt, fjernes sådanne links straks.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Ophavsret</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Indholdet og værkerne oprettet af udbyderen på dette website er underlagt tysk ophavsret. Kopiering, redigering, distribution eller enhver brug ud over ophavsrettens grænser kræver forudgående samtykke, medmindre brugen udtrykkeligt er tilladt ved lov.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Privatliv</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Denne juridiske meddelelse erstatter ikke privatlivspolitikken. Oplysninger om behandling af personoplysninger findes i privatlivspolitikken på dette website.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.es.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Aviso legal</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Información conforme al artículo 5 de la Ley alemana de servicios digitales (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Proveedor de servicios</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Alemania</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Teléfono</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>Correo electrónico</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Responsable del contenido</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>La persona responsable del contenido de este sitio web es</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Información registral y fiscal</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Número de identificación fiscal IVA</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>No asignado o no aplicable.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Inscripción en el registro mercantil</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Sin inscripción en el registro mercantil.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Resolución de litigios de consumo</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>El proveedor de servicios no está dispuesto ni obligado a participar en procedimientos de resolución de disputas ante una junta de arbitraje de consumo, salvo que exista una obligación legal imperativa.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Responsabilidad por contenido y enlaces</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>El contenido de este sitio web se ha preparado con cuidado razonable. Como proveedor de servicios, el proveedor es responsable de su propio contenido de acuerdo con las leyes generales.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Este sitio web puede contener enlaces a sitios externos de terceros. El proveedor no tiene influencia sobre su contenido actual o futuro. Las páginas enlazadas se revisan al crear el enlace para detectar infracciones legales evidentes. Si se conocen infracciones, dichos enlaces se eliminarán rápidamente.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Derechos de autor</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>El contenido y las obras creadas por el proveedor en este sitio están sujetos a la legislación alemana de derechos de autor. La reproducción, edición, distribución o cualquier uso fuera de los límites del derecho de autor requiere consentimiento previo, salvo que la ley lo permita expresamente.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Privacidad</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Este aviso legal no sustituye a la política de privacidad. La información sobre el tratamiento de datos personales se proporciona en la política de privacidad de este sitio web.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.fa.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>اطلاعیه حقوقی</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>اطلاعات مطابق ماده ۵ قانون خدمات دیجیتال آلمان (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>ارائه‌دهنده خدمات</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>آلمان</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>تلفن</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>ایمیل</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>مسئول محتوا</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>شخص مسئول محتوای این وب‌سایت است</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>اطلاعات ثبت و مالیات</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>شماره شناسایی مالیات بر ارزش افزوده</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>اختصاص داده نشده یا قابل اعمال نیست.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>ثبت در دفتر تجاری</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>ثبت تجاری وجود ندارد.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>حل اختلاف مصرف‌کننده</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>ارائه‌دهنده خدمات، مگر در صورت وجود الزام قانونی اجباری، نه مایل و نه موظف به شرکت در روند حل اختلاف نزد هیئت داوری مصرف‌کنندگان است.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>مسئولیت محتوا و پیوندها</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>محتوای این وب‌سایت با دقت معقول تهیه شده است. ارائه‌دهنده خدمات طبق قوانین عمومی مسئول محتوای خود است.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>این وب‌سایت ممکن است شامل پیوندهایی به وب‌سایت‌های خارجی شخص ثالث باشد. ارائه‌دهنده هیچ تأثیری بر محتوای فعلی یا آینده آن‌ها ندارد. هنگام ایجاد پیوند، صفحات پیوندشده برای تخلفات قانونی آشکار بررسی می‌شوند. اگر تخلفات قانونی شناخته شود، این پیوندها سریعاً حذف خواهند شد.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>حق نشر</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>محتوا و آثار ایجادشده توسط ارائه‌دهنده در این وب‌سایت تابع قانون حق نشر آلمان است. تکثیر، ویرایش، توزیع یا هر استفاده فراتر از حدود حق نشر نیازمند رضایت قبلی است، مگر آن‌که قانون صراحتاً اجازه داده باشد.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>حریم خصوصی</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>این اطلاعیه حقوقی جایگزین سیاست حریم خصوصی نیست. اطلاعات مربوط به پردازش داده‌های شخصی در سیاست حریم خصوصی این وب‌سایت ارائه شده است.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.fr.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Mentions légales</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Informations conformément à l’article 5 de la loi allemande sur les services numériques (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Prestataire de service</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Allemagne</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Téléphone</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Responsable du contenu</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>La personne responsable du contenu de ce site est</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Informations d’enregistrement et fiscales</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Numéro d’identification TVA</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Non attribué ou non applicable.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Inscription au registre du commerce</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Aucune inscription au registre du commerce.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Résolution des litiges de consommation</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Le prestataire n’est ni disposé ni obligé de participer à une procédure de règlement des litiges devant une commission d’arbitrage des consommateurs, sauf obligation légale impérative.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Responsabilité relative au contenu et aux liens</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Le contenu de ce site a été préparé avec un soin raisonnable. En tant que prestataire de services, le fournisseur est responsable de son propre contenu conformément aux lois générales.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Ce site peut contenir des liens vers des sites externes de tiers. Le fournisseur n’a aucune influence sur leur contenu actuel ou futur. Les pages liées sont vérifiées lors de la création du lien afin de détecter d’éventuelles violations manifestes. Si de telles violations sont connues, les liens seront retirés rapidement.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Droit d’auteur</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Les contenus et œuvres créés par le fournisseur sur ce site sont soumis au droit d’auteur allemand. Toute reproduction, modification, distribution ou utilisation au-delà des limites du droit d’auteur nécessite un consentement préalable, sauf autorisation expresse de la loi.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Confidentialité</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Ces mentions légales ne remplacent pas la politique de confidentialité. Les informations relatives au traitement des données personnelles figurent dans la politique de confidentialité de ce site.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.ru.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Правовая информация</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Информация согласно разделу 5 немецкого Закона о цифровых услугах (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Поставщик услуги</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Германия</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Телефон</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Ответственный за контент</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>Лицо, ответственное за содержание этого сайта:</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Регистрационная и налоговая информация</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Номер плательщика НДС</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Не назначено или не применимо.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Запись в торговом реестре</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Записи в торговом реестре нет.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Урегулирование потребительских споров</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Поставщик услуги не готов и не обязан участвовать в процедурах урегулирования споров в органе потребительского арбитража, если только не применяется обязательное законодательное требование.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Ответственность за контент и ссылки</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Содержание этого сайта подготовлено с разумной тщательностью. Как поставщик услуги, провайдер несет ответственность за собственный контент в соответствии с общими законами.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Этот сайт может содержать ссылки на внешние сайты третьих лиц. Поставщик не влияет на их текущее или будущее содержание. Связанные страницы проверяются на очевидные правовые нарушения при создании ссылки. Если такие нарушения станут известны, ссылки будут оперативно удалены.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Авторское право</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Контент и материалы, созданные поставщиком на этом сайте, защищены немецким законодательством об авторском праве. Воспроизведение, редактирование, распространение или любое использование за пределами авторского права требует предварительного согласия, если использование прямо не разрешено законом.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Конфиденциальность</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Эта правовая информация не заменяет политику конфиденциальности. Информация об обработке персональных данных приведена в политике конфиденциальности этого сайта.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.tr.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Yasal bildirim</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Alman Dijital Hizmetler Yasası (Digitale-Dienste-Gesetz, DDG) 5. maddesi uyarınca bilgiler.</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Hizmet sağlayıcı</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Almanya</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-posta</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>İçerikten sorumlu</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>Bu web sitesinin içeriğinden sorumlu kişi</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Kayıt ve vergi bilgileri</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>KDV kimlik numarası</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Atanmamış veya uygulanamaz.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Ticaret sicili kaydı</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Ticaret sicili kaydı yok.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Tüketici uyuşmazlık çözümü</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Zorunlu bir yasal yükümlülük bulunmadıkça hizmet sağlayıcı, bir tüketici tahkim kurulu önündeki uyuşmazlık çözüm süreçlerine katılmaya ne istekli ne de yükümlüdür.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>İçerik ve bağlantılara ilişkin sorumluluk</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Bu web sitesindeki içerik makul özenle hazırlanmıştır. Hizmet sağlayıcı olarak sağlayıcı, genel yasalar uyarınca kendi içeriğinden sorumludur.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Bu web sitesi harici üçüncü taraf web sitelerine bağlantılar içerebilir. Sağlayıcının bu sitelerin mevcut veya gelecekteki içerikleri üzerinde etkisi yoktur. Bağlantı verilen sayfalar oluşturulduklarında açık yasal ihlaller açısından kontrol edilir. Yasal ihlaller öğrenilirse bu bağlantılar derhal kaldırılır.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Telif hakkı</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Bu web sitesinde sağlayıcı tarafından oluşturulan içerik ve çalışmalar Alman telif hakkı yasasına tabidir. Yasaların açıkça izin verdiği durumlar dışında çoğaltma, düzenleme, dağıtım veya telif hakkı sınırlarının ötesindeki her türlü kullanım önceden onay gerektirir.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Gizlilik</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Bu yasal bildirim gizlilik politikasının yerine geçmez. Kişisel verilerin işlenmesine ilişkin bilgiler bu web sitesinin gizlilik politikasında yer alır.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Impressum.zh.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>法律声明</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>根据德国数字服务法（Digitale-Dienste-Gesetz, DDG）第 5 条提供的信息。</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>服务提供者</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>德国</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>电话</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>电子邮件</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>内容负责人</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>本网站内容负责人是</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>登记和税务信息</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>增值税识别号</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>未分配或不适用。</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>商业登记信息</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>无商业登记信息。</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>消费者争议解决</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>除非有强制性法定义务，服务提供者既不愿意也没有义务参与消费者仲裁委员会前的争议解决程序。</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>内容和链接责任</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>本网站内容已尽合理谨慎编制。作为服务提供者，提供者根据一般法律对自己的内容负责。</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>本网站可能包含指向外部第三方网站的链接。提供者无法影响这些网站当前或未来的内容。链接创建时会检查明显的法律违规。如果发现法律违规，这些链接将被及时移除。</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>版权</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>提供者在本网站创建的内容和作品受德国版权法保护。除非法律明确允许，复制、编辑、传播或任何超出版权法范围的使用都需要事先同意。</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>隐私</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>本法律声明不替代隐私政策。有关个人数据处理的信息请见本网站的隐私政策。</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.ar.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>تسجيل الدخول</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>استخدم اسم المستخدم أو عنوان البريد الإلكتروني لتسجيل الدخول.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>اسم المستخدم أو البريد الإلكتروني</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>البريد الإلكتروني</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>كلمة المرور</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>تسجيل الدخول</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>هل نسيت كلمة المرور؟</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>التسجيل كمستخدم جديد</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>إعادة إرسال تأكيد البريد الإلكتروني</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>مرحبًا بك في PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>رفيقك الشخصي في الجري. تتبع نتائج سباقاتك، واحسب سرعات التدريب، واتبع خططًا منظمة مناسبة لمستوى لياقتك.</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>مناطق سرعة مخصصة بناءً على أدائك في السباقات</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>خطط تدريب منظمة لأهدافك</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>تمارين موجهة للقوة والحركة</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>تتبع تقدمك بمرور الوقت</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.da.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Log ind</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>Brug dit brugernavn eller din e-mailadresse til at logge ind.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Brugernavn eller e-mail</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Adgangskode</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>Login</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>Har du glemt din adgangskode?</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>Registrer som ny bruger</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>Send e-mailbekræftelse igen</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Velkommen til PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Din personlige løbemakker. Følg dine løbsresultater, beregn træningstempoer, og følg strukturerede træningsplaner tilpasset dit niveau.</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Personlige tempozoner baseret på dine løbspræstationer</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Strukturerede træningsplaner til dine mål</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Guidede træninger til styrke og mobilitet</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>Følg din fremgang over tid</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.es.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Iniciar sesión</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>Usa tu nombre de usuario o correo electrónico para iniciar sesión.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Nombre de usuario o correo electrónico</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Correo electrónico</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>Inicio de sesión</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>¿Has olvidado tu contraseña?</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>Registrarse como nuevo usuario</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>Reenviar confirmación de correo electrónico</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Bienvenido a PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Tu compañero personal para correr. Sigue tus resultados, calcula ritmos y usa planes adaptados a tu nivel.</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Zonas de ritmo personalizadas según tus carreras</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Planes de entrenamiento estructurados para tus objetivos</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Entrenamientos guiados de fuerza y movilidad</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>Sigue tu progreso con el tiempo</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.fa.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>ورود</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>برای ورود از نام کاربری یا نشانی ایمیل خود استفاده کنید.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>نام کاربری یا ایمیل</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>ایمیل</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>گذرواژه</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>ورود</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>گذرواژه خود را فراموش کرده‌اید؟</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>ثبت‌نام به عنوان کاربر جدید</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>ارسال دوباره تأیید ایمیل</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>به PaceLetics خوش آمدید</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>همراه شخصی دویدن شما. نتایج مسابقه را دنبال کنید، سرعت تمرین را محاسبه کنید و برنامه‌های متناسب با سطح آمادگی خود را دنبال کنید.</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>محدوده‌های سرعت شخصی‌سازی‌شده بر اساس عملکرد مسابقه شما</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>برنامه‌های تمرینی ساختاریافته برای اهداف شما</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>تمرین‌های راهنمایی‌شده برای قدرت و تحرک</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>پیشرفت خود را در طول زمان دنبال کنید</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.fr.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Se connecter</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>Utilisez votre nom d’utilisateur ou votre e-mail pour vous connecter.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Nom d’utilisateur ou e-mail</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>Connexion</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>Mot de passe oublié ?</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>S’inscrire comme nouvel utilisateur</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>Renvoyer la confirmation par e-mail</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Bienvenue sur PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Votre compagnon de course personnel. Suivez vos résultats, calculez vos allures et suivez des plans adaptés à votre niveau.</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Zones d’allure personnalisées selon vos performances</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Plans d’entraînement structurés pour vos objectifs</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Entraînements guidés pour la force et la mobilité</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>Suivez vos progrès dans le temps</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.ru.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Войти</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>Используйте имя пользователя или email для входа.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Имя пользователя или email</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>Вход</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>Забыли пароль?</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>Зарегистрироваться как новый пользователь</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>Отправить подтверждение email повторно</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Добро пожаловать в PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Ваш личный спутник для бега. Отслеживайте результаты, рассчитывайте тренировочные темпы и следуйте структурированным планам под ваш уровень.</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Персональные зоны темпа на основе ваших результатов</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Структурированные планы тренировок под ваши цели</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Тренировки с сопровождением для силы и мобильности</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>Отслеживайте прогресс со временем</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.tr.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Giriş yap</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>Giriş yapmak için kullanıcı adınızı veya e-posta adresinizi kullanın.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Kullanıcı adı veya e-posta</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-posta</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Şifre</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>Giriş</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>Şifrenizi mi unuttunuz?</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>Yeni kullanıcı olarak kaydol</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>E-posta onayını yeniden gönder</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>PaceLetics’e hoş geldiniz</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Kişisel koşu yol arkadaşınız. Yarış sonuçlarınızı takip edin, antrenman tempolarınızı hesaplayın ve kondisyon seviyenize göre uyarlanmış yapılandırılmış planları izleyin.</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Yarış performanslarınıza göre kişiselleştirilmiş tempo bölgeleri</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Hedefleriniz için yapılandırılmış antrenman planları</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Güç ve mobilite için rehberli antrenmanlar</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>Zaman içinde ilerlemenizi takip edin</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Login.zh.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="LoginPrompt" xml:space="preserve">
+    <value>使用用户名或电子邮件地址登录。</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>用户名或电子邮件</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>电子邮件</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="LoginButton" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="ForgotPassword" xml:space="preserve">
+    <value>忘记密码？</value>
+  </data>
+  <data name="RegisterNewUser" xml:space="preserve">
+    <value>注册为新用户</value>
+  </data>
+  <data name="ResendEmail" xml:space="preserve">
+    <value>重新发送确认邮件</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>欢迎来到 PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>你的个人跑步伙伴。跟踪比赛成绩、计算训练配速，并遵循适合你体能水平的结构化计划。</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>根据你的比赛表现定制配速区间</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>适合目标的结构化训练计划</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>力量与灵活性的引导训练</value>
+  </data>
+  <data name="Feature4" xml:space="preserve">
+    <value>持续跟踪你的进步</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.ar.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>محاولة تسجيل دخول غير صالحة.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>اسم المستخدم أو البريد الإلكتروني</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>كلمة المرور</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>تذكرني؟</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>يرجى إدخال {0}.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.da.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Ugyldigt loginforsøg.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Brugernavn eller e-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Adgangskode</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Husk mig?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Indtast {0}.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.de.resx
@@ -1,8 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="InvalidLoginAttempt" xml:space="preserve"><value>Ungueltiger Anmeldeversuch.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Ungueltiger Anmeldeversuch.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Benutzername oder E-Mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Angemeldet bleiben?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Bitte gib {0} ein.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.en.resx
@@ -1,8 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="InvalidLoginAttempt" xml:space="preserve"><value>Invalid login attempt.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Invalid login attempt.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Username or email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Remember me?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Please enter {0}.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.es.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Intento de inicio de sesión no válido.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Nombre de usuario o correo electrónico</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>¿Recordarme?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Introduce {0}.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.fa.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>تلاش ورود نامعتبر است.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>نام کاربری یا ایمیل</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>گذرواژه</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>مرا به خاطر بسپار؟</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>لطفاً {0} را وارد کنید.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.fr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Tentative de connexion invalide.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Nom d’utilisateur ou e-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Se souvenir de moi ?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Veuillez saisir {0}.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.resx
@@ -1,8 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="InvalidLoginAttempt" xml:space="preserve"><value>Invalid login attempt.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Invalid login attempt.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Benutzername oder E-Mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Angemeldet bleiben?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Bitte gib {0} ein.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.ru.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Недействительная попытка входа.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Имя пользователя или email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Запомнить меня?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Введите {0}.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.tr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>Geçersiz giriş denemesi.</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>Kullanıcı adı veya e-posta</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Şifre</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Beni hatırla?</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Lütfen {0} girin.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/LoginModel.zh.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="InvalidLoginAttempt" xml:space="preserve">
+    <value>登录尝试无效。</value>
+  </data>
+  <data name="UserNameOrEmail" xml:space="preserve">
+    <value>用户名或电子邮件</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>记住我？</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>请输入{0}。</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.ar.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>تغيير كلمة المرور</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>أدخل كلمة المرور الحالية.</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>أدخل كلمة المرور الجديدة.</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>أكّد كلمة المرور الجديدة.</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>إرسال</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.da.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Skift adgangskode</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>Indtast nuværende adgangskode.</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>Indtast ny adgangskode.</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>Bekræft ny adgangskode.</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Send</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.es.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Cambiar contraseña</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>Introduce la contraseña actual.</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>Introduce la nueva contraseña.</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>Confirma la nueva contraseña.</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.fa.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>تغییر گذرواژه</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>گذرواژه فعلی را وارد کنید.</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>گذرواژه جدید را وارد کنید.</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>گذرواژه جدید را تأیید کنید.</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>ارسال</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.fr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Changer le mot de passe</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>Saisissez le mot de passe actuel.</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>Saisissez le nouveau mot de passe.</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>Confirmez le nouveau mot de passe.</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Envoyer</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.ru.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Изменить пароль</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>Введите текущий пароль.</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>Введите новый пароль.</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>Подтвердите новый пароль.</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Отправить</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.tr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Şifreyi değiştir</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>Mevcut şifreyi girin.</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>Yeni şifreyi girin.</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>Yeni şifreyi onaylayın.</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Gönder</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePassword.zh.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>更改密码</value>
+  </data>
+  <data name="OldPasswordPlaceholder" xml:space="preserve">
+    <value>输入当前密码。</value>
+  </data>
+  <data name="NewPasswordPlaceholder" xml:space="preserve">
+    <value>输入新密码。</value>
+  </data>
+  <data name="ConfirmPasswordPlaceholder" xml:space="preserve">
+    <value>确认新密码。</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>提交</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.ar.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>تم تغيير كلمة المرور الخاصة بك.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>كلمة المرور الحالية</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>كلمة المرور الجديدة</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>تأكيد كلمة المرور الجديدة</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>يرجى إدخال {0}.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>يجب أن يكون {0} بطول لا يقل عن {2} ولا يزيد عن {1} حرفًا.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>كلمة المرور الجديدة وتأكيدها غير متطابقين.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.da.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Din adgangskode er blevet ændret.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Nuværende adgangskode</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>Ny adgangskode</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Bekræft ny adgangskode</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Indtast {0}.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} skal være mindst {2} og højst {1} tegn langt.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>Den nye adgangskode og bekræftelsen stemmer ikke overens.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.de.resx
@@ -1,8 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="PasswordChanged" xml:space="preserve"><value>Ein neues Passwort wurde vergeben.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Ein neues Passwort wurde vergeben.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Aktuelles Passwort</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>Neues Passwort</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Neues Passwort bestätigen</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Bitte gib {0} ein.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} muss mindestens {2} und höchstens {1} Zeichen lang sein.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>Neues Passwort und Passwortbestätigung stimmen nicht überein.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.en.resx
@@ -1,8 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="PasswordChanged" xml:space="preserve"><value>Your password has been changed.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Your password has been changed.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Current password</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>New password</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Confirm new password</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Please enter {0}.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} must be at least {2} and at most {1} characters long.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>The new password and confirmation password do not match.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.es.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Tu contraseña se ha cambiado.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Contraseña actual</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>Nueva contraseña</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Confirmar nueva contraseña</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Introduce {0}.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} debe tener al menos {2} y como máximo {1} caracteres.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>La nueva contraseña y la confirmación no coinciden.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.fa.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>گذرواژه شما تغییر کرد.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>گذرواژه فعلی</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>گذرواژه جدید</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>تأیید گذرواژه جدید</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>لطفاً {0} را وارد کنید.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} باید حداقل {2} و حداکثر {1} نویسه داشته باشد.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>گذرواژه جدید و تأیید آن مطابقت ندارند.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.fr.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Votre mot de passe a été modifié.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Mot de passe actuel</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>Nouveau mot de passe</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Confirmer le nouveau mot de passe</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Veuillez saisir {0}.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} doit contenir au moins {2} et au plus {1} caractères.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>Le nouveau mot de passe et sa confirmation ne correspondent pas.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.resx
@@ -1,8 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="PasswordChanged" xml:space="preserve"><value>Your password has been changed.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Your password has been changed.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Aktuelles Passwort</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>Neues Passwort</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Neues Passwort bestätigen</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Bitte gib {0} ein.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} muss mindestens {2} und höchstens {1} Zeichen lang sein.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>Neues Passwort und Passwortbestätigung stimmen nicht überein.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.ru.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Ваш пароль изменен.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Текущий пароль</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>Новый пароль</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Подтверждение нового пароля</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Введите {0}.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} должен содержать не менее {2} и не более {1} символов.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>Новый пароль и подтверждение пароля не совпадают.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.tr.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>Şifreniz değiştirildi.</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>Mevcut şifre</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>Yeni şifre</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>Yeni şifreyi onayla</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Lütfen {0} girin.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} en az {2} ve en fazla {1} karakter uzunluğunda olmalıdır.</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>Yeni şifre ve şifre onayı eşleşmiyor.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/ChangePasswordModel.zh.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PasswordChanged" xml:space="preserve">
+    <value>你的密码已更改。</value>
+  </data>
+  <data name="CurrentPassword" xml:space="preserve">
+    <value>当前密码</value>
+  </data>
+  <data name="NewPassword" xml:space="preserve">
+    <value>新密码</value>
+  </data>
+  <data name="ConfirmNewPassword" xml:space="preserve">
+    <value>确认新密码</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>请输入{0}。</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0}长度必须至少为 {2} 个字符，最多为 {1} 个字符。</value>
+  </data>
+  <data name="ValidationNewPasswordMatch" xml:space="preserve">
+    <value>新密码和确认密码不匹配。</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.ar.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>حذف بياناتي</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>تحذير، سيتم حذف جميع البيانات! لا يمكن استرداد البيانات!</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>يرجى إدخال كلمة المرور.</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>احذفها!</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.da.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Slet mine data</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Advarsel, alle data slettes! Dataene kan ikke gendannes!</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>Indtast venligst din adgangskode.</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>Slet det!</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.es.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Eliminar mis datos</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Advertencia: se eliminarán todos los datos. No se podrán recuperar.</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>Introduce tu contraseña.</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>¡Eliminar!</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.fa.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>حذف داده‌های من</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>هشدار، همه داده‌ها حذف می‌شوند! داده‌ها قابل بازیابی نیستند!</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>لطفاً گذرواژه خود را وارد کنید.</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>حذف کن!</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.fr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Supprimer mes données</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Attention, toutes les données seront supprimées ! Elles ne pourront pas être récupérées !</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>Veuillez saisir votre mot de passe.</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>Supprimer !</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.ru.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Удалить мои данные</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Внимание, все данные будут удалены! Восстановить их нельзя!</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>Введите пароль.</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>Удалить!</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.tr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Verilerimi sil</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Uyarı, tüm veriler silinecek! Veriler geri getirilemez!</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>Lütfen şifrenizi girin.</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>Sil!</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalData.zh.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>删除我的数据</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>警告，所有数据都将被删除！数据无法恢复！</value>
+  </data>
+  <data name="PasswordPlaceholder" xml:space="preserve">
+    <value>请输入密码。</value>
+  </data>
+  <data name="DeleteButton" xml:space="preserve">
+    <value>删除！</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.ar.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>كلمة المرور غير صحيحة.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.da.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>Forkert adgangskode.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>Contraseña incorrecta.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.fa.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>گذرواژه نادرست است.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.fr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>Mot de passe incorrect.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.ru.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>Неверный пароль.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.tr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>Şifre yanlış.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DeletePersonalDataModel.zh.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="IncorrectPassword" xml:space="preserve">
+    <value>密码不正确。</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.ar.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>تنزيل البيانات</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.da.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Download data</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Descargar datos</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.fa.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>دانلود داده‌ها</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.fr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Télécharger les données</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.ru.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Скачать данные</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.tr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Verileri indir</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/DownloadPersonalData.zh.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>下载数据</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.ar.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>إدارة البريد الإلكتروني</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>أدخل عنوان البريد الإلكتروني.</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>إرسال بريد التحقق</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>إرسال</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.da.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Administrer e-mail</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>Indtast e-mailadresse.</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>Send bekræftelsesmail</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Send</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.es.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Gestionar correo electrónico</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>Introduce la dirección de correo electrónico.</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>Enviar correo de verificación</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.fa.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>مدیریت ایمیل</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>نشانی ایمیل را وارد کنید.</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>ارسال ایمیل تأیید</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>ارسال</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.fr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Gérer l’e-mail</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>Saisissez l’adresse e-mail.</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>Envoyer l’e-mail de vérification</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Envoyer</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.ru.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Управление email</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>Введите адрес email.</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>Отправить письмо подтверждения</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Отправить</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.tr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>E-postayı yönet</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>E-posta adresini girin.</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>Doğrulama e-postası gönder</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Gönder</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/Email.zh.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>管理电子邮件</value>
+  </data>
+  <data name="EmailPlaceholder" xml:space="preserve">
+    <value>输入电子邮件地址。</value>
+  </data>
+  <data name="SendVerification" xml:space="preserve">
+    <value>发送验证邮件</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>提交</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.ar.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>أكّد بريدك الإلكتروني</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>يرجى تأكيد حسابك عبر &lt;a href='{0}'&gt;النقر هنا&lt;/a&gt;.</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>تم إرسال التأكيد. يرجى التحقق من بريدك الإلكتروني.</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>هذا هو العنوان نفسه بالفعل.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.da.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Bekræft din e-mail</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Bekræft din konto ved at &lt;a href='{0}'&gt;klikke her&lt;/a&gt;.</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>Bekræftelse sendt. Tjek din e-mail.</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>Dette er allerede den samme adresse.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.es.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Confirma tu correo electrónico</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Confirma tu cuenta &lt;a href='{0}'&gt;haciendo clic aquí&lt;/a&gt;.</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>Confirmación enviada. Revisa tu correo electrónico.</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>Ya es la misma dirección.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.fa.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>ایمیل خود را تأیید کنید</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>لطفاً با &lt;a href='{0}'&gt;کلیک کردن اینجا&lt;/a&gt; حساب خود را تأیید کنید.</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>تأیید ارسال شد. لطفاً ایمیل خود را بررسی کنید.</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>این همان نشانی است.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.fr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Confirmez votre e-mail</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Veuillez confirmer votre compte en &lt;a href='{0}'&gt;cliquant ici&lt;/a&gt;.</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>Confirmation envoyée. Vérifiez votre e-mail.</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>C’est déjà la même adresse.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.ru.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Подтвердите email</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Подтвердите аккаунт, &lt;a href='{0}'&gt;нажав здесь&lt;/a&gt;.</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>Подтверждение отправлено. Проверьте email.</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>Это уже тот же адрес.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.tr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>E-postanızı onaylayın</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Lütfen &lt;a href='{0}'&gt;buraya tıklayarak&lt;/a&gt; hesabınızı onaylayın.</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>Onay gönderildi. Lütfen e-postanızı kontrol edin.</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>Bu zaten aynı adres.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/EmailModel.zh.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>确认你的电子邮件</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>请&lt;a href='{0}'&gt;点击这里&lt;/a&gt;确认你的账户。</value>
+  </data>
+  <data name="ConfirmationSent" xml:space="preserve">
+    <value>确认邮件已发送。请检查你的邮箱。</value>
+  </data>
+  <data name="EmailUnchanged" xml:space="preserve">
+    <value>这已经是同一个地址。</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.ar.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>البيانات الشخصية</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>يحتوي حسابك على بيانات شخصية. يمكنك هنا تنزيل هذه البيانات أو حذفها.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>تحذير، سيتم حذف جميع البيانات! لا يمكن استرداد البيانات!</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>تنزيل</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>حذف</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.da.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Personlige data</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Din konto indeholder personlige data. Her kan du downloade eller slette disse data.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Advarsel, alle data slettes! Dataene kan ikke gendannes!</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Slet</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.es.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Datos personales</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Tu cuenta contiene datos personales. Aquí puedes descargar o eliminar esos datos.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Advertencia: se eliminarán todos los datos. No se podrán recuperar.</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.fa.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>داده‌های شخصی</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>حساب شما شامل داده‌های شخصی است. اینجا می‌توانید این داده‌ها را دانلود یا حذف کنید.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>هشدار، همه داده‌ها حذف می‌شوند! داده‌ها قابل بازیابی نیستند!</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>دانلود</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>حذف</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.fr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Données personnelles</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Votre compte contient des données personnelles. Vous pouvez les télécharger ou les supprimer ici.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Attention, toutes les données seront supprimées ! Elles ne pourront pas être récupérées !</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Télécharger</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.ru.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Персональные данные</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Ваш аккаунт содержит персональные данные. Здесь вы можете скачать или удалить эти данные.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Внимание, все данные будут удалены! Восстановить их нельзя!</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Скачать</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.tr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Kişisel veriler</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Hesabınız kişisel veriler içerir. Buradan bu verileri indirebilir veya silebilirsiniz.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Uyarı, tüm veriler silinecek! Veriler geri getirilemez!</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>İndir</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Sil</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/PersonalData.zh.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>个人数据</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>你的账户包含个人数据。你可以在这里下载或删除这些数据。</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>警告，所有数据都将被删除！数据无法恢复！</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>下载</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>删除</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.ar.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>إدارة حسابك</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.da.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>Administrer din konto</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>Gestiona tu cuenta</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.fa.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>حساب خود را مدیریت کنید</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.fr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>Gérer votre compte</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.ru.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>Управляйте аккаунтом</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.tr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>Hesabınızı yönetin</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_Layout.zh.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ManageAccount" xml:space="preserve">
+    <value>管理你的账户</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.ar.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>الملف الشخصي</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>البريد الإلكتروني</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>كلمة المرور</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>بياناتي</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.da.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>Profil</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Adgangskode</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>Mine data</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.es.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>Perfil</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Correo electrónico</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>Mis datos</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.fa.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>نمایه</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>ایمیل</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>گذرواژه</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>داده‌های من</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.fr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>Profil</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>Mes données</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.ru.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>Профиль</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>Мои данные</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.tr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>Profil</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-posta</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Şifre</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>Verilerim</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Manage/_ManageNav.zh.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Profile" xml:space="preserve">
+    <value>个人资料</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>电子邮件</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="MyData" xml:space="preserve">
+    <value>我的数据</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.ar.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>سياسة ملفات تعريف الارتباط والخصوصية</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. المقدمة</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>مرحبًا بك في موقعنا. توضح هذه السياسة كيف ولماذا نستخدم ملفات تعريف الارتباط وما البيانات التي نجمعها من خلالها.</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. ما هي ملفات تعريف الارتباط؟</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>ملفات تعريف الارتباط هي ملفات نصية صغيرة تُخزن على جهازك عند زيارة موقع إلكتروني. تُستخدم عادة لجعل المواقع أكثر فاعلية وتزويد مالكي الموقع بالمعلومات.</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. كيف ولماذا نستخدم ملفات تعريف الارتباط؟</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>نستخدم ملفات تعريف الارتباط من أجل:</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>حفظ حالة تسجيل الدخول.</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>تحسين أداء موقعنا وسهولة استخدامه.</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. ما البيانات التي نجمعها؟</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>عند زيارة موقعنا أو التسجيل، قد يتم جمع البيانات التالية:</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>عنوان IP</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>نوع المتصفح وإصداره</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>عنوان البريد الإلكتروني (عند التسجيل أو تسجيل الدخول)</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>اسم المستخدم (عند التسجيل أو تسجيل الدخول)</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>كلمة المرور (عند التسجيل أو تسجيل الدخول)</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>البيانات التي تُجمع أثناء التشغيل (مثل الأنشطة والإعدادات)</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. حذف البيانات</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>عند حذف حسابك، سيتم حذف جميع البيانات المرتبطة به نهائيًا، بما في ذلك عنوان البريد الإلكتروني واسم المستخدم وبيانات التشغيل.</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. كيف يمكنك التحكم في استخدام ملفات تعريف الارتباط؟</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>تتيح معظم المتصفحات التحكم في ملفات تعريف الارتباط. يمكنك ضبط الإعدادات لحظرها أو حذفها. لكن يرجى ملاحظة أن بعض ميزات موقعنا قد لا تعمل بشكل صحيح إذا تم تعطيلها.</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. التغييرات على هذه السياسة</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>قد نقوم بتحديث هذه السياسة من وقت لآخر. ستُنشر التغييرات على هذه الصفحة.</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. الاتصال</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>إذا كانت لديك أسئلة حول سياسة ملفات تعريف الارتباط والخصوصية هذه، يرجى التواصل مع</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.da.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Cookie- og privatlivspolitik</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. Introduktion</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>Velkommen til vores website. Denne politik forklarer, hvordan og hvorfor vi bruger cookies, og hvilke data vi indsamler via dem.</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. Hvad er cookies?</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>Cookies er små tekstfiler, der gemmes på din enhed, når du besøger et website. De bruges ofte til at gøre websites mere funktionelle og give information til ejerne.</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. Hvordan og hvorfor bruger vi cookies?</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>Vi bruger cookies til at:</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>Gem din loginstatus.</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>Forbedre ydeevnen og brugervenligheden af vores site.</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. Hvilke data indsamler vi?</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>Når du besøger vores website eller registrerer dig, kan følgende data blive indsamlet:</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>IP-adresse</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>Browsertype og version</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>E-mailadresse (når du registrerer dig eller logger ind)</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>Brugernavn (når du registrerer dig eller logger ind)</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>Adgangskode (når du registrerer dig eller logger ind)</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>Data indsamlet under brug (f.eks. aktiviteter, indstillinger)</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. Sletning af data</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>Når du sletter din konto, slettes alle data knyttet til kontoen permanent, herunder e-mailadresse, brugernavn og runtime-data.</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. Hvordan kan du styre brugen af cookies?</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>De fleste browsere giver dig mulighed for at styre cookies. Du kan konfigurere indstillinger til at blokere eller slette cookies. Bemærk dog, at nogle funktioner på vores website muligvis ikke fungerer korrekt, hvis cookies er deaktiveret.</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. Ændringer i denne politik</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>Vi kan opdatere denne politik fra tid til anden. Ændringer offentliggøres på denne side.</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. Kontakt</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>Hvis du har spørgsmål om denne cookie- og privatlivspolitik, bedes du kontakte</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.es.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Política de cookies y privacidad</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. Introducción</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>Bienvenido a nuestro sitio web. Esta política explica cómo y por qué usamos cookies y qué datos recopilamos mediante ellas.</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. ¿Qué son las cookies?</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>Las cookies son pequeños archivos de texto almacenados en tu dispositivo cuando visitas un sitio web. Se usan habitualmente para hacer los sitios más funcionales y proporcionar información a sus propietarios.</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. ¿Cómo y por qué usamos cookies?</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>Usamos cookies para:</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>Guardar tu estado de sesión.</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>Mejorar el rendimiento y la usabilidad de nuestro sitio.</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. ¿Qué datos recopilamos?</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>Cuando visitas nuestro sitio web o te registras, se pueden recopilar los siguientes datos:</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>Dirección IP</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>Tipo y versión del navegador</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>Dirección de correo electrónico (al registrarte o iniciar sesión)</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>Nombre de usuario (al registrarte o iniciar sesión)</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>Contraseña (al registrarte o iniciar sesión)</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>Datos recopilados durante el uso (p. ej., actividades, ajustes)</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. Eliminación de datos</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>Cuando eliminas tu cuenta, todos los datos asociados, incluida la dirección de correo electrónico, el nombre de usuario y los datos de uso, se eliminan permanentemente.</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. ¿Cómo puedes controlar el uso de cookies?</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>La mayoría de los navegadores permiten controlar las cookies. Puedes configurar opciones para bloquearlas o eliminarlas. Ten en cuenta que algunas funciones de nuestro sitio pueden no funcionar correctamente si se desactivan las cookies.</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. Cambios en esta política</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>Podemos actualizar esta política ocasionalmente. Los cambios se publicarán en esta página.</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. Contacto</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>Si tienes preguntas sobre esta política de cookies y privacidad, contacta con</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.fa.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>سیاست کوکی و حریم خصوصی</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. مقدمه</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>به وب‌سایت ما خوش آمدید. این سیاست توضیح می‌دهد که چگونه و چرا از کوکی‌ها استفاده می‌کنیم و چه داده‌هایی از طریق آن‌ها جمع‌آوری می‌شود.</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. کوکی‌ها چیستند؟</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>کوکی‌ها فایل‌های متنی کوچکی هستند که هنگام بازدید از یک وب‌سایت روی دستگاه شما ذخیره می‌شوند. معمولاً برای کاربردی‌تر کردن وب‌سایت‌ها و ارائه اطلاعات به صاحبان سایت استفاده می‌شوند.</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. چگونه و چرا از کوکی‌ها استفاده می‌کنیم؟</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>ما از کوکی‌ها استفاده می‌کنیم برای:</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>ذخیره وضعیت ورود شما.</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>بهبود عملکرد و کاربردپذیری سایت ما.</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. چه داده‌هایی جمع‌آوری می‌کنیم؟</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>وقتی از وب‌سایت ما بازدید می‌کنید یا ثبت‌نام می‌کنید، داده‌های زیر ممکن است جمع‌آوری شوند:</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>نشانی IP</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>نوع و نسخه مرورگر</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>نشانی ایمیل (هنگام ثبت‌نام یا ورود)</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>نام کاربری (هنگام ثبت‌نام یا ورود)</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>گذرواژه (هنگام ثبت‌نام یا ورود)</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>داده‌های جمع‌آوری‌شده هنگام اجرا (مانند فعالیت‌ها و تنظیمات)</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. حذف داده‌ها</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>وقتی حساب خود را حذف می‌کنید، همه داده‌های مرتبط با حساب، از جمله نشانی ایمیل، نام کاربری و داده‌های زمان اجرا، برای همیشه حذف می‌شوند.</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. چگونه می‌توانید استفاده از کوکی‌ها را کنترل کنید؟</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>بیشتر مرورگرها امکان کنترل کوکی‌ها را می‌دهند. می‌توانید تنظیمات را برای مسدود یا حذف کردن کوکی‌ها پیکربندی کنید. لطفاً توجه داشته باشید که اگر کوکی‌ها غیرفعال شوند، برخی ویژگی‌های وب‌سایت ممکن است درست کار نکنند.</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. تغییرات این سیاست</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>ممکن است این سیاست را هر از گاهی به‌روزرسانی کنیم. تغییرات در این صفحه منتشر می‌شوند.</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. تماس</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>اگر درباره این سیاست کوکی و حریم خصوصی پرسشی دارید، لطفاً تماس بگیرید با</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.fr.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Politique relative aux cookies et à la confidentialité</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. Introduction</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>Bienvenue sur notre site. Cette politique explique comment et pourquoi nous utilisons des cookies et quelles données nous collectons par leur intermédiaire.</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. Que sont les cookies ?</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>Les cookies sont de petits fichiers texte stockés sur votre appareil lorsque vous visitez un site web. Ils sont couramment utilisés pour rendre les sites plus fonctionnels et fournir des informations à leurs propriétaires.</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. Comment et pourquoi utilisons-nous les cookies ?</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>Nous utilisons des cookies pour :</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>Enregistrer votre état de connexion.</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>Améliorer les performances et l’ergonomie de notre site.</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. Quelles données collectons-nous ?</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>Lorsque vous visitez notre site ou vous inscrivez, les données suivantes peuvent être collectées :</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>Adresse IP</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>Type et version du navigateur</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>Adresse e-mail (lors de l’inscription ou de la connexion)</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>Nom d’utilisateur (lors de l’inscription ou de la connexion)</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>Mot de passe (lors de l’inscription ou de la connexion)</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>Données collectées pendant l’utilisation (p. ex. activités, paramètres)</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. Suppression des données</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>Lorsque vous supprimez votre compte, toutes les données associées, y compris l’adresse e-mail, le nom d’utilisateur et les données d’utilisation, sont supprimées définitivement.</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. Comment contrôler l’utilisation des cookies ?</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>La plupart des navigateurs vous permettent de contrôler les cookies. Vous pouvez configurer les paramètres pour les bloquer ou les supprimer. Certaines fonctionnalités de notre site peuvent toutefois ne pas fonctionner correctement si les cookies sont désactivés.</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. Modifications de cette politique</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>Nous pouvons mettre cette politique à jour de temps à autre. Les changements seront publiés sur cette page.</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. Contact</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>Si vous avez des questions sur cette politique relative aux cookies et à la confidentialité, veuillez contacter</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.ru.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Политика cookie и конфиденциальности</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. Введение</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>Добро пожаловать на наш сайт. Эта политика объясняет, как и зачем мы используем cookie и какие данные собираем с их помощью.</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. Что такое cookie?</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>Cookie — это небольшие текстовые файлы, которые сохраняются на вашем устройстве при посещении сайта. Обычно они используются, чтобы сделать сайты более функциональными и предоставить информацию владельцам сайта.</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. Как и зачем мы используем cookie?</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>Мы используем cookie, чтобы:</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>Сохранять статус входа.</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>Улучшать производительность и удобство сайта.</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. Какие данные мы собираем?</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>Когда вы посещаете наш сайт или регистрируетесь, могут собираться следующие данные:</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>IP-адрес</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>Тип и версия браузера</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>Адрес email (при регистрации или входе)</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>Имя пользователя (при регистрации или входе)</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>Пароль (при регистрации или входе)</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>Данные, собираемые во время работы (например, активности, настройки)</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. Удаление данных</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>При удалении аккаунта все связанные с ним данные, включая email, имя пользователя и данные выполнения, будут безвозвратно удалены.</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. Как управлять использованием cookie?</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>Большинство браузеров позволяют управлять cookie. Вы можете настроить блокировку или удаление cookie. Обратите внимание, что некоторые функции сайта могут работать некорректно, если cookie отключены.</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. Изменения этой политики</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>Мы можем время от времени обновлять эту политику. Изменения будут опубликованы на этой странице.</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. Контакты</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>Если у вас есть вопросы об этой политике cookie и конфиденциальности, свяжитесь с нами</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.tr.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Çerez ve gizlilik politikası</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. Giriş</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>Web sitemize hoş geldiniz. Bu politika, çerezleri nasıl ve neden kullandığımızı ve çerezler aracılığıyla hangi verileri topladığımızı açıklar.</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. Çerezler nedir?</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>Çerezler, bir web sitesini ziyaret ettiğinizde cihazınızda saklanan küçük metin dosyalarıdır. Genellikle web sitelerini daha işlevsel hale getirmek ve site sahiplerine bilgi sağlamak için kullanılır.</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. Çerezleri nasıl ve neden kullanıyoruz?</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>Çerezleri şu amaçlarla kullanıyoruz:</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>Giriş durumunuzu kaydetmek.</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>Sitemizin performansını ve kullanılabilirliğini iyileştirmek.</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. Hangi verileri topluyoruz?</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>Web sitemizi ziyaret ettiğinizde veya kayıt olduğunuzda şu veriler toplanabilir:</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>IP adresi</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>Tarayıcı türü ve sürümü</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>E-posta adresi (kayıt olurken veya giriş yaparken)</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>Kullanıcı adı (kayıt olurken veya giriş yaparken)</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>Şifre (kayıt olurken veya giriş yaparken)</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>Çalışma sırasında toplanan veriler (örn. aktiviteler, ayarlar)</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. Veri silme</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>Hesabınızı sildiğinizde e-posta adresi, kullanıcı adı ve çalışma zamanı verileri dahil hesabınızla ilişkili tüm veriler kalıcı olarak silinir.</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. Çerez kullanımını nasıl kontrol edebilirsiniz?</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>Çoğu tarayıcı çerezleri kontrol etmenize izin verir. Çerezleri engellemek veya silmek için ayarları yapılandırabilirsiniz. Ancak çerezler devre dışı bırakılırsa web sitemizin bazı özellikleri doğru çalışmayabilir.</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. Bu politikadaki değişiklikler</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>Bu politikayı zaman zaman güncelleyebiliriz. Değişiklikler bu sayfada yayımlanır.</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. İletişim</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>Bu çerez ve gizlilik politikası hakkında sorularınız varsa lütfen iletişime geçin</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Privacy.zh.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Cookie 与隐私政策</value>
+  </data>
+  <data name="Section1Title" xml:space="preserve">
+    <value>1. 简介</value>
+  </data>
+  <data name="Section1Text" xml:space="preserve">
+    <value>欢迎访问我们的网站。本政策说明我们如何以及为何使用 Cookie，以及通过 Cookie 收集哪些数据。</value>
+  </data>
+  <data name="Section2Title" xml:space="preserve">
+    <value>2. 什么是 Cookie？</value>
+  </data>
+  <data name="Section2Text" xml:space="preserve">
+    <value>Cookie 是你访问网站时存储在设备上的小型文本文件。它们通常用于让网站更具功能性，并向网站所有者提供信息。</value>
+  </data>
+  <data name="Section3Title" xml:space="preserve">
+    <value>3. 我们如何以及为何使用 Cookie？</value>
+  </data>
+  <data name="Section3Text" xml:space="preserve">
+    <value>我们使用 Cookie 来：</value>
+  </data>
+  <data name="Section3Item1" xml:space="preserve">
+    <value>保存你的登录状态。</value>
+  </data>
+  <data name="Section3Item2" xml:space="preserve">
+    <value>提升网站性能和可用性。</value>
+  </data>
+  <data name="Section4Title" xml:space="preserve">
+    <value>4. 我们收集哪些数据？</value>
+  </data>
+  <data name="Section4Text" xml:space="preserve">
+    <value>当你访问我们的网站或注册时，可能会收集以下数据：</value>
+  </data>
+  <data name="Section4Item1" xml:space="preserve">
+    <value>IP 地址</value>
+  </data>
+  <data name="Section4Item2" xml:space="preserve">
+    <value>浏览器类型和版本</value>
+  </data>
+  <data name="Section4Item3" xml:space="preserve">
+    <value>电子邮件地址（注册或登录时）</value>
+  </data>
+  <data name="Section4Item4" xml:space="preserve">
+    <value>用户名（注册或登录时）</value>
+  </data>
+  <data name="Section4Item5" xml:space="preserve">
+    <value>密码（注册或登录时）</value>
+  </data>
+  <data name="Section4Item6" xml:space="preserve">
+    <value>运行期间收集的数据（例如活动、设置）</value>
+  </data>
+  <data name="Section5Title" xml:space="preserve">
+    <value>5. 数据删除</value>
+  </data>
+  <data name="Section5Text" xml:space="preserve">
+    <value>删除账户时，与账户相关的所有数据都会被永久删除，包括电子邮件地址、用户名和运行数据。</value>
+  </data>
+  <data name="Section6Title" xml:space="preserve">
+    <value>6. 如何控制 Cookie 使用？</value>
+  </data>
+  <data name="Section6Text" xml:space="preserve">
+    <value>大多数浏览器允许你控制 Cookie。你可以配置设置来阻止或删除 Cookie。但请注意，如果禁用 Cookie，我们网站的某些功能可能无法正常工作。</value>
+  </data>
+  <data name="Section7Title" xml:space="preserve">
+    <value>7. 本政策的变更</value>
+  </data>
+  <data name="Section7Text" xml:space="preserve">
+    <value>我们可能会不时更新本政策。变更将在本页面发布。</value>
+  </data>
+  <data name="Section8Title" xml:space="preserve">
+    <value>8. 联系方式</value>
+  </data>
+  <data name="Section8Text" xml:space="preserve">
+    <value>如果你对本 Cookie 和隐私政策有疑问，请联系</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.ar.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>التسجيل</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>أنشئ حسابًا جديدًا.</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>اسمك</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>اسم المستخدم</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>البريد الإلكتروني (اختياري)</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>البريد الإلكتروني اختياري. وهو مطلوب إذا أردت إعادة تعيين كلمة المرور.</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>كلمة المرور</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>تأكيد كلمة المرور</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>إرسال</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>انضم إلى PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>أنشئ حسابك المجاني وابدأ التدريب بذكاء أكبر:</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>احسب سرعات تدريبك الفردية من نتائج السباقات</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>احصل على خطط تدريب منظمة لسباقك القادم</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>الوصول إلى تمارين موجهة للعدائين</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>لا يستغرق البدء سوى لحظة.</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>هل لديك حساب بالفعل؟ سجّل الدخول</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.da.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Registrering</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>Opret en ny konto.</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>Dit navn</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Brugernavn</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail (valgfri)</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>E-mail er valgfri. Den kræves, hvis du vil nulstille din adgangskode.</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Adgangskode</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Bekræft adgangskode</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Send</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Bliv medlem af PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Opret din gratis konto, og begynd at træne smartere:</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Beregn dine individuelle træningstempoer ud fra løbsresultater</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Få strukturerede træningsplaner til dit næste løb</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Få adgang til guidede træninger for løbere</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>Det tager kun et øjeblik at komme i gang.</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>Har du allerede en konto? Log ind</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.es.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Registro</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>Crea una nueva cuenta.</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>Tu nombre</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Correo electrónico (opcional)</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>El correo electrónico es opcional. Es necesario si quieres restablecer tu contraseña.</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmar contraseña</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Únete a PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Crea tu cuenta gratuita y empieza a entrenar mejor:</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Calcula tus ritmos de entrenamiento individuales a partir de resultados de carrera</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Obtén planes de entrenamiento estructurados para tu próxima carrera</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Accede a entrenamientos guiados para corredores</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>Empezar solo lleva un momento.</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>¿Ya tienes una cuenta? Inicia sesión</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.fa.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>ثبت‌نام</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>یک حساب جدید بسازید.</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>نام شما</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>نام کاربری</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>ایمیل (اختیاری)</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>ایمیل اختیاری است. اگر بخواهید گذرواژه را بازنشانی کنید لازم است.</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>گذرواژه</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>تأیید گذرواژه</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>ارسال</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>به PaceLetics بپیوندید</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>حساب رایگان خود را بسازید و هوشمندتر تمرین کنید:</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>سرعت‌های تمرینی فردی خود را از نتایج مسابقه محاسبه کنید</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>برای مسابقه بعدی خود برنامه‌های تمرینی ساختاریافته بگیرید</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>دسترسی به تمرین‌های راهنمایی‌شده برای دونده‌ها</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>شروع کردن فقط یک لحظه زمان می‌برد.</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>حساب دارید؟ وارد شوید</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.fr.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Inscription</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>Créez un nouveau compte.</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>Votre nom</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nom d’utilisateur</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail (facultatif)</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>L’e-mail est facultatif. Il est requis si vous souhaitez réinitialiser votre mot de passe.</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmer le mot de passe</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Envoyer</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Rejoindre PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Créez votre compte gratuit et entraînez-vous plus intelligemment :</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Calculez vos allures d’entraînement individuelles à partir de vos résultats</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Obtenez des plans d’entraînement structurés pour votre prochaine course</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Accédez à des entraînements guidés pour coureurs</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>Il suffit d’un instant pour commencer.</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>Vous avez déjà un compte ? Connectez-vous</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.ru.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Регистрация</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>Создайте новый аккаунт.</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>Ваше имя</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email (необязательно)</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>Email необязателен. Он нужен, если вы хотите сбросить пароль.</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Подтвердите пароль</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Отправить</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>Присоединяйтесь к PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Создайте бесплатный аккаунт и тренируйтесь умнее:</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Рассчитайте индивидуальные тренировочные темпы по результатам забегов</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Получайте структурированные планы тренировок для следующего забега</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Доступ к тренировкам с сопровождением для бегунов</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>Чтобы начать, нужна всего минута.</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>Уже есть аккаунт? Войдите</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.tr.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Kayıt</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>Yeni hesap oluşturun.</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>Adınız</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Kullanıcı adı</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-posta (isteğe bağlı)</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>E-posta isteğe bağlıdır. Şifrenizi sıfırlamak isterseniz gereklidir.</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Şifre</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Şifreyi onayla</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Gönder</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>PaceLetics’e katılın</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>Ücretsiz hesabınızı oluşturun ve daha akıllı antrenmana başlayın:</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>Yarış sonuçlarından kişisel antrenman tempolarınızı hesaplayın</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>Bir sonraki yarışınız için yapılandırılmış antrenman planları alın</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>Koşucular için rehberli antrenmanlara erişin</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>Başlamak sadece bir an sürer.</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>Zaten hesabınız var mı? Giriş yapın</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/Register.zh.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>注册</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>创建新账户。</value>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>你的姓名</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>用户名</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>电子邮件（可选）</value>
+  </data>
+  <data name="EmailHelp" xml:space="preserve">
+    <value>电子邮件是可选的。如果你想重置密码，则需要提供。</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>确认密码</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>提交</value>
+  </data>
+  <data name="WelcomeTitle" xml:space="preserve">
+    <value>加入 PaceLetics</value>
+  </data>
+  <data name="WelcomeText" xml:space="preserve">
+    <value>创建免费账户，开始更聪明地训练：</value>
+  </data>
+  <data name="Feature1" xml:space="preserve">
+    <value>根据比赛成绩计算个人训练配速</value>
+  </data>
+  <data name="Feature2" xml:space="preserve">
+    <value>获取下一场比赛的结构化训练计划</value>
+  </data>
+  <data name="Feature3" xml:space="preserve">
+    <value>访问跑者引导训练</value>
+  </data>
+  <data name="CreateAccountHint" xml:space="preserve">
+    <value>开始只需要片刻。</value>
+  </data>
+  <data name="AlreadyHaveAccount" xml:space="preserve">
+    <value>已有账户？登录</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.ar.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>أكّد بريدك الإلكتروني</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>يرجى تأكيد حسابك عبر &lt;a href='{0}'&gt;النقر هنا&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>البريد الإلكتروني مستخدم بالفعل.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>اسم المستخدم</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>البريد الإلكتروني</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>كلمة المرور</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>تأكيد كلمة المرور</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>يرجى إدخال {0}.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>قد يحتوي اسم المستخدم فقط على أحرف وأرقام ونقاط وشرطات سفلية وشرطات.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>يرجى إدخال عنوان بريد إلكتروني صالح.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>يجب أن يكون {0} بطول لا يقل عن {2} ولا يزيد عن {1} حرفًا.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>كلمة المرور وتأكيدها غير متطابقين.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.da.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Bekræft din e-mail</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Bekræft din konto ved at &lt;a href='{0}'&gt;klikke her&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>E-mailen er allerede i brug.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Brugernavn</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Adgangskode</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Bekræft adgangskode</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Indtast {0}.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>Brugernavnet må kun indeholde bogstaver, tal, punktummer, understregninger og bindestreger.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Indtast en gyldig e-mailadresse.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} skal være mindst {2} og højst {1} tegn langt.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>Adgangskoden og bekræftelsen stemmer ikke overens.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.de.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.de.resx
@@ -1,10 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ConfirmEmailSubject" xml:space="preserve"><value>E-Mail bestaetigen</value></data>
-  <data name="ConfirmEmailBody" xml:space="preserve"><value>Bitte bestaetige deinen Account mit einem Klick auf &lt;a href='{0}'&gt;diesen Link&lt;/a&gt;.</value></data>
-  <data name="EmailAlreadyInUse" xml:space="preserve"><value>Diese E-Mail-Adresse wird bereits verwendet.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>E-Mail bestaetigen</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Bitte bestaetige deinen Account mit einem Klick auf &lt;a href='{0}'&gt;diesen Link&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>Diese E-Mail-Adresse wird bereits verwendet.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Benutzername</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-Mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Passwort bestätigen</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Bitte gib {0} ein.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>Der Benutzername darf nur Buchstaben, Zahlen, Punkte, Unterstriche und Bindestriche enthalten.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Bitte gib eine gültige E-Mail-Adresse ein.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} muss mindestens {2} und höchstens {1} Zeichen lang sein.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>Passwort und Passwortbestätigung stimmen nicht überein.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.en.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.en.resx
@@ -1,10 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ConfirmEmailSubject" xml:space="preserve"><value>Confirm your email</value></data>
-  <data name="ConfirmEmailBody" xml:space="preserve"><value>Please confirm your account by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value></data>
-  <data name="EmailAlreadyInUse" xml:space="preserve"><value>Email is already in use.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Confirm your email</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Please confirm your account by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>Email is already in use.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Please enter {0}.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>The username may only contain letters, numbers, dots, underscores, and hyphens.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Please enter a valid email address.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} must be at least {2} and at most {1} characters long.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>The password and confirmation password do not match.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.es.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Confirma tu correo electrónico</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Confirma tu cuenta &lt;a href='{0}'&gt;haciendo clic aquí&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>El correo electrónico ya está en uso.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Correo electrónico</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmar contraseña</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Introduce {0}.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>El nombre de usuario solo puede contener letras, números, puntos, guiones bajos y guiones.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Introduce una dirección de correo electrónico válida.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} debe tener al menos {2} y como máximo {1} caracteres.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>La contraseña y la confirmación no coinciden.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.fa.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>ایمیل خود را تأیید کنید</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>لطفاً با &lt;a href='{0}'&gt;کلیک کردن اینجا&lt;/a&gt; حساب خود را تأیید کنید.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>این ایمیل قبلاً استفاده شده است.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>نام کاربری</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>ایمیل</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>گذرواژه</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>تأیید گذرواژه</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>لطفاً {0} را وارد کنید.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>نام کاربری فقط می‌تواند شامل حروف، اعداد، نقطه، زیرخط و خط تیره باشد.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>لطفاً یک نشانی ایمیل معتبر وارد کنید.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} باید حداقل {2} و حداکثر {1} نویسه داشته باشد.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>گذرواژه و تأیید آن مطابقت ندارند.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.fr.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Confirmez votre e-mail</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Veuillez confirmer votre compte en &lt;a href='{0}'&gt;cliquant ici&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>Cette adresse e-mail est déjà utilisée.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nom d’utilisateur</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmer le mot de passe</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Veuillez saisir {0}.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>Le nom d’utilisateur ne peut contenir que des lettres, des chiffres, des points, des traits de soulignement et des traits d’union.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Veuillez saisir une adresse e-mail valide.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} doit contenir au moins {2} et au plus {1} caractères.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>Le mot de passe et sa confirmation ne correspondent pas.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.resx
@@ -1,10 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
-  <resheader name="version"><value>2.0</value></resheader>
-  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <data name="ConfirmEmailSubject" xml:space="preserve"><value>Confirm your email</value></data>
-  <data name="ConfirmEmailBody" xml:space="preserve"><value>Please confirm your account by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value></data>
-  <data name="EmailAlreadyInUse" xml:space="preserve"><value>Email is already in use.</value></data>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Confirm your email</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Please confirm your account by &lt;a href='{0}'&gt;clicking here&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>Email is already in use.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Benutzername</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-Mail</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Passwort bestätigen</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Bitte gib {0} ein.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>Der Benutzername darf nur Buchstaben, Zahlen, Punkte, Unterstriche und Bindestriche enthalten.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Bitte gib eine gültige E-Mail-Adresse ein.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} muss mindestens {2} und höchstens {1} Zeichen lang sein.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>Passwort und Passwortbestätigung stimmen nicht überein.</value>
+  </data>
 </root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.ru.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>Подтвердите email</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Подтвердите аккаунт, &lt;a href='{0}'&gt;нажав здесь&lt;/a&gt;.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>Email уже используется.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Имя пользователя</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Подтверждение пароля</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Введите {0}.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>Имя пользователя может содержать только буквы, цифры, точки, подчеркивания и дефисы.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Введите действительный адрес email.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} должен содержать не менее {2} и не более {1} символов.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>Пароль и подтверждение пароля не совпадают.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.tr.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>E-postanızı onaylayın</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>Lütfen &lt;a href='{0}'&gt;buraya tıklayarak&lt;/a&gt; hesabınızı onaylayın.</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>E-posta zaten kullanılıyor.</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Kullanıcı adı</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>E-posta</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Şifre</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Şifreyi onayla</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>Lütfen {0} girin.</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>Kullanıcı adı yalnızca harf, sayı, nokta, alt çizgi ve kısa çizgi içerebilir.</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>Lütfen geçerli bir e-posta adresi girin.</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0} en az {2} ve en fazla {1} karakter uzunluğunda olmalıdır.</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>Şifre ve şifre onayı eşleşmiyor.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Account/RegisterModel.zh.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfirmEmailSubject" xml:space="preserve">
+    <value>确认你的电子邮件</value>
+  </data>
+  <data name="ConfirmEmailBody" xml:space="preserve">
+    <value>请&lt;a href='{0}'&gt;点击这里&lt;/a&gt;确认你的账户。</value>
+  </data>
+  <data name="EmailAlreadyInUse" xml:space="preserve">
+    <value>该电子邮件已被使用。</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>用户名</value>
+  </data>
+  <data name="Email" xml:space="preserve">
+    <value>电子邮件</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>确认密码</value>
+  </data>
+  <data name="ValidationRequired" xml:space="preserve">
+    <value>请输入{0}。</value>
+  </data>
+  <data name="ValidationUserNameCharacters" xml:space="preserve">
+    <value>用户名只能包含字母、数字、点、下划线和连字符。</value>
+  </data>
+  <data name="ValidationEmail" xml:space="preserve">
+    <value>请输入有效的电子邮件地址。</value>
+  </data>
+  <data name="ValidationStringLength" xml:space="preserve">
+    <value>{0}长度必须至少为 {2} 个字符，最多为 {1} 个字符。</value>
+  </data>
+  <data name="ValidationPasswordMatch" xml:space="preserve">
+    <value>密码和确认密码不匹配。</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.ar.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.ar.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>مرحبًا</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>تسجيل الخروج</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>تسجيل</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>تسجيل الدخول</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>سياسة الخصوصية</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>إشعار قانوني</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.da.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.da.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Hej</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Log ud</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrer</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Login</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>Privatlivspolitik</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>Juridisk meddelelse</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.es.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.es.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Hola</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Cerrar sesión</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrarse</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Inicio de sesión</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>Política de privacidad</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>Aviso legal</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.fa.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.fa.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>سلام</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>خروج</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>ثبت‌نام</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>ورود</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>سیاست حریم خصوصی</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>اطلاعیه حقوقی</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.fr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.fr.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Bonjour</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Déconnexion</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>S’inscrire</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Connexion</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>Politique de confidentialité</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>Mentions légales</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.ru.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.ru.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Привет</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Выйти</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Регистрация</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Вход</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>Политика конфиденциальности</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>Правовая информация</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.tr.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.tr.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Merhaba</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Çıkış</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Kayıt ol</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Giriş</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>Gizlilik politikası</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>Yasal bildirim</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.zh.resx
+++ b/PaceLetics.Web/Resources/Areas/Identity/Pages/Shared/_LoginPartial.zh.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>你好</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>退出登录</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>注册</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="Privacy" xml:space="preserve">
+    <value>隐私政策</value>
+  </data>
+  <data name="Impressum" xml:space="preserve">
+    <value>法律声明</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.ar.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>الرياضيون</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.da.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.da.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Atleter</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.es.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.es.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Atletas</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.fa.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>ورزشکاران</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.fr.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Athlètes</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.ru.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Спортсмены</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.tr.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Sporcular</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/AthleteListView.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/AthleteListView.zh.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>运动员</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.ar.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>لوحة المعلومات</value></data>
+  <data name="Loading" xml:space="preserve"><value>جارٍ تحميل بياناتك...</value></data>
+  <data name="Title" xml:space="preserve"><value>لوحة المعلومات</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>مرحبًا بك في PaceLetics</value></data>
+  <data name="Hello" xml:space="preserve"><value>مرحبًا</value></data>
+  <data name="IntroText" xml:space="preserve"><value>ستجد هنا آخر أخبار الدورات ومعلومات عن جلسات التدريب القادمة واقتراحات التدريب.</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>شخصي</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>مرحبًا {0}، هذه هي حالة تدريبك الحالية.</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>خطة التدريب</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>الجلسة التالية</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>الرسائل</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>رسائل لوحة المعلومات الحالية</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>لا يوجد جري تقييمي</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>تم التحديث {0:yyyy/MM/dd}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>لم يتم اختيار خطة</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} جلسة</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>لا توجد جلسة قادمة</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>نظرة عامة على التدريب</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>لا توجد جلسة قادمة مخططة حاليًا.</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>معاينة الخطة</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>يمكن أن تعرض هذه المنطقة لاحقًا جدولًا زمنيًا للجلسات أو الحمل أو التقدم.</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>فتح خطة التدريب</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>جري تقييمي</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>لم يتم حفظ أي جري تقييمي بعد.</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>إدارة التقييم</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>الخطة النشطة</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} جري</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} تمرين</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>لا يوجد محتوى</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.da.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Dashboard</value></data>
+  <data name="Loading" xml:space="preserve"><value>Indlæser dine data...</value></data>
+  <data name="Title" xml:space="preserve"><value>Dashboard</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Velkommen til PaceLetics</value></data>
+  <data name="Hello" xml:space="preserve"><value>Hej</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Her finder du seneste kursusnyt, information om kommende træningspas og træningsforslag.</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>Personligt</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>Hej {0}, her er din aktuelle træningsstatus.</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>Træningsplan</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>Næste session</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>Beskeder</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>Aktuelle dashboardbeskeder</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>Intet vurderingsløb</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>Opdateret {0:dd.MM.yyyy}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>Ingen plan valgt</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} sessioner</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>Ingen kommende session</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>Træningsoverblik</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>Der er ingen kommende session planlagt lige nu.</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>Planforhåndsvisning</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>Dette område kan senere vise en tidslinje over sessioner, belastning eller fremgang.</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>Åbn træningsplan</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>Vurderingsløb</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>Der er endnu ikke gemt et vurderingsløb.</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>Administrer vurdering</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>Aktiv plan</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} løb</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} workouts</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>Intet indhold</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.es.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Panel</value></data>
+  <data name="Loading" xml:space="preserve"><value>Cargando tus datos...</value></data>
+  <data name="Title" xml:space="preserve"><value>Panel</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Bienvenido a PaceLetics</value></data>
+  <data name="Hello" xml:space="preserve"><value>Hola</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Aquí encontrarás noticias de cursos, próximas sesiones y sugerencias de entrenamiento.</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>Personal</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>Hola {0}, aquí está tu estado actual de entrenamiento.</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>Plan de entrenamiento</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>Próxima sesión</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>Mensajes</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>Mensajes actuales del panel</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>Sin carrera de evaluación</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>Actualizado {0:dd/MM/yyyy}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>No hay plan seleccionado</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} sesiones</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>Sin próxima sesión</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>Resumen de entrenamiento</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>No hay ninguna próxima sesión planificada ahora mismo.</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>Vista previa del plan</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>Esta zona podrá mostrar una línea temporal de sesiones, carga o progreso.</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>Abrir plan de entrenamiento</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>Carrera de evaluación</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>Aún no se ha guardado ninguna carrera de evaluación.</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>Gestionar evaluación</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>Plan activo</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} carrera(s)</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} entrenamiento(s)</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>Sin contenido</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.fa.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>داشبورد</value></data>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری داده‌های شما...</value></data>
+  <data name="Title" xml:space="preserve"><value>داشبورد</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>به PaceLetics خوش آمدید</value></data>
+  <data name="Hello" xml:space="preserve"><value>سلام</value></data>
+  <data name="IntroText" xml:space="preserve"><value>اینجا تازه‌ترین اخبار دوره، اطلاعات جلسات آینده و پیشنهادهای تمرینی را می‌بینید.</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>شخصی</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>سلام {0}، وضعیت فعلی تمرین شما اینجاست.</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>برنامه تمرینی</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>جلسه بعدی</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>پیام‌ها</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>پیام‌های فعلی داشبورد</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>دویدن ارزیابی وجود ندارد</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>به‌روزرسانی شد {0:yyyy/MM/dd}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>برنامه‌ای انتخاب نشده است</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} جلسه</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>جلسه آینده‌ای وجود ندارد</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>نمای کلی تمرین</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>در حال حاضر جلسه آینده‌ای برنامه‌ریزی نشده است.</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>پیش‌نمایش برنامه</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>این بخش بعداً می‌تواند خط زمانی جلسات، بار یا پیشرفت را نشان دهد.</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>باز کردن برنامه تمرینی</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>دویدن ارزیابی</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>هنوز هیچ دویدن ارزیابی ذخیره نشده است.</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>مدیریت ارزیابی</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>برنامه فعال</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} دویدن</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} تمرین</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>بدون محتوا</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.fr.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Tableau de bord</value></data>
+  <data name="Loading" xml:space="preserve"><value>Chargement de vos données...</value></data>
+  <data name="Title" xml:space="preserve"><value>Tableau de bord</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Bienvenue sur PaceLetics</value></data>
+  <data name="Hello" xml:space="preserve"><value>Bonjour</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Vous trouverez ici les dernières nouvelles des cours, les prochaines séances et des suggestions d’entraînement.</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>Personnel</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>Bonjour {0}, voici votre statut d’entraînement actuel.</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>Plan d’entraînement</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>Prochaine séance</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>Messages</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>Messages actuels du tableau de bord</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>Aucune course d’évaluation</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>Mis à jour le {0:dd/MM/yyyy}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>Aucun plan sélectionné</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} séances</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>Aucune séance à venir</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>Aperçu de l’entraînement</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>Aucune séance à venir n’est planifiée pour le moment.</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>Aperçu du plan</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>Cette zone pourra afficher plus tard une chronologie des séances, la charge ou la progression.</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>Ouvrir le plan d’entraînement</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>Course d’évaluation</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>Aucune course d’évaluation n’a encore été enregistrée.</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>Gérer l’évaluation</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>Plan actif</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} course(s)</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} entraînement(s)</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>Aucun contenu</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.ru.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Панель</value></data>
+  <data name="Loading" xml:space="preserve"><value>Загрузка ваших данных...</value></data>
+  <data name="Title" xml:space="preserve"><value>Панель</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Добро пожаловать в PaceLetics</value></data>
+  <data name="Hello" xml:space="preserve"><value>Здравствуйте</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Здесь вы найдете новости курсов, информацию о предстоящих тренировках и рекомендации.</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>Личное</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>Здравствуйте, {0}, вот ваш текущий статус тренировок.</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>План тренировок</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>Следующее занятие</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>Сообщения</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>Текущие сообщения панели</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>Нет оценочного забега</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>Обновлено {0:dd.MM.yyyy}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>План не выбран</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} занятий</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>Нет предстоящей тренировки</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>Обзор тренировок</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>Сейчас нет запланированных предстоящих занятий.</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>Предпросмотр плана</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>Позже здесь может отображаться расписание занятий, нагрузка или прогресс.</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>Открыть план тренировок</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>Оценочный забег</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>Оценочный забег еще не сохранен.</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>Управлять оценкой</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>Активный план</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} забег(а)</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} тренировок</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>Нет содержимого</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.tr.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Kontrol paneli</value></data>
+  <data name="Loading" xml:space="preserve"><value>Verilerin yükleniyor...</value></data>
+  <data name="Title" xml:space="preserve"><value>Kontrol paneli</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>PaceLetics’e hoş geldin</value></data>
+  <data name="Hello" xml:space="preserve"><value>Merhaba</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Burada en güncel kurs haberlerini, yaklaşan antrenman bilgilerini ve antrenman önerilerini bulabilirsin.</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>Kişisel</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>Merhaba {0}, işte güncel antrenman durumun.</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>Antrenman planı</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>Sonraki oturum</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>Mesajlar</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>Güncel pano mesajları</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>Değerlendirme koşusu yok</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>Güncellendi {0:dd.MM.yyyy}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>Plan seçilmedi</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} oturum</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>Yaklaşan oturum yok</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>Antrenman özeti</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>Şu anda planlanan yaklaşan oturum yok.</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>Plan önizlemesi</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>Bu alan daha sonra oturum zaman çizelgesi, yük veya ilerleme gösterebilir.</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>Antrenman planını aç</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>Değerlendirme koşusu</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>Henüz değerlendirme koşusu kaydedilmedi.</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>Değerlendirmeyi yönet</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>Aktif plan</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} koşu</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} antrenman</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>İçerik yok</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Dashboard.zh.resx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>仪表板</value></data>
+  <data name="Loading" xml:space="preserve"><value>正在加载你的数据...</value></data>
+  <data name="Title" xml:space="preserve"><value>仪表板</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>欢迎使用 PaceLetics</value></data>
+  <data name="Hello" xml:space="preserve"><value>你好</value></data>
+  <data name="IntroText" xml:space="preserve"><value>这里可以查看最新课程消息、即将到来的训练和训练建议。</value></data>
+  <data name="Breadcrumb_Personal" xml:space="preserve"><value>个人</value></data>
+  <data name="WelcomeText" xml:space="preserve"><value>你好 {0}，这是你当前的训练状态。</value></data>
+  <data name="Metric_Vdot" xml:space="preserve"><value>VDOT</value></data>
+  <data name="Metric_TrainingPlan" xml:space="preserve"><value>训练计划</value></data>
+  <data name="Metric_NextSession" xml:space="preserve"><value>下一次训练</value></data>
+  <data name="Metric_Messages" xml:space="preserve"><value>消息</value></data>
+  <data name="Metric_MessagesDetail" xml:space="preserve"><value>当前仪表板消息</value></data>
+  <data name="Metric_NotAvailable" xml:space="preserve"><value>-</value></data>
+  <data name="Metric_ReferenceMissing" xml:space="preserve"><value>没有评估跑</value></data>
+  <data name="Metric_ReferenceDate" xml:space="preserve"><value>已更新 {0:yyyy/MM/dd}</value></data>
+  <data name="Metric_NoPlan" xml:space="preserve"><value>未选择计划</value></data>
+  <data name="Metric_PlanSessions" xml:space="preserve"><value>{0} 次训练</value></data>
+  <data name="Metric_NoSession" xml:space="preserve"><value>没有即将到来的训练</value></data>
+  <data name="TrainingOverview_Title" xml:space="preserve"><value>训练概览</value></data>
+  <data name="TrainingOverview_Empty" xml:space="preserve"><value>目前没有计划中的下一次训练。</value></data>
+  <data name="TrainingOverview_PreviewTitle" xml:space="preserve"><value>计划预览</value></data>
+  <data name="TrainingOverview_PreviewText" xml:space="preserve"><value>这里之后可以显示训练时间线、负荷或进度。</value></data>
+  <data name="OpenTrainingPlan" xml:space="preserve"><value>打开训练计划</value></data>
+  <data name="ReferencePanel_Title" xml:space="preserve"><value>评估跑</value></data>
+  <data name="ReferencePanel_Empty" xml:space="preserve"><value>尚未保存评估跑。</value></data>
+  <data name="ManageReferenceRun" xml:space="preserve"><value>管理评估</value></data>
+  <data name="PlanPanel_Title" xml:space="preserve"><value>当前计划</value></data>
+  <data name="SessionRuns" xml:space="preserve"><value>{0} 次跑步</value></data>
+  <data name="SessionWorkouts" xml:space="preserve"><value>{0} 个训练</value></data>
+  <data name="SessionEmpty" xml:space="preserve"><value>无内容</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.ar.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>إعدادات الرياضي</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.da.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Atletkonfiguration</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.es.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Configuración del atleta</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.fa.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>پیکربندی ورزشکار</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.fr.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Configuration de l’athlète</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.ru.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Настройки спортсмена</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.tr.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Sporcu yapılandırması</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Konfigurations.zh.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>运动员配置</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.ar.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>دوراتي</value></data>
+  <data name="Loading" xml:space="preserve"><value>جارٍ تحميل الدورات</value></data>
+  <data name="Title" xml:space="preserve"><value>دوراتي</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>عضويات الدورات والمواعيد والفعاليات</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>لا توجد دورات منشورة حاليًا.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>لا يوجد موعد قادم</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>مغادرة</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>إضافة دورة</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>لم تنضم إلى أي دورة بعد.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>لا توجد دورات إضافية متاحة حاليًا.</value></data>
+  <data name="Join" xml:space="preserve"><value>انضم</value></data>
+  <data name="Joined" xml:space="preserve"><value>منضم</value></data>
+  <data name="Dates" xml:space="preserve"><value>المواعيد</value></data>
+  <data name="Events" xml:space="preserve"><value>الفعاليات</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>خطط التدريب</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>الكل</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>أقل</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>لا توجد مواعيد قادمة.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>لا توجد فعاليات مدرجة حاليًا.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>إلغاء</value></data>
+  <data name="Register" xml:space="preserve"><value>تسجيل</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>لم تُنشر أي خطط تدريب بعد.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>تعذر تحميل الدورات من Cosmos DB.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>لقد انضممت إلى الدورة.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>مغادرة &quot;{0}&quot;؟</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>لقد غادرت الدورة.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>لقد سجلت في الفعالية.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>تم إلغاء تسجيلك في الفعالية.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:yyyy/MM/dd} إلى {1:yyyy/MM/dd}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:MM/dd} إلى {1:MM/dd}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} إلى {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm} إلى {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.da.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Mine kurser</value></data>
+  <data name="Loading" xml:space="preserve"><value>Indlæser kurser</value></data>
+  <data name="Title" xml:space="preserve"><value>Mine kurser</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Kursusmedlemskaber, datoer og events</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>Der er i øjeblikket ingen offentliggjorte kurser.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>Ingen kommende dato</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:dd.MM HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>Forlad</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>Tilføj kursus</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>Du har endnu ikke deltaget i et kursus.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>Der er ingen yderligere kurser tilgængelige lige nu.</value></data>
+  <data name="Join" xml:space="preserve"><value>Deltag</value></data>
+  <data name="Joined" xml:space="preserve"><value>Tilmeldt</value></data>
+  <data name="Dates" xml:space="preserve"><value>Datoer</value></data>
+  <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Træningsplaner</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>Alle</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>Mindre</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>Ingen kommende datoer.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Der er ingen events opført lige nu.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>Annuller</value></data>
+  <data name="Register" xml:space="preserve"><value>Tilmeld</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>Der er endnu ikke offentliggjort træningsplaner.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Kurserne kunne ikke indlæses fra Cosmos DB.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>Du deltog i kurset.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>Forlad &quot;{0}&quot;?</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>Du forlod kurset.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>Du er tilmeldt eventet.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>Din eventtilmelding blev annulleret.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} til {1:dd.MM.yyyy}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:dd.MM} til {1:dd.MM}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} til {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} til {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.es.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Mis cursos</value></data>
+  <data name="Loading" xml:space="preserve"><value>Cargando cursos</value></data>
+  <data name="Title" xml:space="preserve"><value>Mis cursos</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Inscripciones a cursos, fechas y eventos</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>No hay cursos publicados actualmente.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>Sin fecha próxima</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:dd/MM HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>Salir</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>Añadir curso</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>Aún no te has unido a ningún curso.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>No hay cursos adicionales disponibles actualmente.</value></data>
+  <data name="Join" xml:space="preserve"><value>Unirse</value></data>
+  <data name="Joined" xml:space="preserve"><value>Inscrito</value></data>
+  <data name="Dates" xml:space="preserve"><value>Fechas</value></data>
+  <data name="Events" xml:space="preserve"><value>Eventos</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Planes de entrenamiento</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>Todo</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>Menos</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>No hay fechas próximas.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>No hay eventos listados actualmente.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="Register" xml:space="preserve"><value>Registrarse</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>Aún no hay planes de entrenamiento publicados.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>No se pudieron cargar los cursos desde Cosmos DB.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>Te has unido al curso.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>¿Salir de &quot;{0}&quot;?</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>Has salido del curso.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>Te has registrado en el evento.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>Tu registro en el evento fue cancelado.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd/MM/yyyy} a {1:dd/MM/yyyy}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:dd/MM} a {1:dd/MM}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} a {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:dd/MM/yyyy HH:mm} a {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.fa.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>دوره‌های من</value></data>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری دوره‌ها</value></data>
+  <data name="Title" xml:space="preserve"><value>دوره‌های من</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>عضویت دوره‌ها، تاریخ‌ها و رویدادها</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>در حال حاضر دوره‌ای منتشر نشده است.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>تاریخ آینده‌ای وجود ندارد</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>ترک</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>افزودن دوره</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>هنوز به هیچ دوره‌ای نپیوسته‌اید.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>در حال حاضر دوره دیگری در دسترس نیست.</value></data>
+  <data name="Join" xml:space="preserve"><value>پیوستن</value></data>
+  <data name="Joined" xml:space="preserve"><value>پیوسته</value></data>
+  <data name="Dates" xml:space="preserve"><value>تاریخ‌ها</value></data>
+  <data name="Events" xml:space="preserve"><value>رویدادها</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>برنامه‌های تمرینی</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>همه</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>کمتر</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>تاریخ‌های آینده وجود ندارد.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>در حال حاضر رویدادی فهرست نشده است.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>لغو</value></data>
+  <data name="Register" xml:space="preserve"><value>ثبت‌نام</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>هنوز برنامه تمرینی منتشر نشده است.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>دوره‌ها از Cosmos DB بارگذاری نشدند.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>شما به دوره پیوستید.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>&quot;{0}&quot; را ترک می‌کنید؟</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>شما دوره را ترک کردید.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>شما برای رویداد ثبت‌نام کردید.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>ثبت‌نام رویداد شما لغو شد.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:yyyy/MM/dd} تا {1:yyyy/MM/dd}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:MM/dd} تا {1:MM/dd}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} تا {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm} تا {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.fr.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Mes cours</value></data>
+  <data name="Loading" xml:space="preserve"><value>Chargement des cours</value></data>
+  <data name="Title" xml:space="preserve"><value>Mes cours</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Inscriptions aux cours, dates et événements</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>Aucun cours n’est actuellement publié.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>Aucune date à venir</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:dd/MM HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>Quitter</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>Ajouter un cours</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>Vous n’avez encore rejoint aucun cours.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>Aucun cours supplémentaire n’est disponible pour le moment.</value></data>
+  <data name="Join" xml:space="preserve"><value>Rejoindre</value></data>
+  <data name="Joined" xml:space="preserve"><value>Inscrit</value></data>
+  <data name="Dates" xml:space="preserve"><value>Dates</value></data>
+  <data name="Events" xml:space="preserve"><value>Événements</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Plans d’entraînement</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>Tout</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>Moins</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>Aucune date à venir.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Aucun événement n’est actuellement listé.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>Annuler</value></data>
+  <data name="Register" xml:space="preserve"><value>S’inscrire</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>Aucun plan d’entraînement publié pour le moment.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Les cours n’ont pas pu être chargés depuis Cosmos DB.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>Vous avez rejoint le cours.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>Quitter &quot;{0}&quot; ?</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>Vous avez quitté le cours.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>Vous êtes inscrit à l’événement.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>Votre inscription à l’événement a été annulée.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd/MM/yyyy} à {1:dd/MM/yyyy}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:dd/MM} à {1:dd/MM}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} à {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:dd/MM/yyyy HH:mm} à {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.ru.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Мои курсы</value></data>
+  <data name="Loading" xml:space="preserve"><value>Загрузка курсов</value></data>
+  <data name="Title" xml:space="preserve"><value>Мои курсы</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Участие в курсах, даты и события</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>Сейчас нет опубликованных курсов.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>Нет предстоящей даты</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:dd.MM HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>Покинуть</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>Добавить курс</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>Вы еще не присоединились к курсу.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>Сейчас нет дополнительных курсов.</value></data>
+  <data name="Join" xml:space="preserve"><value>Присоединиться</value></data>
+  <data name="Joined" xml:space="preserve"><value>Участник</value></data>
+  <data name="Dates" xml:space="preserve"><value>Даты</value></data>
+  <data name="Events" xml:space="preserve"><value>События</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Планы тренировок</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>Все</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>Меньше</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>Нет предстоящих дат.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Сейчас нет событий.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>Отмена</value></data>
+  <data name="Register" xml:space="preserve"><value>Зарегистрироваться</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>Планы тренировок еще не опубликованы.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Не удалось загрузить курсы из Cosmos DB.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>Вы присоединились к курсу.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>Покинуть &quot;{0}&quot;?</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>Вы покинули курс.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>Вы зарегистрировались на событие.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>Ваша регистрация на событие отменена.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} – {1:dd.MM.yyyy}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:dd.MM} – {1:dd.MM}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} – {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} – {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.tr.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Kurslarım</value></data>
+  <data name="Loading" xml:space="preserve"><value>Kurslar yükleniyor</value></data>
+  <data name="Title" xml:space="preserve"><value>Kurslarım</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Kurs üyelikleri, tarihler ve etkinlikler</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>Şu anda yayınlanmış kurs yok.</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>Yaklaşan tarih yok</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:dd.MM HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>Ayrıl</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>Kurs ekle</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>Henüz bir kursa katılmadın.</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>Şu anda ek kurs yok.</value></data>
+  <data name="Join" xml:space="preserve"><value>Katıl</value></data>
+  <data name="Joined" xml:space="preserve"><value>Katıldı</value></data>
+  <data name="Dates" xml:space="preserve"><value>Tarihler</value></data>
+  <data name="Events" xml:space="preserve"><value>Etkinlikler</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Antrenman planları</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>Tümü</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>Daha az</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>Yaklaşan tarih yok.</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Şu anda etkinlik listelenmiyor.</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>İptal</value></data>
+  <data name="Register" xml:space="preserve"><value>Kayıt ol</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>Henüz antrenman planı yayınlanmadı.</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Kurslar Cosmos DB’den yüklenemedi.</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>Kursa katıldın.</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>&quot;{0}&quot; kursundan ayrıl?</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>Kurstan ayrıldın.</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>Etkinliğe kaydoldun.</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>Etkinlik kaydın iptal edildi.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} - {1:dd.MM.yyyy}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:dd.MM} - {1:dd.MM}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} - {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} - {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.zh.resx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>我的课程</value></data>
+  <data name="Loading" xml:space="preserve"><value>正在加载课程</value></data>
+  <data name="Title" xml:space="preserve"><value>我的课程</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>课程成员、日期和活动</value></data>
+  <data name="NoPublishedCourses" xml:space="preserve"><value>当前没有已发布的课程。</value></data>
+  <data name="NoUpcomingDate" xml:space="preserve"><value>没有即将到来的日期</value></data>
+  <data name="UpcomingDate" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm}</value></data>
+  <data name="Leave" xml:space="preserve"><value>退出</value></data>
+  <data name="AddCourse" xml:space="preserve"><value>添加课程</value></data>
+  <data name="NoJoinedCourses" xml:space="preserve"><value>你还没有加入课程。</value></data>
+  <data name="NoAvailableCourses" xml:space="preserve"><value>当前没有其他可用课程。</value></data>
+  <data name="Join" xml:space="preserve"><value>加入</value></data>
+  <data name="Joined" xml:space="preserve"><value>已加入</value></data>
+  <data name="Dates" xml:space="preserve"><value>日期</value></data>
+  <data name="Events" xml:space="preserve"><value>活动</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>训练计划</value></data>
+  <data name="ShowAll" xml:space="preserve"><value>全部</value></data>
+  <data name="ShowLess" xml:space="preserve"><value>更少</value></data>
+  <data name="NoUpcomingDates" xml:space="preserve"><value>没有即将到来的日期。</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>当前没有列出的活动。</value></data>
+  <data name="CancelRegistration" xml:space="preserve"><value>取消</value></data>
+  <data name="Register" xml:space="preserve"><value>报名</value></data>
+  <data name="NoTrainingPlans" xml:space="preserve"><value>尚未发布训练计划。</value></data>
+  <data name="LoadError" xml:space="preserve"><value>无法从 Cosmos DB 加载课程。</value></data>
+  <data name="JoinSuccess" xml:space="preserve"><value>你已加入课程。</value></data>
+  <data name="LeaveConfirm" xml:space="preserve"><value>退出“{0}”？</value></data>
+  <data name="LeaveSuccess" xml:space="preserve"><value>你已退出课程。</value></data>
+  <data name="RegisterSuccess" xml:space="preserve"><value>你已报名活动。</value></data>
+  <data name="CancelRegistrationSuccess" xml:space="preserve"><value>你的活动报名已取消。</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:yyyy/MM/dd} 至 {1:yyyy/MM/dd}</value></data>
+  <data name="ShortPeriod" xml:space="preserve"><value>{0:MM/dd} 至 {1:MM/dd}</value></data>
+  <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} 至 {1:HH:mm}</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm} 至 {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.ar.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>بيانات سباقك</value></data>
+  <data name="Loading" xml:space="preserve"><value>جارٍ تحميل بياناتك...</value></data>
+  <data name="Title" xml:space="preserve"><value>بيانات سباقك</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>أدخل سباقًا مرجعيًا جديدًا أو عدّل الحالي.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>أضف سباقًا مرجعيًا لنتمكن من تحديد مناطق تدريبك.</value></data>
+  <data name="AddRace" xml:space="preserve"><value>إضافة سباق مرجعي</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>سباقك المرجعي أقدم من 6 أشهر. للحصول على تدريب مثالي، استخدم سباقًا مرجعيًا أحدث.</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>خطأ في التحميل</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>تعذر تحميل بياناتك:</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.da.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Dine løbsdata</value></data>
+  <data name="Loading" xml:space="preserve"><value>Indlæser dine data...</value></data>
+  <data name="Title" xml:space="preserve"><value>Dine løbsdata</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Indtast et nyt referenceløb, eller rediger det eksisterende.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Tilføj et referenceløb, så vi kan beregne dine træningszoner.</value></data>
+  <data name="AddRace" xml:space="preserve"><value>Tilføj referenceløb</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>Dit referenceløb er mere end 6 måneder gammelt. For optimal træning bør du bruge et nyere referenceløb.</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>Indlæsningsfejl</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>Dine data kunne ikke indlæses:</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.es.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Tus datos de carrera</value></data>
+  <data name="Loading" xml:space="preserve"><value>Cargando tus datos...</value></data>
+  <data name="Title" xml:space="preserve"><value>Tus datos de carrera</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Introduce una nueva carrera de referencia o edita la existente.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Añade una carrera de referencia para determinar tus zonas de entrenamiento.</value></data>
+  <data name="AddRace" xml:space="preserve"><value>Añadir carrera de referencia</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>Tu carrera de referencia tiene más de 6 meses. Para entrenar mejor, usa una referencia más reciente.</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>Error de carga</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>No se pudieron cargar tus datos:</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.fa.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>داده‌های مسابقه شما</value></data>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری داده‌های شما...</value></data>
+  <data name="Title" xml:space="preserve"><value>داده‌های مسابقه شما</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>یک مسابقه مرجع جدید وارد کنید یا مورد موجود را ویرایش کنید.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>یک مسابقه مرجع اضافه کنید تا بتوانیم محدوده‌های تمرینی شما را تعیین کنیم.</value></data>
+  <data name="AddRace" xml:space="preserve"><value>افزودن مسابقه مرجع</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>مسابقه مرجع شما بیش از ۶ ماه قدیمی است. برای تمرین بهینه، از مسابقه مرجع جدیدتری استفاده کنید.</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>خطای بارگذاری</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>داده‌های شما بارگذاری نشد:</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.fr.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Vos données de course</value></data>
+  <data name="Loading" xml:space="preserve"><value>Chargement de vos données...</value></data>
+  <data name="Title" xml:space="preserve"><value>Vos données de course</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Saisissez une nouvelle course de référence ou modifiez celle existante.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Ajoutez une course de référence afin de déterminer vos zones d’entraînement.</value></data>
+  <data name="AddRace" xml:space="preserve"><value>Ajouter une course de référence</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>Votre course de référence date de plus de 6 mois. Pour un entraînement optimal, utilisez une référence plus récente.</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>Erreur de chargement</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>Vos données n’ont pas pu être chargées :</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.ru.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Ваши данные забега</value></data>
+  <data name="Loading" xml:space="preserve"><value>Загрузка ваших данных...</value></data>
+  <data name="Title" xml:space="preserve"><value>Ваши данные забега</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Введите новый контрольный забег или измените существующий.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Добавьте контрольный забег, чтобы мы могли определить ваши тренировочные зоны.</value></data>
+  <data name="AddRace" xml:space="preserve"><value>Добавить контрольный забег</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>Ваш контрольный забег старше 6 месяцев. Для оптимальной тренировки используйте более свежий забег.</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>Ошибка загрузки</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>Ваши данные не удалось загрузить:</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.tr.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Yarış verilerin</value></data>
+  <data name="Loading" xml:space="preserve"><value>Verilerin yükleniyor...</value></data>
+  <data name="Title" xml:space="preserve"><value>Yarış verilerin</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Yeni bir referans yarış gir veya mevcut olanı düzenle.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Antrenman bölgelerini belirleyebilmemiz için bir referans yarış ekle.</value></data>
+  <data name="AddRace" xml:space="preserve"><value>Referans yarış ekle</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>Referans yarışın 6 aydan eski. En iyi antrenman için daha güncel bir referans yarış kullanmalısın.</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>Yükleme hatası</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>Verilerin yüklenemedi:</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/RacePaces.zh.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>你的比赛数据</value></data>
+  <data name="Loading" xml:space="preserve"><value>正在加载你的数据...</value></data>
+  <data name="Title" xml:space="preserve"><value>你的比赛数据</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>输入新的参考比赛或编辑现有比赛。</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>添加一次参考比赛，以便我们确定你的训练区间。</value></data>
+  <data name="AddRace" xml:space="preserve"><value>添加参考比赛</value></data>
+  <data name="RaceOldWarning" xml:space="preserve"><value>你的参考比赛已超过 6 个月。为了最佳训练，请使用更新的参考比赛。</value></data>
+  <data name="LoadError_Title" xml:space="preserve"><value>加载错误</value></data>
+  <data name="LoadError_Message" xml:space="preserve"><value>无法加载你的数据：</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.ar.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>تدريب الفواصل التالي</value></data>
+  <data name="Loading" xml:space="preserve"><value>جارٍ تحميل بياناتك...</value></data>
+  <data name="Title" xml:space="preserve"><value>تدريب الفواصل التالي</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>تُحسب هذه الجلسة بناءً على نموذج الوتيرة الحالي لديك.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>أضف سباقًا مرجعيًا لنتمكن من تحديد سرعات تدريبك المثلى.</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>لا توجد تدريبات فواصل محددة حاليًا.</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>مخطط في:</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>تنبيه</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>أنت غير مسجل الدخول. يرجى تسجيل الدخول مرة أخرى.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.da.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Din næste intervaltræning</value></data>
+  <data name="Loading" xml:space="preserve"><value>Indlæser dine data...</value></data>
+  <data name="Title" xml:space="preserve"><value>Din næste intervaltræning</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Denne session beregnes ud fra din aktuelle tempomodel.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Tilføj et referenceløb, så vi kan beregne dine optimale træningstempoer.</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>Der er i øjeblikket ingen intervaltræninger defineret.</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>Planlagt den:</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>Bemærk</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>Du er ikke logget ind. Log venligst ind igen.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.es.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Tu próximo entrenamiento de intervalos</value></data>
+  <data name="Loading" xml:space="preserve"><value>Cargando tus datos...</value></data>
+  <data name="Title" xml:space="preserve"><value>Tu próximo entrenamiento de intervalos</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Esta sesión se calcula a partir de tu modelo de ritmo actual.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Añade una carrera de referencia para determinar tus ritmos de entrenamiento óptimos.</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>Actualmente no hay entrenamientos de intervalos definidos.</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>Planificado para:</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>Atención</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>No has iniciado sesión. Vuelve a iniciar sesión.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.fa.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>تمرین اینتروال بعدی شما</value></data>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری داده‌های شما...</value></data>
+  <data name="Title" xml:space="preserve"><value>تمرین اینتروال بعدی شما</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>این جلسه بر اساس مدل پیس فعلی شما محاسبه می‌شود.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>یک مسابقه مرجع اضافه کنید تا بتوانیم پیس‌های تمرینی بهینه شما را تعیین کنیم.</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>در حال حاضر تمرین اینتروالی تعریف نشده است.</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>برنامه‌ریزی شده در:</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>توجه</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>شما وارد نشده‌اید. لطفاً دوباره وارد شوید.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.fr.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Votre prochain entraînement fractionné</value></data>
+  <data name="Loading" xml:space="preserve"><value>Chargement de vos données...</value></data>
+  <data name="Title" xml:space="preserve"><value>Votre prochain entraînement fractionné</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Cette séance est calculée à partir de votre modèle d’allure actuel.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Ajoutez une course de référence afin de déterminer vos allures d’entraînement optimales.</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>Aucun entraînement fractionné n’est actuellement défini.</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>Prévu le :</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>Attention</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>Vous n’êtes pas connecté. Veuillez vous reconnecter.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.ru.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Ваша следующая интервальная тренировка</value></data>
+  <data name="Loading" xml:space="preserve"><value>Загрузка ваших данных...</value></data>
+  <data name="Title" xml:space="preserve"><value>Ваша следующая интервальная тренировка</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Это занятие рассчитывается на основе вашей текущей модели темпа.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Добавьте контрольный забег, чтобы мы могли определить ваши оптимальные тренировочные темпы.</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>Сейчас интервальные тренировки не заданы.</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>Запланировано на:</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>Внимание</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>Вы не вошли в систему. Пожалуйста, войдите снова.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.tr.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Sonraki interval antrenmanın</value></data>
+  <data name="Loading" xml:space="preserve"><value>Verilerin yükleniyor...</value></data>
+  <data name="Title" xml:space="preserve"><value>Sonraki interval antrenmanın</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Bu oturum mevcut tempo modeline göre hesaplanır.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>En uygun antrenman tempolarını belirleyebilmemiz için bir referans yarış ekle.</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>Şu anda tanımlı interval antrenmanı yok.</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>Planlanan tarih:</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>Dikkat</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>Giriş yapmadın. Lütfen tekrar giriş yap.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingIntervalls.zh.resx
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>你的下一次间歇训练</value></data>
+  <data name="Loading" xml:space="preserve"><value>正在加载你的数据...</value></data>
+  <data name="Title" xml:space="preserve"><value>你的下一次间歇训练</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>本次训练基于你当前的配速模型计算。</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>添加一次参考比赛，以便我们确定你的最佳训练配速。</value></data>
+  <data name="NoTrainings" xml:space="preserve"><value>当前没有定义间歇训练。</value></data>
+  <data name="PlannedOn" xml:space="preserve"><value>计划日期：</value></data>
+  <data name="NotLoggedIn_Title" xml:space="preserve"><value>注意</value></data>
+  <data name="NotLoggedIn_Message" xml:space="preserve"><value>你尚未登录。请重新登录。</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.ar.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>مناطق وتيرتك</value></data>
+  <data name="Loading" xml:space="preserve"><value>جارٍ تحميل بياناتك...</value></data>
+  <data name="Title" xml:space="preserve"><value>مناطق وتيرتك</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>هنا تجد مناطق وتيرة التدريب المثلى بناءً على قيمة VDOT الخاصة بك.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>أضف سباقًا مرجعيًا لنتمكن من تحديد سرعات تدريبك المثلى.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.da.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Dine tempozoner</value></data>
+  <data name="Loading" xml:space="preserve"><value>Indlæser dine data...</value></data>
+  <data name="Title" xml:space="preserve"><value>Dine tempozoner</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Her finder du dine optimale træningstempozoner baseret på din VDOT-værdi.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Tilføj et referenceløb, så vi kan beregne dine optimale træningstempoer.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.es.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Tus zonas de ritmo</value></data>
+  <data name="Loading" xml:space="preserve"><value>Cargando tus datos...</value></data>
+  <data name="Title" xml:space="preserve"><value>Tus zonas de ritmo</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Aquí encontrarás tus zonas óptimas de ritmo basadas en tu valor VDOT.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Añade una carrera de referencia para determinar tus ritmos de entrenamiento óptimos.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.fa.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>محدوده‌های پیس شما</value></data>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری داده‌های شما...</value></data>
+  <data name="Title" xml:space="preserve"><value>محدوده‌های پیس شما</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>اینجا می‌توانید محدوده‌های پیس تمرینی بهینه بر اساس مقدار VDOT خود را ببینید.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>یک مسابقه مرجع اضافه کنید تا بتوانیم پیس‌های تمرینی بهینه شما را تعیین کنیم.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.fr.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Vos zones d’allure</value></data>
+  <data name="Loading" xml:space="preserve"><value>Chargement de vos données...</value></data>
+  <data name="Title" xml:space="preserve"><value>Vos zones d’allure</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Vous trouverez ici vos zones d’allure optimales basées sur votre VDOT.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Ajoutez une course de référence afin de déterminer vos allures d’entraînement optimales.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.ru.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Ваши зоны темпа</value></data>
+  <data name="Loading" xml:space="preserve"><value>Загрузка ваших данных...</value></data>
+  <data name="Title" xml:space="preserve"><value>Ваши зоны темпа</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Здесь вы найдете оптимальные зоны тренировочного темпа на основе вашего VDOT.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>Добавьте контрольный забег, чтобы мы могли определить ваши оптимальные тренировочные темпы.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.tr.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Tempo bölgelerin</value></data>
+  <data name="Loading" xml:space="preserve"><value>Verilerin yükleniyor...</value></data>
+  <data name="Title" xml:space="preserve"><value>Tempo bölgelerin</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>VDOT değerine göre en uygun antrenman tempo bölgelerini burada bulabilirsin.</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>En uygun antrenman tempolarını belirleyebilmemiz için bir referans yarış ekle.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPaces.zh.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>你的配速区间</value></data>
+  <data name="Loading" xml:space="preserve"><value>正在加载你的数据...</value></data>
+  <data name="Title" xml:space="preserve"><value>你的配速区间</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>这里可以根据你的 VDOT 值查看最佳训练配速区间。</value></data>
+  <data name="NoRaceWarning" xml:space="preserve"><value>添加一次参考比赛，以便我们确定你的最佳训练配速。</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.ar.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>خطة تدريبك</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>خطة التدريب للفصل الرياضي الحالي.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>لا توجد خطط تدريب متاحة. انضم إلى دورة للحصول على خطة تدريب.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>الانتقال إلى اختيار الدورة</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>اختر خطة التدريب</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>لم يتم تحميل أي تفاصيل.</value></data>
+  <data name="Session" xml:space="preserve"><value>جلسة</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>تنبيه</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>حدثت مشكلة أثناء تحميل بياناتك أو خطط التدريب.</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>خطأ</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>تعذر حفظ اختيارك في المتصفح.</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>خطأ</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>تعذر حفظ الاختيار على الخادم.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.da.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Din træningsplan</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Træningsplanen for det aktuelle sportssemester.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>Ingen træningsplaner tilgængelige. Deltag i et kursus for at modtage en plan.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>Gå til kursusvalg</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>Vælg træningsplan</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>Ingen detaljer indlæst.</value></data>
+  <data name="Session" xml:space="preserve"><value>Session</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>Bemærk</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>Der opstod et problem ved indlæsning af dine data eller træningsplaner.</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>Fejl</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>Dit valg kunne ikke gemmes i browseren.</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>Fejl</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>Valget kunne ikke gemmes på serveren.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.es.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Tu plan de entrenamiento</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>El plan de entrenamiento del semestre deportivo actual.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>No hay planes de entrenamiento disponibles. Únete a un curso para recibir uno.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>Ir a la selección de cursos</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>Seleccionar plan de entrenamiento</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>No se han cargado detalles.</value></data>
+  <data name="Session" xml:space="preserve"><value>Sesión</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>Atención</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>Hubo un problema al cargar tus datos o planes de entrenamiento.</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>Error</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>No se pudo guardar tu selección en el navegador.</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>Error</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>No se pudo guardar la selección en el servidor.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.fa.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>برنامه تمرینی شما</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>برنامه تمرینی برای نیم‌سال ورزشی فعلی.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>برنامه تمرینی در دسترس نیست. برای دریافت برنامه به یک دوره بپیوندید.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>رفتن به انتخاب دوره</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>انتخاب برنامه تمرینی</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>جزئیاتی بارگذاری نشده است.</value></data>
+  <data name="Session" xml:space="preserve"><value>جلسه</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>توجه</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>در بارگذاری داده‌ها یا برنامه‌های تمرینی شما مشکلی رخ داد.</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>خطا</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>انتخاب شما در مرورگر ذخیره نشد.</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>خطا</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>انتخاب روی سرور ذخیره نشد.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.fr.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Votre plan d’entraînement</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Le plan d’entraînement du semestre sportif actuel.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>Aucun plan d’entraînement disponible. Rejoignez un cours pour en recevoir un.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>Aller à la sélection des cours</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>Sélectionner un plan d’entraînement</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>Aucun détail chargé.</value></data>
+  <data name="Session" xml:space="preserve"><value>Séance</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>Attention</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>Un problème est survenu lors du chargement de vos données ou plans d’entraînement.</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>Erreur</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>Votre sélection n’a pas pu être enregistrée dans le navigateur.</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>Erreur</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>La sélection n’a pas pu être enregistrée sur le serveur.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.ru.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Ваш план тренировок</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>План тренировок на текущий спортивный семестр.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>Планы тренировок недоступны. Присоединитесь к курсу, чтобы получить план.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>Перейти к выбору курса</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>Выберите план тренировок</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>Детали не загружены.</value></data>
+  <data name="Session" xml:space="preserve"><value>Занятие</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>Внимание</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>Возникла проблема при загрузке данных или планов тренировок.</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>Ошибка</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>Ваш выбор не удалось сохранить в браузере.</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>Ошибка</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>Не удалось сохранить выбор на сервере.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.tr.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>Antrenman planın</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Mevcut spor dönemi için antrenman planı.</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>Antrenman planı yok. Plan almak için bir kursa katıl.</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>Kurs seçimine git</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>Antrenman planı seç</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>Detay yüklenmedi.</value></data>
+  <data name="Session" xml:space="preserve"><value>Oturum</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>Dikkat</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>Verilerini veya antrenman planlarını yüklerken bir sorun oluştu.</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>Hata</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>Seçimin tarayıcıda kaydedilemedi.</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>Hata</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>Seçim sunucuda kaydedilemedi.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/TrainingPlanPage.zh.resx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Title" xml:space="preserve"><value>你的训练计划</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>当前运动学期的训练计划。</value></data>
+  <data name="NoPlans" xml:space="preserve"><value>没有可用训练计划。加入课程以接收训练计划。</value></data>
+  <data name="CourseSelectionLink" xml:space="preserve"><value>前往课程选择</value></data>
+  <data name="SelectPlan" xml:space="preserve"><value>选择训练计划</value></data>
+  <data name="NoDetails" xml:space="preserve"><value>未加载详情。</value></data>
+  <data name="Session" xml:space="preserve"><value>训练课</value></data>
+  <data name="Error_Title" xml:space="preserve"><value>注意</value></data>
+  <data name="Error_LoadData" xml:space="preserve"><value>加载你的数据或训练计划时出现问题。</value></data>
+  <data name="Error_SaveBrowser_Title" xml:space="preserve"><value>错误</value></data>
+  <data name="Error_SaveBrowser" xml:space="preserve"><value>无法在浏览器中保存你的选择。</value></data>
+  <data name="Error_SaveServer_Title" xml:space="preserve"><value>错误</value></data>
+  <data name="Error_SaveServer" xml:space="preserve"><value>无法在服务器上保存选择。</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.ar.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>إشعار قانوني</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>معلومات وفقًا للمادة 5 من قانون الخدمات الرقمية الألماني (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>مزود الخدمة</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>ألمانيا</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>الهاتف</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>البريد الإلكتروني</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>المسؤول عن المحتوى</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>الشخص المسؤول عن محتوى هذا الموقع هو</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>معلومات التسجيل والضرائب</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>رقم تعريف ضريبة القيمة المضافة</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>غير مخصص أو غير قابل للتطبيق.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>قيد السجل التجاري</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>لا يوجد قيد في السجل التجاري.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>تسوية نزاعات المستهلكين</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>مزود الخدمة غير مستعد وغير ملزم بالمشاركة في إجراءات تسوية النزاعات أمام هيئة تحكيم للمستهلكين، ما لم يكن هناك التزام قانوني إلزامي.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>المسؤولية عن المحتوى والروابط</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>تم إعداد المحتوى على هذا الموقع بعناية معقولة. وبصفته مزود خدمة، يكون المزود مسؤولًا عن محتواه الخاص وفقًا للقوانين العامة.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>قد يحتوي هذا الموقع على روابط لمواقع خارجية تابعة لأطراف ثالثة. لا يملك المزود أي تأثير على محتواها الحالي أو المستقبلي. تتم مراجعة الصفحات المرتبطة عند إنشاء الرابط بحثًا عن انتهاكات قانونية واضحة. وإذا أصبحت الانتهاكات معروفة، فستتم إزالة هذه الروابط فورًا.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>حقوق النشر</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>يخضع المحتوى والأعمال التي أنشأها المزود على هذا الموقع لقانون حقوق النشر الألماني. يتطلب النسخ أو التحرير أو التوزيع أو أي استخدام يتجاوز حدود حقوق النشر موافقة مسبقة، ما لم يكن الاستخدام مسموحًا به صراحة بموجب القانون.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>الخصوصية</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>لا يحل هذا الإشعار القانوني محل سياسة الخصوصية. تتوفر معلومات معالجة البيانات الشخصية في سياسة الخصوصية لهذا الموقع.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.da.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Juridisk meddelelse</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Oplysninger i henhold til § 5 i den tyske lov om digitale tjenester (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Tjenesteudbyder</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Tyskland</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Ansvarlig for indhold</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>Den person, der er ansvarlig for indholdet på dette website, er</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Register- og skatteoplysninger</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Momsregistreringsnummer</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Ikke tildelt eller ikke relevant.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Registrering i handelsregister</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Ingen registrering i handelsregister.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Forbrugerklageløsning</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Tjenesteudbyderen er hverken villig eller forpligtet til at deltage i tvistbilæggelse ved et forbrugerklagenævn, medmindre en obligatorisk lovpligtig forpligtelse gælder.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Ansvar for indhold og links</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Indholdet på dette website er udarbejdet med rimelig omhu. Som tjenesteudbyder er udbyderen ansvarlig for eget indhold i henhold til de almindelige love.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Dette website kan indeholde links til eksterne tredjepartswebsites. Udbyderen har ingen indflydelse på deres nuværende eller fremtidige indhold. Linkede sider kontrolleres for åbenlyse juridiske overtrædelser, når linket oprettes. Hvis juridiske overtrædelser bliver kendt, fjernes sådanne links straks.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Ophavsret</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Indholdet og værkerne oprettet af udbyderen på dette website er underlagt tysk ophavsret. Kopiering, redigering, distribution eller enhver brug ud over ophavsrettens grænser kræver forudgående samtykke, medmindre brugen udtrykkeligt er tilladt ved lov.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Privatliv</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Denne juridiske meddelelse erstatter ikke privatlivspolitikken. Oplysninger om behandling af personoplysninger findes i privatlivspolitikken på dette website.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.es.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Aviso legal</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Información conforme al artículo 5 de la Ley alemana de servicios digitales (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Proveedor de servicios</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Alemania</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Teléfono</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>Correo electrónico</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Responsable del contenido</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>La persona responsable del contenido de este sitio web es</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Información registral y fiscal</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Número de identificación fiscal IVA</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>No asignado o no aplicable.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Inscripción en el registro mercantil</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Sin inscripción en el registro mercantil.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Resolución de litigios de consumo</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>El proveedor de servicios no está dispuesto ni obligado a participar en procedimientos de resolución de disputas ante una junta de arbitraje de consumo, salvo que exista una obligación legal imperativa.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Responsabilidad por contenido y enlaces</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>El contenido de este sitio web se ha preparado con cuidado razonable. Como proveedor de servicios, el proveedor es responsable de su propio contenido de acuerdo con las leyes generales.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Este sitio web puede contener enlaces a sitios externos de terceros. El proveedor no tiene influencia sobre su contenido actual o futuro. Las páginas enlazadas se revisan al crear el enlace para detectar infracciones legales evidentes. Si se conocen infracciones, dichos enlaces se eliminarán rápidamente.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Derechos de autor</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>El contenido y las obras creadas por el proveedor en este sitio están sujetos a la legislación alemana de derechos de autor. La reproducción, edición, distribución o cualquier uso fuera de los límites del derecho de autor requiere consentimiento previo, salvo que la ley lo permita expresamente.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Privacidad</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Este aviso legal no sustituye a la política de privacidad. La información sobre el tratamiento de datos personales se proporciona en la política de privacidad de este sitio web.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.fa.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>اطلاعیه حقوقی</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>اطلاعات مطابق ماده ۵ قانون خدمات دیجیتال آلمان (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>ارائه‌دهنده خدمات</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>آلمان</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>تلفن</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>ایمیل</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>مسئول محتوا</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>شخص مسئول محتوای این وب‌سایت است</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>اطلاعات ثبت و مالیات</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>شماره شناسایی مالیات بر ارزش افزوده</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>اختصاص داده نشده یا قابل اعمال نیست.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>ثبت در دفتر تجاری</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>ثبت تجاری وجود ندارد.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>حل اختلاف مصرف‌کننده</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>ارائه‌دهنده خدمات، مگر در صورت وجود الزام قانونی اجباری، نه مایل و نه موظف به شرکت در روند حل اختلاف نزد هیئت داوری مصرف‌کنندگان است.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>مسئولیت محتوا و پیوندها</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>محتوای این وب‌سایت با دقت معقول تهیه شده است. ارائه‌دهنده خدمات طبق قوانین عمومی مسئول محتوای خود است.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>این وب‌سایت ممکن است شامل پیوندهایی به وب‌سایت‌های خارجی شخص ثالث باشد. ارائه‌دهنده هیچ تأثیری بر محتوای فعلی یا آینده آن‌ها ندارد. هنگام ایجاد پیوند، صفحات پیوندشده برای تخلفات قانونی آشکار بررسی می‌شوند. اگر تخلفات قانونی شناخته شود، این پیوندها سریعاً حذف خواهند شد.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>حق نشر</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>محتوا و آثار ایجادشده توسط ارائه‌دهنده در این وب‌سایت تابع قانون حق نشر آلمان است. تکثیر، ویرایش، توزیع یا هر استفاده فراتر از حدود حق نشر نیازمند رضایت قبلی است، مگر آن‌که قانون صراحتاً اجازه داده باشد.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>حریم خصوصی</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>این اطلاعیه حقوقی جایگزین سیاست حریم خصوصی نیست. اطلاعات مربوط به پردازش داده‌های شخصی در سیاست حریم خصوصی این وب‌سایت ارائه شده است.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.fr.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Mentions légales</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Informations conformément à l’article 5 de la loi allemande sur les services numériques (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Prestataire de service</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Allemagne</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Téléphone</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Responsable du contenu</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>La personne responsable du contenu de ce site est</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Informations d’enregistrement et fiscales</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Numéro d’identification TVA</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Non attribué ou non applicable.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Inscription au registre du commerce</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Aucune inscription au registre du commerce.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Résolution des litiges de consommation</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Le prestataire n’est ni disposé ni obligé de participer à une procédure de règlement des litiges devant une commission d’arbitrage des consommateurs, sauf obligation légale impérative.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Responsabilité relative au contenu et aux liens</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Le contenu de ce site a été préparé avec un soin raisonnable. En tant que prestataire de services, le fournisseur est responsable de son propre contenu conformément aux lois générales.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Ce site peut contenir des liens vers des sites externes de tiers. Le fournisseur n’a aucune influence sur leur contenu actuel ou futur. Les pages liées sont vérifiées lors de la création du lien afin de détecter d’éventuelles violations manifestes. Si de telles violations sont connues, les liens seront retirés rapidement.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Droit d’auteur</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Les contenus et œuvres créés par le fournisseur sur ce site sont soumis au droit d’auteur allemand. Toute reproduction, modification, distribution ou utilisation au-delà des limites du droit d’auteur nécessite un consentement préalable, sauf autorisation expresse de la loi.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Confidentialité</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Ces mentions légales ne remplacent pas la politique de confidentialité. Les informations relatives au traitement des données personnelles figurent dans la politique de confidentialité de ce site.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.ru.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Правовая информация</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Информация согласно разделу 5 немецкого Закона о цифровых услугах (Digitale-Dienste-Gesetz, DDG).</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Поставщик услуги</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Германия</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Телефон</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>Ответственный за контент</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>Лицо, ответственное за содержание этого сайта:</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Регистрационная и налоговая информация</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>Номер плательщика НДС</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Не назначено или не применимо.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Запись в торговом реестре</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Записи в торговом реестре нет.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Урегулирование потребительских споров</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Поставщик услуги не готов и не обязан участвовать в процедурах урегулирования споров в органе потребительского арбитража, если только не применяется обязательное законодательное требование.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>Ответственность за контент и ссылки</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Содержание этого сайта подготовлено с разумной тщательностью. Как поставщик услуги, провайдер несет ответственность за собственный контент в соответствии с общими законами.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Этот сайт может содержать ссылки на внешние сайты третьих лиц. Поставщик не влияет на их текущее или будущее содержание. Связанные страницы проверяются на очевидные правовые нарушения при создании ссылки. Если такие нарушения станут известны, ссылки будут оперативно удалены.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Авторское право</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Контент и материалы, созданные поставщиком на этом сайте, защищены немецким законодательством об авторском праве. Воспроизведение, редактирование, распространение или любое использование за пределами авторского права требует предварительного согласия, если использование прямо не разрешено законом.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Конфиденциальность</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Эта правовая информация не заменяет политику конфиденциальности. Информация об обработке персональных данных приведена в политике конфиденциальности этого сайта.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.tr.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Yasal bildirim</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Alman Dijital Hizmetler Yasası (Digitale-Dienste-Gesetz, DDG) 5. maddesi uyarınca bilgiler.</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>Hizmet sağlayıcı</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>Almanya</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-posta</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>İçerikten sorumlu</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>Bu web sitesinin içeriğinden sorumlu kişi</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>Kayıt ve vergi bilgileri</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>KDV kimlik numarası</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>Atanmamış veya uygulanamaz.</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>Ticaret sicili kaydı</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>Ticaret sicili kaydı yok.</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>Tüketici uyuşmazlık çözümü</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>Zorunlu bir yasal yükümlülük bulunmadıkça hizmet sağlayıcı, bir tüketici tahkim kurulu önündeki uyuşmazlık çözüm süreçlerine katılmaya ne istekli ne de yükümlüdür.</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>İçerik ve bağlantılara ilişkin sorumluluk</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>Bu web sitesindeki içerik makul özenle hazırlanmıştır. Hizmet sağlayıcı olarak sağlayıcı, genel yasalar uyarınca kendi içeriğinden sorumludur.</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>Bu web sitesi harici üçüncü taraf web sitelerine bağlantılar içerebilir. Sağlayıcının bu sitelerin mevcut veya gelecekteki içerikleri üzerinde etkisi yoktur. Bağlantı verilen sayfalar oluşturulduklarında açık yasal ihlaller açısından kontrol edilir. Yasal ihlaller öğrenilirse bu bağlantılar derhal kaldırılır.</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>Telif hakkı</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>Bu web sitesinde sağlayıcı tarafından oluşturulan içerik ve çalışmalar Alman telif hakkı yasasına tabidir. Yasaların açıkça izin verdiği durumlar dışında çoğaltma, düzenleme, dağıtım veya telif hakkı sınırlarının ötesindeki her türlü kullanım önceden onay gerektirir.</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>Gizlilik</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>Bu yasal bildirim gizlilik politikasının yerine geçmez. Kişisel verilerin işlenmesine ilişkin bilgiler bu web sitesinin gizlilik politikasında yer alır.</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Impressum.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Impressum.zh.resx
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>法律声明</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>根据德国数字服务法（Digitale-Dienste-Gesetz, DDG）第 5 条提供的信息。</value>
+  </data>
+  <data name="ProviderHeading" xml:space="preserve">
+    <value>服务提供者</value>
+  </data>
+  <data name="Country" xml:space="preserve">
+    <value>德国</value>
+  </data>
+  <data name="Phone" xml:space="preserve">
+    <value>电话</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>电子邮件</value>
+  </data>
+  <data name="ResponsibleHeading" xml:space="preserve">
+    <value>内容负责人</value>
+  </data>
+  <data name="ResponsibleText" xml:space="preserve">
+    <value>本网站内容负责人是</value>
+  </data>
+  <data name="TaxHeading" xml:space="preserve">
+    <value>登记和税务信息</value>
+  </data>
+  <data name="VatId" xml:space="preserve">
+    <value>增值税识别号</value>
+  </data>
+  <data name="VatIdNotProvided" xml:space="preserve">
+    <value>未分配或不适用。</value>
+  </data>
+  <data name="RegisterEntry" xml:space="preserve">
+    <value>商业登记信息</value>
+  </data>
+  <data name="RegisterEntryNotProvided" xml:space="preserve">
+    <value>无商业登记信息。</value>
+  </data>
+  <data name="DisputeHeading" xml:space="preserve">
+    <value>消费者争议解决</value>
+  </data>
+  <data name="DisputeText" xml:space="preserve">
+    <value>除非有强制性法定义务，服务提供者既不愿意也没有义务参与消费者仲裁委员会前的争议解决程序。</value>
+  </data>
+  <data name="LiabilityHeading" xml:space="preserve">
+    <value>内容和链接责任</value>
+  </data>
+  <data name="LiabilityOwnContent" xml:space="preserve">
+    <value>本网站内容已尽合理谨慎编制。作为服务提供者，提供者根据一般法律对自己的内容负责。</value>
+  </data>
+  <data name="LiabilityLinks" xml:space="preserve">
+    <value>本网站可能包含指向外部第三方网站的链接。提供者无法影响这些网站当前或未来的内容。链接创建时会检查明显的法律违规。如果发现法律违规，这些链接将被及时移除。</value>
+  </data>
+  <data name="CopyrightHeading" xml:space="preserve">
+    <value>版权</value>
+  </data>
+  <data name="CopyrightText" xml:space="preserve">
+    <value>提供者在本网站创建的内容和作品受德国版权法保护。除非法律明确允许，复制、编辑、传播或任何超出版权法范围的使用都需要事先同意。</value>
+  </data>
+  <data name="PrivacyHeading" xml:space="preserve">
+    <value>隐私</value>
+  </data>
+  <data name="PrivacyText" xml:space="preserve">
+    <value>本法律声明不替代隐私政策。有关个人数据处理的信息请见本网站的隐私政策。</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.ar.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>إشعار ملفات تعريف الارتباط</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>نستخدم ملفات تعريف الارتباط لتقديم أفضل تجربة ممكنة على موقعنا وحفظ حالة تسجيل الدخول. هذه الملفات ضرورية لوظائف الموقع.</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>بالنقر على "قبول" أو متابعة استخدام الموقع، فإنك توافق على استخدام هذه الملفات. إذا أردت معرفة المزيد عن الملفات التي نستخدمها أو سحب موافقتك، فانقر على "معرفة المزيد".</value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>معرفة المزيد</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>قبول</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.da.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>Cookiemeddelelse</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>Vi bruger cookies til at give dig den bedst mulige oplevelse på vores website og gemme din loginstatus. Disse cookies er nødvendige for websitets funktionalitet.</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>Ved at klikke på "Accepter" eller fortsætte med at bruge websitet accepterer du brugen af disse cookies. Hvis du vil læse mere om de cookies, vi bruger, eller trække dit samtykke tilbage, skal du klikke på "Læs mere".</value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>Læs mere</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Accepter</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.es.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>Aviso de cookies</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>Usamos cookies para ofrecerte la mejor experiencia posible en nuestro sitio y guardar tu estado de inicio de sesión. Estas cookies son esenciales para el funcionamiento del sitio.</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>Al hacer clic en “Aceptar” o continuar usando el sitio, aceptas el uso de estas cookies. Si quieres saber más sobre las cookies que usamos o retirar tu consentimiento, haz clic en “Más información”.</value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>Más información</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Aceptar</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.fa.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>اطلاعیه کوکی</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>ما از کوکی‌ها برای ارائه بهترین تجربه ممکن در وب‌سایت و ذخیره وضعیت ورود شما استفاده می‌کنیم. این کوکی‌ها برای عملکرد وب‌سایت ضروری هستند.</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>با کلیک روی «پذیرش» یا ادامه استفاده از وب‌سایت، با استفاده از این کوکی‌ها موافقت می‌کنید. اگر می‌خواهید درباره کوکی‌هایی که استفاده می‌کنیم بیشتر بدانید یا رضایت خود را پس بگیرید، روی «بیشتر بدانید» کلیک کنید.</value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>بیشتر بدانید</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>پذیرش</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.fr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>Avis sur les cookies</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>Nous utilisons des cookies pour vous offrir la meilleure expérience possible sur notre site et enregistrer votre état de connexion. Ces cookies sont essentiels au fonctionnement du site.</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>En cliquant sur « Accepter » ou en continuant à utiliser le site, vous acceptez l’utilisation de ces cookies. Pour en savoir plus sur les cookies utilisés ou retirer votre consentement, cliquez sur « En savoir plus ». </value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>En savoir plus</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Accepter</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.ru.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>Уведомление о cookie</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>Мы используем cookie, чтобы обеспечить наилучший опыт на сайте и сохранить ваш статус входа. Эти cookie необходимы для работы сайта.</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>Нажимая «Принять» или продолжая пользоваться сайтом, вы соглашаетесь с использованием этих cookie. Если вы хотите узнать больше о cookie, которые мы используем, или отозвать согласие, нажмите «Подробнее».</value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>Подробнее</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Принять</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.tr.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>Çerez bildirimi</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>Web sitemizde size en iyi deneyimi sunmak ve giriş durumunuzu kaydetmek için çerezleri kullanıyoruz. Bu çerezler web sitesinin işlevselliği için gereklidir.</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>"Kabul et"e tıklayarak veya web sitesini kullanmaya devam ederek bu çerezlerin kullanımını kabul edersiniz. Kullandığımız çerezler hakkında daha fazla bilgi almak veya onayınızı geri çekmek istiyorsanız lütfen "Daha fazla bilgi"ye tıklayın.</value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>Daha fazla bilgi</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Kabul et</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_CookieConsentPartial.zh.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CookieNotice" xml:space="preserve">
+    <value>Cookie 通知</value>
+  </data>
+  <data name="CookieText" xml:space="preserve">
+    <value>我们使用 Cookie 为你提供最佳网站体验并保存登录状态。这些 Cookie 对网站功能至关重要。</value>
+  </data>
+  <data name="ConsentText" xml:space="preserve">
+    <value>点击“接受”或继续使用网站，即表示你同意使用这些 Cookie。如果你想了解我们使用的 Cookie 或撤回同意，请点击“了解更多”。</value>
+  </data>
+  <data name="LearnMore" xml:space="preserve">
+    <value>了解更多</value>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>接受</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.ar.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>مرحبًا</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>تسجيل الخروج</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>تسجيل</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>تسجيل الدخول</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.da.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Hej</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Log ud</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrer</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Login</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.es.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Hola</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Cerrar sesión</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrarse</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Inicio de sesión</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.fa.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>سلام</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>خروج</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>ثبت‌نام</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>ورود</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.fr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Bonjour</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Déconnexion</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>S’inscrire</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Connexion</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.ru.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Привет</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Выйти</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Регистрация</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Вход</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.tr.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Merhaba</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Çıkış</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Kayıt ol</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Giriş</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Shared/_LoginPartial.zh.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>你好</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>退出登录</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>注册</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>登录</value>
+  </data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.ar.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>إدارة الدورات</value></data>
+  <data name="Loading" xml:space="preserve"><value>جارٍ تحميل الدورات</value></data>
+  <data name="Title" xml:space="preserve"><value>إدارة الدورات</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>أنشئ دورات وأضف مدربين واحذف دوراتك الخاصة.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>إنشاء دورة جديدة</value></data>
+  <data name="Name" xml:space="preserve"><value>الاسم</value></data>
+  <data name="Level" xml:space="preserve"><value>المستوى</value></data>
+  <data name="Description" xml:space="preserve"><value>الوصف</value></data>
+  <data name="Start" xml:space="preserve"><value>البداية</value></data>
+  <data name="End" xml:space="preserve"><value>النهاية</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>إنشاء دورة</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>لست معينًا كمدرب في أي دورة.</value></data>
+  <data name="Course" xml:space="preserve"><value>دورة</value></data>
+  <data name="Leave" xml:space="preserve"><value>مغادرة</value></data>
+  <data name="Trainers" xml:space="preserve"><value>المدربون</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>إضافة مدرب</value></data>
+  <data name="Add" xml:space="preserve"><value>إضافة</value></data>
+  <data name="Dates" xml:space="preserve"><value>المواعيد</value></data>
+  <data name="NoDates" xml:space="preserve"><value>لا توجد مواعيد بعد.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>العنوان</value></data>
+  <data name="Location" xml:space="preserve"><value>الموقع</value></data>
+  <data name="Date" xml:space="preserve"><value>التاريخ</value></data>
+  <data name="StartTime" xml:space="preserve"><value>وقت البدء</value></data>
+  <data name="EndTime" xml:space="preserve"><value>وقت الانتهاء</value></data>
+  <data name="Notes" xml:space="preserve"><value>ملاحظات</value></data>
+  <data name="AddDate" xml:space="preserve"><value>إضافة موعد</value></data>
+  <data name="Events" xml:space="preserve"><value>الفعاليات</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>لا توجد فعاليات بعد.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>لا يوجد مشاركون مسجلون بعد.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>السعة</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>موعد انتهاء التسجيل</value></data>
+  <data name="EventType" xml:space="preserve"><value>نوع الفعالية</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>عام</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>تحليل الجري</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>إضافة فعالية</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>خطط التدريب</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>لم تُنشر أي خطة بعد.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>خطة التدريب</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>إضافة خطة</value></data>
+  <data name="Participants" xml:space="preserve"><value>المشاركون</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>المشاركون ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>تم إنشاء الدورة.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>هل تريد حقًا حذف الدورة &quot;{0}&quot;؟</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>تم حذف الدورة.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>تمت إضافة المدرب.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>إزالة {0} من الدورة؟</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>تمت إزالة المدرب.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>مغادرة &quot;{0}&quot; كمدرب؟</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>لقد غادرت كمدرب.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>تمت إضافة الموعد.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>إزالة الموعد &quot;{0}&quot;؟</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>تمت إزالة الموعد.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>تمت إضافة الفعالية.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>إزالة الفعالية &quot;{0}&quot;؟</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>تمت إزالة الفعالية.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>تمت إضافة خطة التدريب.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>إزالة خطة التدريب &quot;{0}&quot;؟</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>تمت إزالة خطة التدريب.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:yyyy/MM/dd} إلى {1:yyyy/MM/dd}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm} إلى {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>يرجى اختيار تاريخ.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>يرجى إدخال وقت بتنسيق HH:mm.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>تعذر تحديد المدرب.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.da.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Administrer kurser</value></data>
+  <data name="Loading" xml:space="preserve"><value>Indlæser kurser</value></data>
+  <data name="Title" xml:space="preserve"><value>Administrer kurser</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Opret kurser, tilføj coaches, og slet dine egne kurser.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>Opret et nyt kursus</value></data>
+  <data name="Name" xml:space="preserve"><value>Navn</value></data>
+  <data name="Level" xml:space="preserve"><value>Niveau</value></data>
+  <data name="Description" xml:space="preserve"><value>Beskrivelse</value></data>
+  <data name="Start" xml:space="preserve"><value>Start</value></data>
+  <data name="End" xml:space="preserve"><value>Slut</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>Opret kursus</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>Du er ikke tilknyttet noget kursus som coach.</value></data>
+  <data name="Course" xml:space="preserve"><value>Kursus</value></data>
+  <data name="Leave" xml:space="preserve"><value>Forlad</value></data>
+  <data name="Trainers" xml:space="preserve"><value>Coaches</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>Tilføj coach</value></data>
+  <data name="Add" xml:space="preserve"><value>Tilføj</value></data>
+  <data name="Dates" xml:space="preserve"><value>Datoer</value></data>
+  <data name="NoDates" xml:space="preserve"><value>Ingen datoer endnu.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>Titel</value></data>
+  <data name="Location" xml:space="preserve"><value>Sted</value></data>
+  <data name="Date" xml:space="preserve"><value>Dato</value></data>
+  <data name="StartTime" xml:space="preserve"><value>Starttid</value></data>
+  <data name="EndTime" xml:space="preserve"><value>Sluttid</value></data>
+  <data name="Notes" xml:space="preserve"><value>Noter</value></data>
+  <data name="AddDate" xml:space="preserve"><value>Tilføj dato</value></data>
+  <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Ingen events endnu.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>Ingen deltagere registreret endnu.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>Kapacitet</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>Tilmeldingsfrist</value></data>
+  <data name="EventType" xml:space="preserve"><value>Eventtype</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>Generelt</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Løbeanalyse</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>Tilføj event</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Træningsplaner</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>Ingen plan offentliggjort endnu.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>Træningsplan</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>Tilføj plan</value></data>
+  <data name="Participants" xml:space="preserve"><value>Deltagere</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>Deltagere ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>Kursus blev oprettet.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>Vil du virkelig slette kurset &quot;{0}&quot;?</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>Kursus blev slettet.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>Coach blev tilføjet.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>Fjern {0} fra kurset?</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>Coach blev fjernet.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>Forlad &quot;{0}&quot; som coach?</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>Du forlod rollen som coach.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>Dato blev tilføjet.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>Fjern datoen &quot;{0}&quot;?</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>Dato blev fjernet.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>Event blev tilføjet.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>Fjern eventet &quot;{0}&quot;?</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>Event blev fjernet.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>Træningsplan blev tilføjet.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>Fjern træningsplanen &quot;{0}&quot;?</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>Træningsplan blev fjernet.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} til {1:dd.MM.yyyy}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} til {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>Vælg en dato.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>Indtast et tidspunkt i HH:mm-format.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>Coachen kunne ikke findes.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.es.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Gestionar cursos</value></data>
+  <data name="Loading" xml:space="preserve"><value>Cargando cursos</value></data>
+  <data name="Title" xml:space="preserve"><value>Gestionar cursos</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Crea cursos, añade entrenadores y elimina tus propios cursos.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>Crear un nuevo curso</value></data>
+  <data name="Name" xml:space="preserve"><value>Nombre</value></data>
+  <data name="Level" xml:space="preserve"><value>Nivel</value></data>
+  <data name="Description" xml:space="preserve"><value>Descripción</value></data>
+  <data name="Start" xml:space="preserve"><value>Inicio</value></data>
+  <data name="End" xml:space="preserve"><value>Fin</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>Crear curso</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>No estás asignado a ningún curso como entrenador.</value></data>
+  <data name="Course" xml:space="preserve"><value>Curso</value></data>
+  <data name="Leave" xml:space="preserve"><value>Salir</value></data>
+  <data name="Trainers" xml:space="preserve"><value>Entrenadores</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>Añadir entrenador</value></data>
+  <data name="Add" xml:space="preserve"><value>Añadir</value></data>
+  <data name="Dates" xml:space="preserve"><value>Fechas</value></data>
+  <data name="NoDates" xml:space="preserve"><value>Aún no hay fechas.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>Título</value></data>
+  <data name="Location" xml:space="preserve"><value>Ubicación</value></data>
+  <data name="Date" xml:space="preserve"><value>Fecha</value></data>
+  <data name="StartTime" xml:space="preserve"><value>Hora de inicio</value></data>
+  <data name="EndTime" xml:space="preserve"><value>Hora de fin</value></data>
+  <data name="Notes" xml:space="preserve"><value>Notas</value></data>
+  <data name="AddDate" xml:space="preserve"><value>Añadir fecha</value></data>
+  <data name="Events" xml:space="preserve"><value>Eventos</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Aún no hay eventos.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>Aún no hay participantes registrados.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>Capacidad</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>Fecha límite de inscripción</value></data>
+  <data name="EventType" xml:space="preserve"><value>Tipo de evento</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>General</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Análisis de carrera</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>Añadir evento</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Planes de entrenamiento</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>Aún no hay plan publicado.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>Plan de entrenamiento</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>Añadir plan</value></data>
+  <data name="Participants" xml:space="preserve"><value>Participantes</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>Participantes ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>Se creó el curso.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>¿Eliminar realmente el curso &quot;{0}&quot;?</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>Se eliminó el curso.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>Se añadió el entrenador.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>¿Eliminar a {0} del curso?</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>Se eliminó el entrenador.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>¿Salir de &quot;{0}&quot; como entrenador?</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>Has salido como entrenador.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>Se añadió la fecha.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>¿Eliminar fecha &quot;{0}&quot;?</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>Se eliminó la fecha.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>Se añadió el evento.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>¿Eliminar evento &quot;{0}&quot;?</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>Se eliminó el evento.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>Se añadió el plan de entrenamiento.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>¿Eliminar plan de entrenamiento &quot;{0}&quot;?</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>Se eliminó el plan de entrenamiento.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd/MM/yyyy} a {1:dd/MM/yyyy}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:dd/MM/yyyy HH:mm} a {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>Selecciona una fecha.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>Introduce una hora en formato HH:mm.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>No se pudo resolver el entrenador.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.fa.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>مدیریت دوره‌ها</value></data>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری دوره‌ها</value></data>
+  <data name="Title" xml:space="preserve"><value>مدیریت دوره‌ها</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>دوره ایجاد کنید، مربی اضافه کنید و دوره‌های خود را حذف کنید.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>ایجاد دوره جدید</value></data>
+  <data name="Name" xml:space="preserve"><value>نام</value></data>
+  <data name="Level" xml:space="preserve"><value>سطح</value></data>
+  <data name="Description" xml:space="preserve"><value>توضیح</value></data>
+  <data name="Start" xml:space="preserve"><value>شروع</value></data>
+  <data name="End" xml:space="preserve"><value>پایان</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>ایجاد دوره</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>شما به عنوان مربی به هیچ دوره‌ای اختصاص داده نشده‌اید.</value></data>
+  <data name="Course" xml:space="preserve"><value>دوره</value></data>
+  <data name="Leave" xml:space="preserve"><value>ترک</value></data>
+  <data name="Trainers" xml:space="preserve"><value>مربیان</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>افزودن مربی</value></data>
+  <data name="Add" xml:space="preserve"><value>افزودن</value></data>
+  <data name="Dates" xml:space="preserve"><value>تاریخ‌ها</value></data>
+  <data name="NoDates" xml:space="preserve"><value>هنوز تاریخی وجود ندارد.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>عنوان</value></data>
+  <data name="Location" xml:space="preserve"><value>مکان</value></data>
+  <data name="Date" xml:space="preserve"><value>تاریخ</value></data>
+  <data name="StartTime" xml:space="preserve"><value>زمان شروع</value></data>
+  <data name="EndTime" xml:space="preserve"><value>زمان پایان</value></data>
+  <data name="Notes" xml:space="preserve"><value>یادداشت‌ها</value></data>
+  <data name="AddDate" xml:space="preserve"><value>افزودن تاریخ</value></data>
+  <data name="Events" xml:space="preserve"><value>رویدادها</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>هنوز رویدادی وجود ندارد.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>هنوز شرکت‌کننده‌ای ثبت‌نام نکرده است.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>ظرفیت</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>مهلت ثبت‌نام</value></data>
+  <data name="EventType" xml:space="preserve"><value>نوع رویداد</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>عمومی</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>تحلیل دویدن</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>افزودن رویداد</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>برنامه‌های تمرینی</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>هنوز برنامه‌ای منتشر نشده است.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>برنامه تمرینی</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>افزودن برنامه</value></data>
+  <data name="Participants" xml:space="preserve"><value>شرکت‌کنندگان</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>شرکت‌کنندگان ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>دوره ایجاد شد.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>واقعاً دوره &quot;{0}&quot; حذف شود؟</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>دوره حذف شد.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>مربی اضافه شد.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>{0} از دوره حذف شود؟</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>مربی حذف شد.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>&quot;{0}&quot; را به عنوان مربی ترک می‌کنید؟</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>شما به عنوان مربی خارج شدید.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>تاریخ اضافه شد.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>تاریخ &quot;{0}&quot; حذف شود؟</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>تاریخ حذف شد.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>رویداد اضافه شد.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>رویداد &quot;{0}&quot; حذف شود؟</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>رویداد حذف شد.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>برنامه تمرینی اضافه شد.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>برنامه تمرینی &quot;{0}&quot; حذف شود؟</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>برنامه تمرینی حذف شد.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:yyyy/MM/dd} تا {1:yyyy/MM/dd}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm} تا {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>لطفاً یک تاریخ انتخاب کنید.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>لطفاً زمان را با قالب HH:mm وارد کنید.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>مربی شناسایی نشد.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.fr.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Gérer les cours</value></data>
+  <data name="Loading" xml:space="preserve"><value>Chargement des cours</value></data>
+  <data name="Title" xml:space="preserve"><value>Gérer les cours</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Créez des cours, ajoutez des coachs et supprimez vos propres cours.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>Créer un nouveau cours</value></data>
+  <data name="Name" xml:space="preserve"><value>Nom</value></data>
+  <data name="Level" xml:space="preserve"><value>Niveau</value></data>
+  <data name="Description" xml:space="preserve"><value>Description</value></data>
+  <data name="Start" xml:space="preserve"><value>Début</value></data>
+  <data name="End" xml:space="preserve"><value>Fin</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>Créer le cours</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>Vous n’êtes affecté à aucun cours comme coach.</value></data>
+  <data name="Course" xml:space="preserve"><value>Cours</value></data>
+  <data name="Leave" xml:space="preserve"><value>Quitter</value></data>
+  <data name="Trainers" xml:space="preserve"><value>Coachs</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>Ajouter un coach</value></data>
+  <data name="Add" xml:space="preserve"><value>Ajouter</value></data>
+  <data name="Dates" xml:space="preserve"><value>Dates</value></data>
+  <data name="NoDates" xml:space="preserve"><value>Pas encore de dates.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>Titre</value></data>
+  <data name="Location" xml:space="preserve"><value>Lieu</value></data>
+  <data name="Date" xml:space="preserve"><value>Date</value></data>
+  <data name="StartTime" xml:space="preserve"><value>Heure de début</value></data>
+  <data name="EndTime" xml:space="preserve"><value>Heure de fin</value></data>
+  <data name="Notes" xml:space="preserve"><value>Notes</value></data>
+  <data name="AddDate" xml:space="preserve"><value>Ajouter une date</value></data>
+  <data name="Events" xml:space="preserve"><value>Événements</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Pas encore d’événements.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>Aucun participant inscrit pour le moment.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>Capacité</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>Date limite d’inscription</value></data>
+  <data name="EventType" xml:space="preserve"><value>Type d’événement</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>Général</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Analyse de course</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>Ajouter un événement</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Plans d’entraînement</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>Aucun plan publié pour le moment.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>Plan d’entraînement</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>Ajouter un plan</value></data>
+  <data name="Participants" xml:space="preserve"><value>Participants</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>Participants ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>Le cours a été créé.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>Voulez-vous vraiment supprimer le cours &quot;{0}&quot; ?</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>Le cours a été supprimé.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>Le coach a été ajouté.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>Retirer {0} du cours ?</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>Le coach a été retiré.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>Quitter &quot;{0}&quot; en tant que coach ?</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>Vous avez quitté le rôle de coach.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>La date a été ajoutée.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>Supprimer la date &quot;{0}&quot; ?</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>La date a été retirée.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>L’événement a été ajouté.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>Supprimer l’événement &quot;{0}&quot; ?</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>L’événement a été retiré.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>Le plan d’entraînement a été ajouté.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>Supprimer le plan d’entraînement &quot;{0}&quot; ?</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>Le plan d’entraînement a été retiré.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd/MM/yyyy} à {1:dd/MM/yyyy}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:dd/MM/yyyy HH:mm} à {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>Veuillez sélectionner une date.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>Veuillez saisir une heure au format HH:mm.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>Le coach n’a pas pu être résolu.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.ru.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Управление курсами</value></data>
+  <data name="Loading" xml:space="preserve"><value>Загрузка курсов</value></data>
+  <data name="Title" xml:space="preserve"><value>Управление курсами</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Создавайте курсы, добавляйте тренеров и удаляйте свои курсы.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>Создать новый курс</value></data>
+  <data name="Name" xml:space="preserve"><value>Название</value></data>
+  <data name="Level" xml:space="preserve"><value>Уровень</value></data>
+  <data name="Description" xml:space="preserve"><value>Описание</value></data>
+  <data name="Start" xml:space="preserve"><value>Начало</value></data>
+  <data name="End" xml:space="preserve"><value>Конец</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>Создать курс</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>Вы не назначены тренером ни на один курс.</value></data>
+  <data name="Course" xml:space="preserve"><value>Курс</value></data>
+  <data name="Leave" xml:space="preserve"><value>Покинуть</value></data>
+  <data name="Trainers" xml:space="preserve"><value>Тренеры</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>Добавить тренера</value></data>
+  <data name="Add" xml:space="preserve"><value>Добавить</value></data>
+  <data name="Dates" xml:space="preserve"><value>Даты</value></data>
+  <data name="NoDates" xml:space="preserve"><value>Дат пока нет.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>Заголовок</value></data>
+  <data name="Location" xml:space="preserve"><value>Место</value></data>
+  <data name="Date" xml:space="preserve"><value>Дата</value></data>
+  <data name="StartTime" xml:space="preserve"><value>Время начала</value></data>
+  <data name="EndTime" xml:space="preserve"><value>Время окончания</value></data>
+  <data name="Notes" xml:space="preserve"><value>Заметки</value></data>
+  <data name="AddDate" xml:space="preserve"><value>Добавить дату</value></data>
+  <data name="Events" xml:space="preserve"><value>События</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Событий пока нет.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>Участники пока не зарегистрированы.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>Вместимость</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>Срок регистрации</value></data>
+  <data name="EventType" xml:space="preserve"><value>Тип события</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>Общее</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Анализ бега</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>Добавить событие</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Планы тренировок</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>План пока не опубликован.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>План тренировок</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>Добавить план</value></data>
+  <data name="Participants" xml:space="preserve"><value>Участники</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>Участники ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>Курс создан.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>Действительно удалить курс &quot;{0}&quot;?</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>Курс удален.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>Тренер добавлен.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>Удалить {0} из курса?</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>Тренер удален.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>Покинуть &quot;{0}&quot; как тренер?</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>Вы покинули курс как тренер.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>Дата добавлена.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>Удалить дату &quot;{0}&quot;?</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>Дата удалена.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>Событие добавлено.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>Удалить событие &quot;{0}&quot;?</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>Событие удалено.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>План тренировок добавлен.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>Удалить план тренировок &quot;{0}&quot;?</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>План тренировок удален.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} – {1:dd.MM.yyyy}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} – {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>Выберите дату.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>Введите время в формате HH:mm.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>Не удалось определить тренера.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.tr.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Kursları yönet</value></data>
+  <data name="Loading" xml:space="preserve"><value>Kurslar yükleniyor</value></data>
+  <data name="Title" xml:space="preserve"><value>Kursları yönet</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Kurs oluştur, antrenör ekle ve kendi kurslarını sil.</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>Yeni kurs oluştur</value></data>
+  <data name="Name" xml:space="preserve"><value>Ad</value></data>
+  <data name="Level" xml:space="preserve"><value>Seviye</value></data>
+  <data name="Description" xml:space="preserve"><value>Açıklama</value></data>
+  <data name="Start" xml:space="preserve"><value>Başlangıç</value></data>
+  <data name="End" xml:space="preserve"><value>Bitiş</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>Kurs oluştur</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>Antrenör olarak hiçbir kursa atanmadın.</value></data>
+  <data name="Course" xml:space="preserve"><value>Kurs</value></data>
+  <data name="Leave" xml:space="preserve"><value>Ayrıl</value></data>
+  <data name="Trainers" xml:space="preserve"><value>Antrenörler</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>Antrenör ekle</value></data>
+  <data name="Add" xml:space="preserve"><value>Ekle</value></data>
+  <data name="Dates" xml:space="preserve"><value>Tarihler</value></data>
+  <data name="NoDates" xml:space="preserve"><value>Henüz tarih yok.</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>Başlık</value></data>
+  <data name="Location" xml:space="preserve"><value>Konum</value></data>
+  <data name="Date" xml:space="preserve"><value>Tarih</value></data>
+  <data name="StartTime" xml:space="preserve"><value>Başlangıç saati</value></data>
+  <data name="EndTime" xml:space="preserve"><value>Bitiş saati</value></data>
+  <data name="Notes" xml:space="preserve"><value>Notlar</value></data>
+  <data name="AddDate" xml:space="preserve"><value>Tarih ekle</value></data>
+  <data name="Events" xml:space="preserve"><value>Etkinlikler</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>Henüz etkinlik yok.</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>Henüz kayıtlı katılımcı yok.</value></data>
+  <data name="Capacity" xml:space="preserve"><value>Kapasite</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>Kayıt son tarihi</value></data>
+  <data name="EventType" xml:space="preserve"><value>Etkinlik türü</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>Genel</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Koşu analizi</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>Etkinlik ekle</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>Antrenman planları</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>Henüz plan yayınlanmadı.</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>Antrenman planı</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>Plan ekle</value></data>
+  <data name="Participants" xml:space="preserve"><value>Katılımcılar</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>Katılımcılar ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>Kurs oluşturuldu.</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>&quot;{0}&quot; kursu gerçekten silinsin mi?</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>Kurs silindi.</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>Antrenör eklendi.</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>{0} kurstan kaldırılsın mı?</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>Antrenör kaldırıldı.</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>&quot;{0}&quot; kursundan antrenör olarak ayrıl?</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>Antrenör olarak ayrıldın.</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>Tarih eklendi.</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>&quot;{0}&quot; tarihi kaldırılsın mı?</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>Tarih kaldırıldı.</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>Etkinlik eklendi.</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>&quot;{0}&quot; etkinliği kaldırılsın mı?</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>Etkinlik kaldırıldı.</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>Antrenman planı eklendi.</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>&quot;{0}&quot; antrenman planı kaldırılsın mı?</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>Antrenman planı kaldırıldı.</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} - {1:dd.MM.yyyy}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} - {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>Lütfen bir tarih seç.</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>Lütfen HH:mm formatında saat gir.</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>Antrenör bulunamadı.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.zh.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>管理课程</value></data>
+  <data name="Loading" xml:space="preserve"><value>正在加载课程</value></data>
+  <data name="Title" xml:space="preserve"><value>管理课程</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>创建课程、添加教练并删除自己的课程。</value></data>
+  <data name="CreateCourseTitle" xml:space="preserve"><value>创建新课程</value></data>
+  <data name="Name" xml:space="preserve"><value>名称</value></data>
+  <data name="Level" xml:space="preserve"><value>等级</value></data>
+  <data name="Description" xml:space="preserve"><value>描述</value></data>
+  <data name="Start" xml:space="preserve"><value>开始</value></data>
+  <data name="End" xml:space="preserve"><value>结束</value></data>
+  <data name="CreateCourse" xml:space="preserve"><value>创建课程</value></data>
+  <data name="NoTrainerCourses" xml:space="preserve"><value>你没有作为教练分配到任何课程。</value></data>
+  <data name="Course" xml:space="preserve"><value>课程</value></data>
+  <data name="Leave" xml:space="preserve"><value>退出</value></data>
+  <data name="Trainers" xml:space="preserve"><value>教练</value></data>
+  <data name="AddTrainerLabel" xml:space="preserve"><value>添加教练</value></data>
+  <data name="Add" xml:space="preserve"><value>添加</value></data>
+  <data name="Dates" xml:space="preserve"><value>日期</value></data>
+  <data name="NoDates" xml:space="preserve"><value>暂无日期。</value></data>
+  <data name="EventTitle" xml:space="preserve"><value>标题</value></data>
+  <data name="Location" xml:space="preserve"><value>地点</value></data>
+  <data name="Date" xml:space="preserve"><value>日期</value></data>
+  <data name="StartTime" xml:space="preserve"><value>开始时间</value></data>
+  <data name="EndTime" xml:space="preserve"><value>结束时间</value></data>
+  <data name="Notes" xml:space="preserve"><value>备注</value></data>
+  <data name="AddDate" xml:space="preserve"><value>添加日期</value></data>
+  <data name="Events" xml:space="preserve"><value>活动</value></data>
+  <data name="NoEvents" xml:space="preserve"><value>暂无活动。</value></data>
+  <data name="NoParticipants" xml:space="preserve"><value>暂无已报名参与者。</value></data>
+  <data name="Capacity" xml:space="preserve"><value>容量</value></data>
+  <data name="RegistrationDeadline" xml:space="preserve"><value>报名截止日期</value></data>
+  <data name="EventType" xml:space="preserve"><value>活动类型</value></data>
+  <data name="EventType_General" xml:space="preserve"><value>常规</value></data>
+  <data name="EventType_RunningAnalysis" xml:space="preserve"><value>跑步分析</value></data>
+  <data name="AddEvent" xml:space="preserve"><value>添加活动</value></data>
+  <data name="TrainingPlans" xml:space="preserve"><value>训练计划</value></data>
+  <data name="NoPublishedPlan" xml:space="preserve"><value>尚未发布计划。</value></data>
+  <data name="TrainingPlan" xml:space="preserve"><value>训练计划</value></data>
+  <data name="AddPlan" xml:space="preserve"><value>添加计划</value></data>
+  <data name="Participants" xml:space="preserve"><value>参与者</value></data>
+  <data name="ParticipantsCount" xml:space="preserve"><value>参与者 ({0})</value></data>
+  <data name="CreateCourseSuccess" xml:space="preserve"><value>课程已创建。</value></data>
+  <data name="DeleteCourseConfirm" xml:space="preserve"><value>确定删除课程“{0}”？</value></data>
+  <data name="DeleteCourseSuccess" xml:space="preserve"><value>课程已删除。</value></data>
+  <data name="AddTrainerSuccess" xml:space="preserve"><value>教练已添加。</value></data>
+  <data name="RemoveTrainerConfirm" xml:space="preserve"><value>从课程中移除 {0}？</value></data>
+  <data name="RemoveTrainerSuccess" xml:space="preserve"><value>教练已移除。</value></data>
+  <data name="LeaveTrainerConfirm" xml:space="preserve"><value>以教练身份退出“{0}”？</value></data>
+  <data name="LeaveTrainerSuccess" xml:space="preserve"><value>你已以教练身份退出。</value></data>
+  <data name="AddDateSuccess" xml:space="preserve"><value>日期已添加。</value></data>
+  <data name="RemoveDateConfirm" xml:space="preserve"><value>移除日期“{0}”？</value></data>
+  <data name="RemoveDateSuccess" xml:space="preserve"><value>日期已移除。</value></data>
+  <data name="AddEventSuccess" xml:space="preserve"><value>活动已添加。</value></data>
+  <data name="DeleteEventConfirm" xml:space="preserve"><value>移除活动“{0}”？</value></data>
+  <data name="DeleteEventSuccess" xml:space="preserve"><value>活动已移除。</value></data>
+  <data name="PublishPlanSuccess" xml:space="preserve"><value>训练计划已添加。</value></data>
+  <data name="RemovePlanConfirm" xml:space="preserve"><value>移除训练计划“{0}”？</value></data>
+  <data name="RemovePlanSuccess" xml:space="preserve"><value>训练计划已移除。</value></data>
+  <data name="Period" xml:space="preserve"><value>{0:yyyy/MM/dd} 至 {1:yyyy/MM/dd}</value></data>
+  <data name="DateRange" xml:space="preserve"><value>{0:yyyy/MM/dd HH:mm} 至 {1:HH:mm}</value></data>
+  <data name="ValidationDateRequired" xml:space="preserve"><value>请选择日期。</value></data>
+  <data name="ValidationTimeFormat" xml:space="preserve"><value>请输入 HH:mm 格式的时间。</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>无法解析教练。</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.ar.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>اختر الصعوبة</value></data>
+  <data name="Title" xml:space="preserve"><value>اختر الصعوبة</value></data>
+  <data name="Back" xml:space="preserve"><value>رجوع</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>لم يتم العثور على Varianten.</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>تكرارات لكل تمرين</value></data>
+  <data name="Rounds" xml:space="preserve"><value>عدد الجولات</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>مستويات الصعوبة المتاحة</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>سهل</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>متوسط</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>متقدم</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>ملحمي</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.da.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Vælg sværhedsgrad</value></data>
+  <data name="Title" xml:space="preserve"><value>Vælg sværhedsgrad</value></data>
+  <data name="Back" xml:space="preserve"><value>Tilbage</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>Ingen varianter fundet.</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>Gentagelser pr. øvelse</value></data>
+  <data name="Rounds" xml:space="preserve"><value>Antal runder</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>Tilgængelige sværhedsgrader</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Let</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Moderat</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Avanceret</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Episk</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Elegir dificultad</value></data>
+  <data name="Title" xml:space="preserve"><value>Elegir dificultad</value></data>
+  <data name="Back" xml:space="preserve"><value>Atrás</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>No se encontraron variantes.</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>Repeticiones por ejercicio</value></data>
+  <data name="Rounds" xml:space="preserve"><value>Número de rondas</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>Niveles de dificultad disponibles</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Fácil</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Moderado</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Avanzado</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Épico</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.fa.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>انتخاب دشواری</value></data>
+  <data name="Title" xml:space="preserve"><value>انتخاب دشواری</value></data>
+  <data name="Back" xml:space="preserve"><value>بازگشت</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>گونه‌ای یافت نشد.</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>تکرار برای هر تمرین</value></data>
+  <data name="Rounds" xml:space="preserve"><value>تعداد دورها</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>سطوح دشواری موجود</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>آسان</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>متوسط</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>پیشرفته</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>حماسی</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.fr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Choisir la difficulté</value></data>
+  <data name="Title" xml:space="preserve"><value>Choisir la difficulté</value></data>
+  <data name="Back" xml:space="preserve"><value>Retour</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>Aucune variante trouvée.</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>Répétitions par exercice</value></data>
+  <data name="Rounds" xml:space="preserve"><value>Nombre de tours</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>Niveaux de difficulté disponibles</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Facile</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Modéré</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Avancé</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Épique</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.ru.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Выберите сложность</value></data>
+  <data name="Title" xml:space="preserve"><value>Выберите сложность</value></data>
+  <data name="Back" xml:space="preserve"><value>Назад</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>Варианты не найдены.</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>Повторений на упражнение</value></data>
+  <data name="Rounds" xml:space="preserve"><value>Количество раундов</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>Доступные уровни сложности</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Легкий</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Средний</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>Продвинутый</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Эпический</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.tr.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Zorluk seç</value></data>
+  <data name="Title" xml:space="preserve"><value>Zorluk seç</value></data>
+  <data name="Back" xml:space="preserve"><value>Geri</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>Varyant bulunamadı.</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>Egzersiz başına tekrar</value></data>
+  <data name="Rounds" xml:space="preserve"><value>Tur sayısı</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>Mevcut zorluk seviyeleri</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>Kolay</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>Orta</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>İleri</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>Epik</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/SelectDifficulty.zh.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>选择难度</value></data>
+  <data name="Title" xml:space="preserve"><value>选择难度</value></data>
+  <data name="Back" xml:space="preserve"><value>返回</value></data>
+  <data name="NoVariants" xml:space="preserve"><value>未找到变体。</value></data>
+  <data name="SetsPerExercise" xml:space="preserve"><value>每个练习的次数</value></data>
+  <data name="Rounds" xml:space="preserve"><value>轮数</value></data>
+  <data name="AvailableLevels" xml:space="preserve"><value>可用难度等级</value></data>
+  <data name="Level_Easy" xml:space="preserve"><value>简单</value></data>
+  <data name="Level_Moderate" xml:space="preserve"><value>中等</value></data>
+  <data name="Level_Advanced" xml:space="preserve"><value>高级</value></data>
+  <data name="Level_Epic" xml:space="preserve"><value>史诗级</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.ar.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>منطقة تمارينك</value></data>
+  <data name="Loading" xml:space="preserve"><value>جارٍ تحميل بياناتك...</value></data>
+  <data name="Title" xml:space="preserve"><value>منطقة التمارين</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>اختر تمرينًا وابدأ.</value></data>
+  <data name="IntroText" xml:space="preserve"><value>مرحبًا بك في منطقة التمارين! ستجد هنا مجموعة متزايدة من التمارين المختلفة. ابدأ الآن وابدأ تمرينًا.</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>لا توجد تمارين متاحة بعد.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.da.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Dit workoutområde</value></data>
+  <data name="Loading" xml:space="preserve"><value>Indlæser dine data...</value></data>
+  <data name="Title" xml:space="preserve"><value>Workoutområde</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Vælg en workout, og kom i gang.</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Velkommen til dit workoutområde! Her finder du et voksende udvalg af forskellige workouts. Kom i gang og start en workout.</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>Der er endnu ingen workouts tilgængelige.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.es.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Tu zona de entrenamiento</value></data>
+  <data name="Loading" xml:space="preserve"><value>Cargando tus datos...</value></data>
+  <data name="Title" xml:space="preserve"><value>Zona de entrenamiento</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Elige un entrenamiento y empieza.</value></data>
+  <data name="IntroText" xml:space="preserve"><value>¡Bienvenido a tu zona de entrenamiento! Aquí encontrarás una selección creciente de entrenamientos. Empieza ahora.</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>Aún no hay entrenamientos disponibles.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.fa.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>بخش تمرین شما</value></data>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری داده‌های شما...</value></data>
+  <data name="Title" xml:space="preserve"><value>بخش تمرین</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>یک تمرین انتخاب کنید و شروع کنید.</value></data>
+  <data name="IntroText" xml:space="preserve"><value>به بخش تمرین خود خوش آمدید! اینجا مجموعه‌ای رو به رشد از تمرین‌های مختلف را پیدا می‌کنید. شروع کنید و یک تمرین را آغاز کنید.</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>هنوز تمرینی در دسترس نیست.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.fr.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Votre espace d’entraînement</value></data>
+  <data name="Loading" xml:space="preserve"><value>Chargement de vos données...</value></data>
+  <data name="Title" xml:space="preserve"><value>Espace d’entraînement</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Choisissez un entraînement et commencez.</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Bienvenue dans votre espace d’entraînement ! Vous y trouverez une sélection croissante d’entraînements. Lancez-vous et commencez.</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>Aucun entraînement disponible pour le moment.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.ru.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Ваша зона тренировок</value></data>
+  <data name="Loading" xml:space="preserve"><value>Загрузка ваших данных...</value></data>
+  <data name="Title" xml:space="preserve"><value>Зона тренировок</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Выберите тренировку и начинайте.</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Добро пожаловать в зону тренировок! Здесь вы найдете постоянно растущий выбор разных тренировок. Начните тренировку.</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>Тренировки пока недоступны.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.tr.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Antrenman alanın</value></data>
+  <data name="Loading" xml:space="preserve"><value>Verilerin yükleniyor...</value></data>
+  <data name="Title" xml:space="preserve"><value>Antrenman alanı</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Bir antrenman seç ve başla.</value></data>
+  <data name="IntroText" xml:space="preserve"><value>Antrenman alanına hoş geldin! Burada giderek büyüyen farklı antrenman seçenekleri bulacaksın. Hemen başla ve bir antrenmana gir.</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>Henüz antrenman yok.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutArea.zh.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>你的训练区</value></data>
+  <data name="Loading" xml:space="preserve"><value>正在加载你的数据...</value></data>
+  <data name="Title" xml:space="preserve"><value>训练区</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>选择一个训练并开始。</value></data>
+  <data name="IntroText" xml:space="preserve"><value>欢迎来到你的训练区！这里有不断增加的各种训练。开始并进入训练吧。</value></data>
+  <data name="NoWorkouts" xml:space="preserve"><value>暂无可用训练。</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.ar.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.ar.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>لم يتم تحميل أي تمرين.</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>تهانينا! لقد أكملت التمرين بنجاح!</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.da.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.da.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>Ingen workout indlæst.</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>Tillykke! Du har gennemført workouten!</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.es.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.es.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>No hay entrenamiento cargado.</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>¡Enhorabuena! Has completado el entrenamiento con éxito.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.fa.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.fa.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>تمرینی بارگذاری نشده است.</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>تبریک! شما تمرین را با موفقیت کامل کردید!</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.fr.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.fr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>Aucun entraînement chargé.</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>Félicitations ! Vous avez terminé l’entraînement avec succès !</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.ru.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.ru.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>Тренировка не загружена.</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>Поздравляем! Вы успешно завершили тренировку!</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.tr.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.tr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>Antrenman yüklenmedi.</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>Tebrikler! Antrenmanı başarıyla tamamladın!</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.zh.resx
+++ b/PaceLetics.Web/Resources/Pages/Workouts/WorkoutRoom.zh.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoWorkout" xml:space="preserve"><value>未加载训练。</value></data>
+  <data name="WorkoutCompleted" xml:space="preserve"><value>恭喜！你已成功完成训练！</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.ar.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.ar.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>يرجى اختيار مدرب.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>يتطلب إلغاء تسجيل الفعالية رياضيًا مسجل الدخول.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>أنت غير مسجل في هذه الفعالية.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>لم يتم العثور على الدورة.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>لا يمكن أن يكون تاريخ نهاية الدورة قبل تاريخ البدء.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>تحتاج الدورة إلى اسم.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>تحتاج الدورة إلى مدرب مسجل الدخول.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>يجب أن يكون وقت النهاية بعد وقت البدء.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>لم يتم العثور على الموعد.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>يحتاج الموعد إلى عنوان.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>يمكن للمدرب الذي أنشأ الدورة فقط حذفها.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>يجب أن يكون وقت نهاية الفعالية بعد وقت البدء.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>لم يتم العثور على الفعالية.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>تحتاج الفعالية إلى عنوان.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>يتطلب الانضمام إلى دورة رياضيًا مسجل الدخول.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>تتطلب مغادرة الدورة رياضيًا مسجل الدخول.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>لم تنضم إلى هذه الدورة.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>غير مسموح لك بإدارة مواعيد وفعاليات هذه الدورة.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>غير مسموح لك بإدارة خطط التدريب لهذه الدورة.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>غير مسموح لك بإدارة مدربي هذه الدورة.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>يتطلب تسجيل الفعالية رياضيًا مسجل الدخول.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>انتهى موعد التسجيل لهذه الفعالية.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>لا توجد أماكن متاحة لهذه الفعالية.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>يجب أن تنضم إلى الدورة قبل التسجيل في الفعاليات.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>يمكن لقائد الدورة حذفها لكنه لا يستطيع مغادرتها.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>هذا المدرب غير مخصص للدورة.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>قائد الدورة</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>مدرب</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>لم يتم العثور على خطة التدريب.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>يرجى اختيار خطة تدريب.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.da.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.da.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>Vælg en coach.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>Annullering af en eventtilmelding kræver en indlogget atlet.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>Du er ikke tilmeldt dette event.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>Kurset blev ikke fundet.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>Kursets slutdato kan ikke være før startdatoen.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>Et kursus skal have et navn.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>Et kursus kræver en indlogget coach.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>Sluttidspunktet skal være efter starttidspunktet.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>Datoen blev ikke fundet.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>En dato skal have en titel.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>Kun coachen, der oprettede kurset, kan slette det.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>Eventets sluttidspunkt skal være efter starttidspunktet.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>Eventet blev ikke fundet.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>Et event skal have en titel.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>Deltagelse i et kursus kræver en indlogget atlet.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>At forlade et kursus kræver en indlogget atlet.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>Du har ikke deltaget i dette kursus.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>Du må ikke administrere datoer og events for dette kursus.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>Du må ikke administrere træningsplaner for dette kursus.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>Du må ikke administrere coaches for dette kursus.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>Eventtilmelding kræver en indlogget atlet.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>Tilmeldingsfristen for dette event er overskredet.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>Der er ingen ledige pladser til dette event.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>Du skal deltage i kurset, før du kan tilmelde dig events.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>Kursusansvarlig kan slette kurset, men kan ikke forlade det.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>Denne coach er ikke tilknyttet kurset.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>Kursusansvarlig</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Coach</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>Træningsplanen blev ikke fundet.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>Vælg en træningsplan.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.es.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.es.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>Selecciona un entrenador.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>Cancelar una inscripción requiere un atleta conectado.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>No estás registrado en este evento.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>No se encontró el curso.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>La fecha de fin del curso no puede ser anterior a la de inicio.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>Un curso necesita un nombre.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>Un curso necesita un entrenador conectado.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>La hora de fin debe ser posterior a la de inicio.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>No se encontró la fecha.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>Una fecha necesita un título.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>Solo el entrenador que creó el curso puede eliminarlo.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>La hora de fin del evento debe ser posterior a la de inicio.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>No se encontró el evento.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>Un evento necesita un título.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>Unirse a un curso requiere un atleta conectado.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>Salir de un curso requiere un atleta conectado.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>No te has unido a este curso.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>No tienes permiso para gestionar fechas y eventos de este curso.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>No tienes permiso para gestionar planes de entrenamiento de este curso.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>No tienes permiso para gestionar los entrenadores de este curso.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>La inscripción requiere un atleta conectado.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>La fecha límite de inscripción ya pasó.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>No hay plazas disponibles para este evento.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>Debes unirte al curso antes de registrarte en eventos.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>El responsable puede eliminar el curso, pero no salir de él.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>Este entrenador no está asignado al curso.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>Responsable del curso</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Entrenador</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>No se encontró el plan de entrenamiento.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>Selecciona un plan de entrenamiento.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.fa.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.fa.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>لطفاً یک مربی انتخاب کنید.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>لغو ثبت‌نام رویداد به ورزشکار واردشده نیاز دارد.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>شما برای این رویداد ثبت‌نام نکرده‌اید.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>دوره یافت نشد.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>تاریخ پایان دوره نمی‌تواند قبل از تاریخ شروع باشد.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>یک دوره به نام نیاز دارد.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>یک دوره به مربی واردشده نیاز دارد.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>زمان پایان باید بعد از زمان شروع باشد.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>تاریخ یافت نشد.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>یک تاریخ به عنوان نیاز دارد.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>فقط مربی ایجادکننده دوره می‌تواند آن را حذف کند.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>زمان پایان رویداد باید بعد از زمان شروع باشد.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>رویداد یافت نشد.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>یک رویداد به عنوان نیاز دارد.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>پیوستن به دوره به ورزشکار واردشده نیاز دارد.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>ترک دوره به ورزشکار واردشده نیاز دارد.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>شما به این دوره نپیوسته‌اید.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>شما اجازه مدیریت تاریخ‌ها و رویدادهای این دوره را ندارید.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>شما اجازه مدیریت برنامه‌های تمرینی این دوره را ندارید.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>شما اجازه مدیریت مربیان این دوره را ندارید.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>ثبت‌نام رویداد به ورزشکار واردشده نیاز دارد.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>مهلت ثبت‌نام این رویداد گذشته است.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>برای این رویداد ظرفیت خالی وجود ندارد.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>پیش از ثبت‌نام در رویدادها باید به دوره بپیوندید.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>مسئول دوره می‌تواند دوره را حذف کند اما نمی‌تواند آن را ترک کند.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>این مربی به دوره اختصاص داده نشده است.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>مسئول دوره</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>مربی</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>برنامه تمرینی یافت نشد.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>لطفاً یک برنامه تمرینی انتخاب کنید.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.fr.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.fr.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>Veuillez sélectionner un coach.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>L’annulation d’une inscription nécessite un athlète connecté.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>Vous n’êtes pas inscrit à cet événement.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>Le cours est introuvable.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>La date de fin du cours ne peut pas être antérieure à la date de début.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>Un cours doit avoir un nom.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>Un cours nécessite un coach connecté.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>L’heure de fin doit être après l’heure de début.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>La date est introuvable.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>Une date doit avoir un titre.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>Seul le coach qui a créé ce cours peut le supprimer.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>L’heure de fin de l’événement doit être après l’heure de début.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>L’événement est introuvable.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>Un événement doit avoir un titre.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>Rejoindre un cours nécessite un athlète connecté.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>Quitter un cours nécessite un athlète connecté.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>Vous n’avez pas rejoint ce cours.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>Vous n’êtes pas autorisé à gérer les dates et événements de ce cours.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>Vous n’êtes pas autorisé à gérer les plans d’entraînement de ce cours.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>Vous n’êtes pas autorisé à gérer les coachs de ce cours.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>L’inscription à un événement nécessite un athlète connecté.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>La date limite d’inscription à cet événement est passée.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>Aucune place n’est disponible pour cet événement.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>Vous devez rejoindre le cours avant de vous inscrire aux événements.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>Le responsable peut supprimer le cours, mais ne peut pas le quitter.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>Ce coach n’est pas affecté au cours.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>Responsable du cours</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Coach</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>Le plan d’entraînement est introuvable.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>Veuillez sélectionner un plan d’entraînement.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.ru.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.ru.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>Выберите тренера.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>Для отмены регистрации на событие нужен вошедший спортсмен.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>Вы не зарегистрированы на это событие.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>Курс не найден.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>Дата окончания курса не может быть раньше даты начала.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>Курсу нужно название.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>Курсу нужен вошедший тренер.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>Время окончания должно быть позже времени начала.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>Дата не найдена.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>Дате нужен заголовок.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>Удалить курс может только создавший его тренер.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>Время окончания события должно быть позже начала.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>Событие не найдено.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>Событию нужен заголовок.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>Для присоединения к курсу нужен вошедший спортсмен.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>Для выхода из курса нужен вошедший спортсмен.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>Вы не присоединились к этому курсу.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>У вас нет прав управлять датами и событиями этого курса.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>У вас нет прав управлять планами тренировок этого курса.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>У вас нет прав управлять тренерами этого курса.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>Для регистрации на событие нужен вошедший спортсмен.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>Срок регистрации на это событие истек.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>На это событие нет свободных мест.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>Перед регистрацией на события нужно присоединиться к курсу.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>Руководитель курса может удалить курс, но не может покинуть его.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>Этот тренер не назначен на курс.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>Руководитель курса</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Тренер</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>План тренировок не найден.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>Выберите план тренировок.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.tr.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.tr.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>Lütfen bir antrenör seç.</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>Etkinlik kaydını iptal etmek için giriş yapmış bir sporcu gerekir.</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>Bu etkinliğe kayıtlı değilsin.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>Kurs bulunamadı.</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>Kurs bitiş tarihi başlangıç tarihinden önce olamaz.</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>Kurs için ad gerekli.</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>Kurs için giriş yapmış bir antrenör gerekli.</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>Bitiş saati başlangıç saatinden sonra olmalıdır.</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>Tarih bulunamadı.</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>Tarih için başlık gerekli.</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>Bu kursu yalnızca oluşturan antrenör silebilir.</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>Etkinlik bitiş saati başlangıç saatinden sonra olmalıdır.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>Etkinlik bulunamadı.</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>Etkinlik için başlık gerekli.</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>Kursa katılmak için giriş yapmış bir sporcu gerekir.</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>Kurstan ayrılmak için giriş yapmış bir sporcu gerekir.</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>Bu kursa katılmadın.</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>Bu kursun tarihlerini ve etkinliklerini yönetme iznin yok.</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>Bu kursun antrenman planlarını yönetme iznin yok.</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>Bu kursun antrenörlerini yönetme iznin yok.</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>Etkinlik kaydı için giriş yapmış bir sporcu gerekir.</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>Bu etkinliğin kayıt süresi doldu.</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>Bu etkinlikte boş yer yok.</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>Etkinliklere kayıt olmadan önce kursa katılmalısın.</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>Kurs sorumlusu kursu silebilir ama kurstan ayrılamaz.</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>Bu antrenör kursa atanmadı.</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>Kurs sorumlusu</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>Antrenör</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>Antrenman planı bulunamadı.</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>Lütfen bir antrenman planı seç.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Services/Courses/CourseService.zh.resx
+++ b/PaceLetics.Web/Resources/Services/Courses/CourseService.zh.resx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="AddTrainerRequired" xml:space="preserve"><value>请选择教练。</value></data>
+  <data name="CancelEventAthleteRequired" xml:space="preserve"><value>取消活动报名需要已登录的运动员。</value></data>
+  <data name="CancelEventNotRegistered" xml:space="preserve"><value>你未报名此活动。</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>未找到课程。</value></data>
+  <data name="CreateCourseEndBeforeStart" xml:space="preserve"><value>课程结束日期不能早于开始日期。</value></data>
+  <data name="CreateCourseNameRequired" xml:space="preserve"><value>课程需要名称。</value></data>
+  <data name="CreateCourseTrainerRequired" xml:space="preserve"><value>课程需要已登录的教练。</value></data>
+  <data name="DateEndAfterStart" xml:space="preserve"><value>结束时间必须晚于开始时间。</value></data>
+  <data name="DateNotFound" xml:space="preserve"><value>未找到日期。</value></data>
+  <data name="DateTitleRequired" xml:space="preserve"><value>日期需要标题。</value></data>
+  <data name="DeleteCourseCreatorOnly" xml:space="preserve"><value>只有创建该课程的教练可以删除它。</value></data>
+  <data name="EventEndAfterStart" xml:space="preserve"><value>活动结束时间必须晚于开始时间。</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>未找到活动。</value></data>
+  <data name="EventTitleRequired" xml:space="preserve"><value>活动需要标题。</value></data>
+  <data name="JoinCourseAthleteRequired" xml:space="preserve"><value>加入课程需要已登录的运动员。</value></data>
+  <data name="LeaveCourseAthleteRequired" xml:space="preserve"><value>退出课程需要已登录的运动员。</value></data>
+  <data name="LeaveCourseNotJoined" xml:space="preserve"><value>你尚未加入此课程。</value></data>
+  <data name="PermissionManageEvents" xml:space="preserve"><value>你无权管理此课程的日期和活动。</value></data>
+  <data name="PermissionManagePlans" xml:space="preserve"><value>你无权管理此课程的训练计划。</value></data>
+  <data name="PermissionManageTrainers" xml:space="preserve"><value>你无权管理此课程的教练。</value></data>
+  <data name="RegisterEventAthleteRequired" xml:space="preserve"><value>活动报名需要已登录的运动员。</value></data>
+  <data name="RegisterEventDeadlinePassed" xml:space="preserve"><value>该活动报名截止日期已过。</value></data>
+  <data name="RegisterEventFull" xml:space="preserve"><value>该活动没有可用名额。</value></data>
+  <data name="RegisterEventRequiresEnrollment" xml:space="preserve"><value>报名活动前必须先加入课程。</value></data>
+  <data name="RemoveTrainerLeadCannotLeave" xml:space="preserve"><value>课程负责人可以删除课程，但不能退出。</value></data>
+  <data name="RemoveTrainerNotAssigned" xml:space="preserve"><value>该教练未分配到课程。</value></data>
+  <data name="RoleCourseLead" xml:space="preserve"><value>课程负责人</value></data>
+  <data name="RoleTrainer" xml:space="preserve"><value>教练</value></data>
+  <data name="TrainingPlanNotFound" xml:space="preserve"><value>未找到训练计划。</value></data>
+  <data name="TrainingPlanRequired" xml:space="preserve"><value>请选择训练计划。</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ar.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ar.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>الرسائل الحالية</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>ملاحظات حالية لتدريبك</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>كل شيء محدث. ستظهر الرسائل المهمة هنا.</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>الجري التقييمي مفقود</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>أضف جريًا تقييميًا حتى يتمكن PaceLetics من حساب سرعات تدريبك بدقة.</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>حدّث الجري التقييمي</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>الجري التقييمي الحالي بتاريخ {0:d} ولم يتم تحديثه منذ {1:0} يومًا.</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>إدارة الجري التقييمي</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>الجلسة التالية</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>&quot;{0}&quot; موجود في خطة تدريبك اليوم.</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; موجود في خطة تدريبك غدًا.</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; موجود في خطة تدريبك بتاريخ {1:d}.</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>فتح خطة التدريب</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>معلومة</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>حسنًا</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>مهم</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>خطأ</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.da.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.da.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>Aktuelle beskeder</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Aktuelle noter til din træning</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>Alt er opdateret. Vigtige beskeder vises her.</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Vurderingsløb mangler</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>Tilføj et vurderingsløb, så PaceLetics kan beregne dine træningstempoer pålideligt.</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>Opdater dit vurderingsløb</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>Dit aktuelle vurderingsløb er fra {0:d} og er ikke blevet opdateret i {1:0} dage.</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>Administrer vurderingsløb</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>Næste session</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>&quot;{0}&quot; er på din træningsplan i dag.</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; er på din træningsplan i morgen.</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; er på din træningsplan den {1:d}.</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>Åbn træningsplan</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>Ok</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>Vigtigt</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>Fejl</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.de.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.de.resx
@@ -5,6 +5,7 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="FeedTitle" xml:space="preserve"><value>Aktuelle Hinweise</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Aktuelle Hinweise fuer dein Training</value></data>
   <data name="NoMessages" xml:space="preserve"><value>Alles aktuell. Sobald etwas Wichtiges ansteht, erscheint es hier.</value></data>
   <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Einstufungslauf fehlt</value></data>
   <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>Lege einen Einstufungslauf an, damit PaceLetics deine Trainingspaces sauber berechnen kann.</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.en.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.en.resx
@@ -5,6 +5,7 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="FeedTitle" xml:space="preserve"><value>Current messages</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Current notes for your training</value></data>
   <data name="NoMessages" xml:space="preserve"><value>Everything is up to date. Important messages will appear here.</value></data>
   <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Assessment run missing</value></data>
   <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>Add an assessment run so PaceLetics can calculate your training paces reliably.</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.es.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.es.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>Mensajes actuales</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Notas actuales para tu entrenamiento</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>Todo está al día. Los mensajes importantes aparecerán aquí.</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Falta la carrera de evaluación</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>Añade una carrera de evaluación para que PaceLetics calcule tus ritmos de entrenamiento con fiabilidad.</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>Actualiza tu carrera de evaluación</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>Tu carrera de evaluación actual es del {0:d} y no se ha actualizado en {1:0} días.</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>Gestionar carrera de evaluación</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>Próxima sesión</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>&quot;{0}&quot; está en tu plan de entrenamiento de hoy.</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; está en tu plan de entrenamiento de mañana.</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; está en tu plan de entrenamiento el {1:d}.</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>Abrir plan de entrenamiento</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>Aceptar</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>Importante</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>Error</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fa.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fa.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>پیام‌های فعلی</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>نکات فعلی برای تمرین شما</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>همه چیز به‌روز است. پیام‌های مهم اینجا نمایش داده می‌شوند.</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>دویدن ارزیابی وجود ندارد</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>یک دویدن ارزیابی اضافه کنید تا PaceLetics بتواند پیس‌های تمرینی شما را دقیق محاسبه کند.</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>دویدن ارزیابی خود را به‌روزرسانی کنید</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>دویدن ارزیابی فعلی شما مربوط به {0:d} است و {1:0} روز به‌روزرسانی نشده است.</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>مدیریت دویدن ارزیابی</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>جلسه بعدی</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>&quot;{0}&quot; امروز در برنامه تمرینی شماست.</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; فردا در برنامه تمرینی شماست.</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; در تاریخ {1:d} در برنامه تمرینی شماست.</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>باز کردن برنامه تمرینی</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>اطلاعات</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>باشه</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>مهم</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>خطا</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fr.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fr.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>Messages actuels</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Notes actuelles pour votre entraînement</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>Tout est à jour. Les messages importants apparaîtront ici.</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Course d’évaluation manquante</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>Ajoutez une course d’évaluation pour que PaceLetics calcule vos allures d’entraînement de manière fiable.</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>Mettez à jour votre course d’évaluation</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>Votre course d’évaluation actuelle date du {0:d} et n’a pas été mise à jour depuis {1:0} jours.</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>Gérer la course d’évaluation</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>Prochaine séance</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>&quot;{0}&quot; est prévu dans votre plan d’entraînement aujourd’hui.</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; est prévu dans votre plan d’entraînement demain.</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; est prévu dans votre plan d’entraînement le {1:d}.</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>Ouvrir le plan d’entraînement</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>OK</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>Important</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>Erreur</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.resx
@@ -5,6 +5,7 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="FeedTitle" xml:space="preserve"><value>Current messages</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Current notes for your training</value></data>
   <data name="NoMessages" xml:space="preserve"><value>Everything is up to date. Important messages will appear here.</value></data>
   <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Assessment run missing</value></data>
   <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>Add an assessment run so PaceLetics can calculate your training paces reliably.</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ru.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ru.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>Текущие сообщения</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Актуальные заметки по вашей тренировке</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>Все актуально. Важные сообщения появятся здесь.</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Нет оценочного забега</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>Добавьте оценочный забег, чтобы PaceLetics мог надежно рассчитать ваши тренировочные темпы.</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>Обновите оценочный забег</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>Ваш текущий оценочный забег от {0:d} и не обновлялся {1:0} дней.</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>Управлять оценочным забегом</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>Следующее занятие</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>&quot;{0}&quot; сегодня в вашем плане тренировок.</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; завтра в вашем плане тренировок.</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; в вашем плане тренировок на {1:d}.</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>Открыть план тренировок</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>Инфо</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>ОК</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>Важно</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>Ошибка</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.tr.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.tr.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>Güncel mesajlar</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>Antrenmanın için güncel notlar</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>Her şey güncel. Önemli mesajlar burada görünecek.</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>Değerlendirme koşusu eksik</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>PaceLetics’in antrenman tempolarını güvenilir biçimde hesaplayabilmesi için bir değerlendirme koşusu ekle.</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>Değerlendirme koşusunu güncelle</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>Mevcut değerlendirme koşun {0:d} tarihinden ve {1:0} gündür güncellenmedi.</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>Değerlendirme koşusunu yönet</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>Sonraki oturum</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>&quot;{0}&quot; bugün antrenman planında.</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; yarın antrenman planında.</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; {1:d} tarihinde antrenman planında.</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>Antrenman planını aç</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>Bilgi</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>Tamam</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>Önemli</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>Hata</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.zh.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.zh.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="FeedTitle" xml:space="preserve"><value>当前消息</value></data>
+  <data name="FeedSubtitle" xml:space="preserve"><value>你的训练当前提示</value></data>
+  <data name="NoMessages" xml:space="preserve"><value>一切都是最新的。重要消息会显示在这里。</value></data>
+  <data name="ReferenceRunMissing_Title" xml:space="preserve"><value>缺少评估跑</value></data>
+  <data name="ReferenceRunMissing_Body" xml:space="preserve"><value>添加一次评估跑，让 PaceLetics 能可靠计算你的训练配速。</value></data>
+  <data name="ReferenceRunStale_Title" xml:space="preserve"><value>更新你的评估跑</value></data>
+  <data name="ReferenceRunStale_Body" xml:space="preserve"><value>你当前的评估跑日期为 {0:d}，已经 {1:0} 天未更新。</value></data>
+  <data name="ReferenceRun_Action" xml:space="preserve"><value>管理评估跑</value></data>
+  <data name="UpcomingTraining_Title" xml:space="preserve"><value>下一次训练</value></data>
+  <data name="UpcomingTrainingToday_Body" xml:space="preserve"><value>“{0}” 今天在你的训练计划中。</value></data>
+  <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>“{0}” 明天在你的训练计划中。</value></data>
+  <data name="UpcomingTraining_Body" xml:space="preserve"><value>“{0}” 安排在 {1:d} 的训练计划中。</value></data>
+  <data name="UpcomingTraining_Action" xml:space="preserve"><value>打开训练计划</value></data>
+  <data name="Severity_Info" xml:space="preserve"><value>信息</value></data>
+  <data name="Severity_Success" xml:space="preserve"><value>确定</value></data>
+  <data name="Severity_Warning" xml:space="preserve"><value>重要</value></data>
+  <data name="Severity_Error" xml:space="preserve"><value>错误</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.ar.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.ar.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>لا توجد جلسة تدريب بعد</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>انضم إلى دورة لرؤية خطط التدريب المنشورة.</value></data>
+  <data name="Courses" xml:space="preserve"><value>الدورات</value></data>
+  <data name="Open" xml:space="preserve"><value>فتح</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>معاينة</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>تفاصيل التدريب وبنية الجلسة.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} تمرين</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>جلسة تدريب</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.da.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.da.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>Ingen træningssession endnu</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>Deltag i et kursus for at se offentliggjorte træningsplaner.</value></data>
+  <data name="Courses" xml:space="preserve"><value>Kurser</value></data>
+  <data name="Open" xml:space="preserve"><value>Åbn</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>Forhåndsvisning</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>Træningsdetaljer og sessionsstruktur.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} workouts</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>Træningssession</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.es.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.es.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>Aún no hay sesión de entrenamiento</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>Únete a un curso para ver los planes publicados.</value></data>
+  <data name="Courses" xml:space="preserve"><value>Cursos</value></data>
+  <data name="Open" xml:space="preserve"><value>Abrir</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>Vista previa</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>Detalles del entrenamiento y estructura de la sesión.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} entrenamiento(s)</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>Sesión de entrenamiento</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.fa.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.fa.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>هنوز جلسه تمرینی وجود ندارد</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>برای دیدن برنامه‌های تمرینی منتشرشده به یک دوره بپیوندید.</value></data>
+  <data name="Courses" xml:space="preserve"><value>دوره‌ها</value></data>
+  <data name="Open" xml:space="preserve"><value>باز کردن</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>پیش‌نمایش</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>جزئیات تمرین و ساختار جلسه.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} تمرین</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>جلسه تمرینی</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.fr.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.fr.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>Pas encore de séance</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>Rejoignez un cours pour voir les plans d’entraînement publiés.</value></data>
+  <data name="Courses" xml:space="preserve"><value>Cours</value></data>
+  <data name="Open" xml:space="preserve"><value>Ouvrir</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>Aperçu</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>Détails de l’entraînement et structure de la séance.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} entraînement(s)</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>Séance d’entraînement</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.ru.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.ru.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>Тренировки пока нет</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>Присоединитесь к курсу, чтобы видеть опубликованные планы тренировок.</value></data>
+  <data name="Courses" xml:space="preserve"><value>Курсы</value></data>
+  <data name="Open" xml:space="preserve"><value>Открыть</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>Предпросмотр</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>Детали тренировки и структура занятия.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} тренировок</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>Тренировочное занятие</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.tr.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.tr.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>Henüz antrenman oturumu yok</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>Yayınlanan antrenman planlarını görmek için bir kursa katıl.</value></data>
+  <data name="Courses" xml:space="preserve"><value>Kurslar</value></data>
+  <data name="Open" xml:space="preserve"><value>Aç</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>Önizleme</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>Antrenman detayları ve oturum yapısı.</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} antrenman</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>Antrenman oturumu</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.zh.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardNextTrainingSessionTile.zh.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="NoSessionTitle" xml:space="preserve"><value>暂无训练课</value></data>
+  <data name="NoSessionDetail" xml:space="preserve"><value>加入课程以查看已发布的训练计划。</value></data>
+  <data name="Courses" xml:space="preserve"><value>课程</value></data>
+  <data name="Open" xml:space="preserve"><value>打开</value></data>
+  <data name="PreviewTitle" xml:space="preserve"><value>预览</value></data>
+  <data name="PreviewDetail" xml:space="preserve"><value>训练详情和课程结构。</value></data>
+  <data name="WorkoutCount" xml:space="preserve"><value>{0} 个训练</value></data>
+  <data name="TrainingSession" xml:space="preserve"><value>训练课</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.ar.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.ar.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>جارٍ التحميل...</value></data>
+  <data name="Name" xml:space="preserve"><value>الاسم</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.da.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.da.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>Indlæser...</value></data>
+  <data name="Name" xml:space="preserve"><value>Navn</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.es.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.es.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>Cargando...</value></data>
+  <data name="Name" xml:space="preserve"><value>Nombre</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.fa.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.fa.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>در حال بارگذاری...</value></data>
+  <data name="Name" xml:space="preserve"><value>نام</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.fr.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.fr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>Chargement...</value></data>
+  <data name="Name" xml:space="preserve"><value>Nom</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.ru.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.ru.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>Загрузка...</value></data>
+  <data name="Name" xml:space="preserve"><value>Имя</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.tr.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.tr.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>Yükleniyor...</value></data>
+  <data name="Name" xml:space="preserve"><value>Ad</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/DataGridView.zh.resx
+++ b/PaceLetics.Web/Resources/Shared/DataGridView.zh.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Loading" xml:space="preserve"><value>正在加载...</value></data>
+  <data name="Name" xml:space="preserve"><value>名称</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.ar.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.ar.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>إدارة الملف الشخصي</value></data>
+  <data name="LogOut" xml:space="preserve"><value>تسجيل الخروج</value></data>
+  <data name="Register" xml:space="preserve"><value>تسجيل</value></data>
+  <data name="LogIn" xml:space="preserve"><value>تسجيل الدخول</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.da.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.da.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>Administrer profil</value></data>
+  <data name="LogOut" xml:space="preserve"><value>Log ud</value></data>
+  <data name="Register" xml:space="preserve"><value>Tilmeld</value></data>
+  <data name="LogIn" xml:space="preserve"><value>Log ind</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.es.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.es.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>Gestionar perfil</value></data>
+  <data name="LogOut" xml:space="preserve"><value>Cerrar sesión</value></data>
+  <data name="Register" xml:space="preserve"><value>Registrarse</value></data>
+  <data name="LogIn" xml:space="preserve"><value>Iniciar sesión</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.fa.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.fa.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>مدیریت نمایه</value></data>
+  <data name="LogOut" xml:space="preserve"><value>خروج</value></data>
+  <data name="Register" xml:space="preserve"><value>ثبت‌نام</value></data>
+  <data name="LogIn" xml:space="preserve"><value>ورود</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.fr.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.fr.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>Gérer le profil</value></data>
+  <data name="LogOut" xml:space="preserve"><value>Se déconnecter</value></data>
+  <data name="Register" xml:space="preserve"><value>S’inscrire</value></data>
+  <data name="LogIn" xml:space="preserve"><value>Se connecter</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.ru.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.ru.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>Управлять профилем</value></data>
+  <data name="LogOut" xml:space="preserve"><value>Выйти</value></data>
+  <data name="Register" xml:space="preserve"><value>Зарегистрироваться</value></data>
+  <data name="LogIn" xml:space="preserve"><value>Войти</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.tr.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.tr.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>Profili yönet</value></data>
+  <data name="LogOut" xml:space="preserve"><value>Çıkış yap</value></data>
+  <data name="Register" xml:space="preserve"><value>Kayıt ol</value></data>
+  <data name="LogIn" xml:space="preserve"><value>Giriş yap</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/LoginDisplay.zh.resx
+++ b/PaceLetics.Web/Resources/Shared/LoginDisplay.zh.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ManageProfile" xml:space="preserve"><value>管理个人资料</value></data>
+  <data name="LogOut" xml:space="preserve"><value>退出登录</value></data>
+  <data name="Register" xml:space="preserve"><value>报名</value></data>
+  <data name="LogIn" xml:space="preserve"><value>登录</value></data>
+</root>

--- a/PaceLetics.Web/Shared/AthleteMessageFeedButton.razor
+++ b/PaceLetics.Web/Shared/AthleteMessageFeedButton.razor
@@ -1,0 +1,170 @@
+@using System.Text.Json
+@using AthleteDataAccessLibrary.Contracts
+@using PaceLetics.AthleteModule.CodeBase.Models
+@using PaceLetics.CoreModule.Infrastructure.Models
+@using PaceLetics.CoreModule.Infrastructure.Services
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IAthleteData AthleteData
+@inject IAthleteMessageFeedService AthleteMessageFeedService
+@inject IJSRuntime JS
+@inject IStringLocalizer<DashboardMessageFeed> L
+
+@if (_isAuthenticated)
+{
+    <MudMenu AnchorOrigin="Origin.BottomRight"
+             TransformOrigin="Origin.TopRight"
+             PopoverClass="pl-message-popover"
+             ListClass="pa-0"
+             OpenChanged="HandleMenuOpenChanged">
+        <ActivatorContent>
+            <MudBadge Content="@_unreadCount"
+                      Visible="@ShowUnreadBadge"
+                      Color="Color.Warning"
+                      Overlap="true"
+                      Class="pl-message-badge">
+                <MudTooltip Text="@L["FeedTitle"]">
+                    <MudIconButton Icon="@Icons.Material.Filled.Alarm"
+                                   Color="@MessageButtonColor"
+                                   Class="@MessageButtonClass"
+                                   OnClick="@context.ToggleAsync"
+                                   aria-label="@L["FeedTitle"]" />
+                </MudTooltip>
+            </MudBadge>
+        </ActivatorContent>
+        <ChildContent>
+            <div class="pl-message-menu-panel" @onclick:stopPropagation="true">
+                <DashboardMessageFeed Messages="_messages" Framed="false" />
+            </div>
+        </ChildContent>
+    </MudMenu>
+}
+
+@code {
+    private IReadOnlyList<AthleteMessage> _messages = Array.Empty<AthleteMessage>();
+    private HashSet<string> _readMessageIds = new(StringComparer.Ordinal);
+    private bool _isAuthenticated;
+    private bool _readStateLoaded;
+    private int _unreadCount;
+    private string? _storageKey;
+
+    private bool ShowUnreadBadge => _readStateLoaded && _unreadCount > 0;
+
+    private Color MessageButtonColor => ShowUnreadBadge ? Color.Warning : Color.Inherit;
+
+    private string MessageButtonClass => ShowUnreadBadge ? "pl-message-button-unread" : string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        _isAuthenticated = user.Identity?.IsAuthenticated == true;
+
+        if (!_isAuthenticated)
+            return;
+
+        var userId = user.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
+        var storageUserId = !string.IsNullOrWhiteSpace(userId)
+            ? userId
+            : user.Identity?.Name ?? "current";
+
+        _storageKey = $"paceletics.messageFeed.read.{storageUserId}";
+
+        AthleteModel? athlete = null;
+        try
+        {
+            athlete = string.IsNullOrWhiteSpace(userId)
+                ? null
+                : await AthleteData.GetAthlete(userId);
+        }
+        catch
+        {
+            athlete = null;
+        }
+
+        var athleteName = string.IsNullOrWhiteSpace(athlete?.Name)
+            ? user.Identity?.Name ?? string.Empty
+            : athlete.Name;
+
+        _messages = AthleteMessageFeedService.Build(new AthleteMessageContext(
+            athlete?.AthleteId ?? athlete?.Id ?? userId,
+            athleteName,
+            athlete?.Vdot ?? 0,
+            athlete?.ActiveReferenceResult,
+            athlete?.SelectedTrainingPlanId,
+            DateTime.Today));
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || !_isAuthenticated)
+            return;
+
+        await LoadReadStateAsync();
+        RefreshUnreadCount();
+        _readStateLoaded = true;
+        StateHasChanged();
+    }
+
+    private async Task HandleMenuOpenChanged(bool open)
+    {
+        if (!open)
+            return;
+
+        await MarkCurrentMessagesReadAsync();
+    }
+
+    private async Task LoadReadStateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_storageKey))
+            return;
+
+        try
+        {
+            var json = await JS.InvokeAsync<string?>("localStorage.getItem", _storageKey);
+            var ids = string.IsNullOrWhiteSpace(json)
+                ? Array.Empty<string>()
+                : JsonSerializer.Deserialize<string[]>(json) ?? Array.Empty<string>();
+
+            _readMessageIds = new HashSet<string>(ids, StringComparer.Ordinal);
+        }
+        catch
+        {
+            _readMessageIds = new HashSet<string>(StringComparer.Ordinal);
+        }
+    }
+
+    private async Task MarkCurrentMessagesReadAsync()
+    {
+        if (_messages.Count == 0)
+            return;
+
+        foreach (var message in _messages)
+        {
+            _readMessageIds.Add(message.Id);
+        }
+
+        RefreshUnreadCount();
+        await PersistReadStateAsync();
+    }
+
+    private async Task PersistReadStateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_storageKey))
+            return;
+
+        try
+        {
+            var json = JsonSerializer.Serialize(_readMessageIds.OrderBy(id => id));
+            await JS.InvokeVoidAsync("localStorage.setItem", _storageKey, json);
+        }
+        catch
+        {
+            // localStorage is a convenience for highlighting only.
+        }
+    }
+
+    private void RefreshUnreadCount()
+    {
+        _unreadCount = _messages.Count(message => !_readMessageIds.Contains(message.Id));
+    }
+}

--- a/PaceLetics.Web/Shared/DashboardMessageFeed.razor
+++ b/PaceLetics.Web/Shared/DashboardMessageFeed.razor
@@ -1,30 +1,40 @@
 @using PaceLetics.CoreModule.Infrastructure.Models
 @inject IStringLocalizer<DashboardMessageFeed> L
 
-<MudPaper Elevation="0"
-          Class="pa-4 pl-panel">
+@if (Framed)
+{
+    <MudPaper Elevation="0" Class="pa-4 pl-panel">
+        @FeedContent
+    </MudPaper>
+}
+else
+{
+    <div class="pa-4">
+        @FeedContent
+    </div>
+}
 
-    <MudStack Spacing="3">
-        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
-                <MudAvatar Size="Size.Small" Color="Color.Primary" Variant="Variant.Filled">
+@code {
+    [Parameter]
+    public IReadOnlyList<AthleteMessage> Messages { get; set; } = Array.Empty<AthleteMessage>();
+
+    [Parameter]
+    public bool Framed { get; set; } = true;
+
+    private RenderFragment FeedContent => @<MudStack Spacing="3">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="min-width:0;">
+                <div class="pl-feed-header-icon">
                     <MudIcon Icon="@Icons.Material.Filled.Campaign" Size="Size.Small" />
-                </MudAvatar>
+                </div>
 
-                <MudStack Spacing="0">
+                <MudStack Spacing="0" Style="min-width:0;">
                     <MudText Typo="Typo.subtitle2">@L["FeedTitle"]</MudText>
                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                        Aktuelle Hinweise für dein Training
+                        @L["FeedSubtitle"]
                     </MudText>
                 </MudStack>
             </MudStack>
-
-            <MudBadge Content="@Messages.Count"
-                      Color="Color.Primary"
-                      Overlap="false">
-                <MudIcon Icon="@Icons.Material.Filled.NotificationsNone"
-                         Color="Color.Secondary" />
-            </MudBadge>
         </MudStack>
 
         <MudDivider />
@@ -48,10 +58,5 @@
                 }
             </MudStack>
         }
-    </MudStack>
-</MudPaper>
-
-@code {
-    [Parameter]
-    public IReadOnlyList<AthleteMessage> Messages { get; set; } = Array.Empty<AthleteMessage>();
+    </MudStack>;
 }

--- a/PaceLetics.Web/Shared/DashboardMetricTile.razor
+++ b/PaceLetics.Web/Shared/DashboardMetricTile.razor
@@ -1,18 +1,15 @@
 @if (!string.IsNullOrWhiteSpace(Href))
 {
-    <MudPaper Elevation="0"
-          Class="pa-4 pl-panel">
-        <MudLink Href="@Href" Underline="Underline.None" Class="pl-metric-link">
-            @TileContent
-        </MudLink>
-    </MudPaper>
+    <MudLink Href="@Href" Underline="Underline.None" Class="pl-metric-link">
+        @TileContent
+    </MudLink>
 }
 else
 {
     @TileContent
 }
 @code {
-    private RenderFragment TileContent => @<MudPaper Elevation="2" Class="@TileClass">
+    private RenderFragment TileContent => @<MudPaper Elevation="0" Class="@TileClass">
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="pl-metric-content">
             <div class="pl-metric-icon">
                 <MudIcon Icon="@Icon" Size="Size.Large" />

--- a/PaceLetics.Web/Shared/DashboardNewsFeedTile.razor
+++ b/PaceLetics.Web/Shared/DashboardNewsFeedTile.razor
@@ -10,7 +10,7 @@ else
 }
 
 @code {
-    private RenderFragment TileContent => @<MudPaper Elevation="2"
+    private RenderFragment TileContent => @<MudPaper Elevation="0"
                                                      Class="@TileClass">
         <MudStack Row="true"
                   AlignItems="AlignItems.Center"
@@ -19,7 +19,8 @@ else
 
             <MudAvatar Color="@Color"
                        Variant="Variant.Filled"
-                       Size="Size.Medium">
+                       Size="Size.Medium"
+                       Class="pl-feed-tile-icon">
                 <MudIcon Icon="@Icon" Size="Size.Small" />
             </MudAvatar>
 
@@ -60,7 +61,21 @@ else
     [Parameter]
     public string? Href { get; set; }
 
-    private Color Color => Color.Primary;
+    private Color Color => Severity switch
+    {
+        Severity.Success => Color.Success,
+        Severity.Warning => Color.Warning,
+        Severity.Error => Color.Error,
+        Severity.Info => Color.Info,
+        _ => Color.Primary
+    };
 
-    private string TileClass => "mud-border-primary";
+    private string TileClass => Severity switch
+    {
+        Severity.Success => "pl-feed-tile pl-feed-tile-success",
+        Severity.Warning => "pl-feed-tile pl-feed-tile-warning",
+        Severity.Error => "pl-feed-tile pl-feed-tile-error",
+        Severity.Info => "pl-feed-tile pl-feed-tile-info",
+        _ => "pl-feed-tile"
+    };
 }

--- a/PaceLetics.Web/Shared/MainLayout.razor
+++ b/PaceLetics.Web/Shared/MainLayout.razor
@@ -23,6 +23,7 @@
                        OnClick="@((e) => DrawerToggle())" />
         <MudText Align="Align.Start">PaceLetics - Team Running</MudText>
         <MudSpacer />
+        <AthleteMessageFeedButton />
         <MudMenu Icon="@GetThemeMenuIcon()"
                  Color="Color.Inherit"
                  AnchorOrigin="Origin.BottomRight"

--- a/PaceLetics.Web/wwwroot/css/app-theme.css
+++ b/PaceLetics.Web/wwwroot/css/app-theme.css
@@ -3,6 +3,13 @@
     --pl-overlay-background: color-mix(in srgb, var(--mud-palette-background) 18%, black 52%);
 }
 
+.pl-pageheader {
+    padding: 12px 14px;
+    border: 1px solid color-mix(in srgb, var(--mud-palette-primary) 22%, var(--mud-palette-lines-default));
+    border-radius: var(--pl-radius);
+    background: linear-gradient(135deg, color-mix(in srgb, var(--mud-palette-primary) 10%, var(--mud-palette-surface)), var(--mud-palette-surface) 68%);
+}
+
 .pl-panel {
     border: 1px solid var(--mud-palette-lines-default);
     border-radius: var(--pl-radius);
@@ -43,6 +50,7 @@
     width: min(560px, 100%);
     max-height: min(720px, 88vh);
     overflow: auto;
+    border-radius: var(--pl-radius);
 }
 
 .pl-bottom-sheet {
@@ -110,6 +118,10 @@
     --pl-metric-accent: var(--mud-palette-tertiary);
 }
 
+.pl-metric-red {
+    --pl-metric-accent: var(--mud-palette-error);
+}
+
 .pl-metric-tile {
     border: 1px solid color-mix(in srgb, var(--pl-metric-accent, var(--mud-palette-primary)) 34%, var(--mud-palette-lines-default));
     border-radius: var(--pl-radius);
@@ -155,6 +167,112 @@
 
 .pl-metric-arrow {
     color: var(--pl-metric-accent, var(--mud-palette-primary));
+}
+
+.pl-message-menu-panel {
+    width: min(390px, calc(100vw - 24px));
+    max-height: min(640px, calc(100vh - 88px));
+    overflow: auto;
+    border-radius: var(--pl-radius);
+}
+
+.pl-message-button-unread {
+    color: var(--mud-palette-warning) !important;
+    background: color-mix(in srgb, var(--mud-palette-warning) 22%, transparent) !important;
+}
+
+.pl-message-badge .mud-badge {
+    box-shadow: 0 0 0 2px var(--mud-palette-appbar-background);
+}
+
+.pl-feed-header-icon,
+.pl-race-icon,
+.pl-vdot-icon,
+.pl-pace-icon,
+.pl-training-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    flex: 0 0 42px;
+    border-radius: var(--pl-radius);
+    color: var(--pl-metric-accent, var(--mud-palette-primary));
+    background: color-mix(in srgb, var(--pl-metric-accent, var(--mud-palette-primary)) 16%, transparent);
+}
+
+.pl-feed-tile {
+    --pl-feed-accent: var(--mud-palette-primary);
+    border: 1px solid color-mix(in srgb, var(--pl-feed-accent) 28%, var(--mud-palette-lines-default));
+    border-radius: var(--pl-radius);
+    background: color-mix(in srgb, var(--pl-feed-accent) 7%, var(--mud-palette-surface));
+}
+
+.pl-feed-tile-info {
+    --pl-feed-accent: var(--mud-palette-info);
+}
+
+.pl-feed-tile-success {
+    --pl-feed-accent: var(--mud-palette-success);
+}
+
+.pl-feed-tile-warning {
+    --pl-feed-accent: var(--mud-palette-warning);
+}
+
+.pl-feed-tile-error {
+    --pl-feed-accent: var(--mud-palette-error);
+}
+
+.pl-feed-tile-icon {
+    color: var(--pl-feed-accent);
+    background: color-mix(in srgb, var(--pl-feed-accent) 16%, transparent);
+}
+
+.pl-vdot-card,
+.pl-race-card,
+.pl-pace-card,
+.pl-training-panel {
+    border: 1px solid color-mix(in srgb, var(--pl-metric-accent, var(--mud-palette-primary)) 26%, var(--mud-palette-lines-default));
+    border-radius: var(--pl-radius);
+    background: color-mix(in srgb, var(--pl-metric-accent, var(--mud-palette-primary)) 8%, var(--mud-palette-surface));
+}
+
+.pl-vdot-card {
+    --pl-metric-accent: var(--mud-palette-primary);
+    text-align: center;
+}
+
+.pl-race-card,
+.pl-training-panel {
+    --pl-metric-accent: var(--mud-palette-secondary);
+}
+
+.pl-pace-card {
+    min-height: 136px;
+}
+
+.pl-interval-row {
+    display: grid;
+    grid-template-columns: 42px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+}
+
+.pl-interval-row:last-child {
+    border-bottom: 0;
+}
+
+.pl-interval-row-muted {
+    opacity: .72;
+}
+
+.pl-course-detail {
+    border: 1px solid color-mix(in srgb, var(--mud-palette-primary) 18%, var(--mud-palette-lines-default));
+    border-radius: var(--pl-radius);
+    background: color-mix(in srgb, var(--mud-palette-primary) 6%, var(--mud-palette-surface));
 }
 
 .pl-identity-success {


### PR DESCRIPTION
Report

Harmonized the athlete-facing UI with the dashboard style: removed nested/double containers around VDOT, race, and metric elements, and aligned related pages with the dashboard’s colored surface treatment.
Moved the message feed out of the dashboard into an AppBar alarm-clock overlay with an unread-message badge.
Completed localization coverage: all 46 resource groups now include de/en/tr/da/ar/ru/fr/zh/es/fa.
Fixed Identity/DataAnnotation localization so Login, Register, and Change Password no longer render German or English fallback validation text in other languages.
Extended localization tests for dashboard, athlete components, course management, course services, and identity resources.
Verification

dotnet build PaceLeticsFramework.sln passed.
dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-build passed: 99/99 tests.
Rendered Spanish login page checked: lang="es", Spanish labels and validation attributes, no English required-field fallback.
Existing NU1902 warnings for OpenMcdf and SharpCompress remain unchanged.