### PR TITLE
Refresh theme catalog

### DIFF
--- a/PR_REPORT.md
+++ b/PR_REPORT.md
@@ -1,27 +1,34 @@
-# PR Report: Localization Language Expansion
+# PR Report: Theme Catalog Refresh
 
 ## Summary
-- Added Turkish, Danish, Arabic, Russian, French, Chinese, Spanish, and Persian to the supported app cultures.
-- Reworked the language selector to render from a shared culture catalog instead of hard-coded German/English entries.
-- Added right-to-left document direction support for Arabic and Persian in both the Blazor host and Identity layout.
-- Localized visible profile role labels such as athlete and coach, including the profile overview and account management area.
-- Added controlled English fallback resource files so newly supported cultures resolve text instead of showing raw resource keys.
+- Reworked theme selection so each theme now controls whether it renders in light or dark mode.
+- Removed the separate Light/Dark/System color-scheme selector from the app bar theme menu.
+- Moved visible theme names into the theme catalog as English display names, making English the single source for theme labels.
+- Removed the `ElderVale` theme from the enum, catalog, menu, and legacy layout resources.
+- Simplified the theme catalog by keeping only the active palette for each theme instead of maintaining unused light/dark variants.
+
+## Theme Direction
+- Dark themes: PaceLetics, Ocean, Forest, Afterglow, Dark Romance, Stellar Forge.
+- Light themes: High Contrast, Wildflowers, Maritime, Tropical, Golden Hour, Summit Blaze.
+- Ocean now uses a deeper dark-blue background.
+- Forest now uses a dark-brown background.
+- Wildflowers has a brighter poppy/cornflower-inspired palette.
+- Maritime is light with a warmer beach/shabby-chic coastal palette.
+- Stellar Forge is dark with stronger Star-Wars-like yellow and heavier display typography.
 
 ## Main Areas Changed
-- Supported culture catalog: `PaceLetics.Web/Localization/*`
-- Request localization registration: `PaceLetics.Web/Program.cs`
-- Language menu: `PaceLetics.Web/Shared/CultureSelector.razor`
-- HTML language and direction metadata: `PaceLetics.Web/Pages/_Host.cshtml`, `PaceLetics.Web/Pages/Shared/_Layout.cshtml`
-- Profile role localization: `PaceLetics.Web/Pages/Profiles.razor`, `PaceLetics.Web/Resources/Pages/Profiles.*.resx`
-- Account profile localization and validation messaging: `PaceLetics.Web/Areas/Identity/Pages/Account/Manage/Index.cshtml*`
-- Localization fallback resources: neutral `.resx` files copied from existing English resources.
-- New translated resource files for core surfaces: app title fallback, navigation, layout theme labels, profile overview, and account profile management.
+- Theme catalog and palettes: `PaceLetics.Web/Services/Theming/AppThemeCatalog.cs`
+- Theme metadata: `PaceLetics.Web/Services/Theming/AppThemeDefinition.cs`
+- Theme enum cleanup: `PaceLetics.Web/Services/Theming/AppThemeName.cs`
+- Theme preference behavior: `PaceLetics.Web/Services/Theming/ThemePreferenceService.cs`
+- App bar theme menu: `PaceLetics.Web/Shared/MainLayout.razor`
+- Removed color-scheme enum: `PaceLetics.Web/Services/Theming/AppColorScheme.cs`
+- Removed obsolete translated theme and scheme labels from `PaceLetics.Web/Resources/Shared/MainLayout*.resx`
 
 ## Verification
-- `dotnet test PaceLeticsFramework.sln` succeeded.
-- Browser smoke check confirmed `culture=ar&ui-culture=ar` renders the Identity layout with `lang="ar"` and `dir="rtl"`.
+- `dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --filter AppThemeCatalogTests` succeeded.
+- Search confirmed no remaining `AppColorScheme`, `ColorScheme`, `Scheme_*`, `ElderVale`, or localized `Theme_*` references in `PaceLetics.Web` and `PaceLetics.Tests`.
 
 ## Notes
-- The new cultures use English fallback resources for screens that do not yet have full native translations. This prevents missing-resource keys from appearing while keeping future translation work incremental.
-- Existing package vulnerability warnings for `OpenMcdf` and `SharpCompress` remain unrelated to this change.
-- German course seed content still exists in `CourseSeedData.cs`; that is seeded course data rather than profile UI localization.
+- Existing NuGet vulnerability warnings for `OpenMcdf` and `SharpCompress` still appear during test restore/build and are unrelated to this change.
+- Existing analyzer/nullability warnings in component projects remain unrelated to this change.

--- a/PaceLetics.Web/Resources/Shared/MainLayout.ar.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.ar.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>السمة</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>نظام الألوان</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>المحيط</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>الغابة</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>تباين عالٍ</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>زهور برية</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>وهج المساء</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>رومانسية داكنة</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>بحري</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>استوائي</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>الساعة الذهبية</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>مسبك النجوم</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>الوادي القديم</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>وهج القمة</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>فاتح</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>داكن</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>النظام</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.da.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.da.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Tema</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Farveskema</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Hav</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Skov</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>Høj kontrast</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Vilde blomster</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Efterglød</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Mørk romance</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Maritim</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Tropisk</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Gylden time</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Stjernesmedje</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Ældgammel dal</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Topglød</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Lys</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Mørk</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>System</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.de.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.de.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Theme</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Farbschema</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Ocean</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Forest</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>Hoher Kontrast</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Wildflowers</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Afterglow</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Dark Romance</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Maritime</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Tropical</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Goldene Stunde</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Sternenschmiede</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Altes Tal</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Gipfelglut</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Hell</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Dunkel</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>System</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.en.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.en.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Theme</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Color scheme</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Ocean</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Forest</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>High contrast</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Wildflowers</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Afterglow</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Dark Romance</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Maritime</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Tropical</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Golden Hour</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Stellar Forge</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Elder Vale</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Summit Blaze</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Light</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Dark</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>System</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.es.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.es.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Tema</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Combinación de colores</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Océano</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Bosque</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>Alto contraste</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Flores silvestres</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Resplandor</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Romance oscuro</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Marítimo</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Tropical</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Hora dorada</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Forja estelar</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Valle antiguo</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Brillo de cumbre</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Claro</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Oscuro</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>Sistema</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.fa.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.fa.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>پوسته</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>طرح رنگ</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>اقیانوس</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>جنگل</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>کنتراست بالا</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>گل‌های وحشی</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>پس‌تاب</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>رمانس تیره</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>دریایی</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>گرمسیری</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>ساعت طلایی</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>کوره ستاره‌ای</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>دره کهن</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>درخشش قله</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>روشن</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>تیره</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>سیستم</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.fr.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.fr.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Thème</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Jeu de couleurs</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Océan</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Forêt</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>Contraste élevé</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Fleurs sauvages</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Lueur du soir</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Romance sombre</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Maritime</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Tropical</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Heure dorée</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Forge stellaire</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Ancien vallon</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Éclat du sommet</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Clair</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Sombre</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>Système</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Theme</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Color scheme</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Ocean</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Forest</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>High contrast</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Wildflowers</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Afterglow</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Dark Romance</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Maritime</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Tropical</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Golden Hour</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Stellar Forge</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Elder Vale</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Summit Blaze</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Light</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Dark</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>System</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.ru.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.ru.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Тема</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Цветовая схема</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Океан</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Лес</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>Высокий контраст</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Полевые цветы</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Послесвечение</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Темная романтика</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Морская</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Тропическая</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Золотой час</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Звездная кузница</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Древняя долина</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Сияние вершины</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Светлая</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Темная</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>Система</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.tr.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.tr.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>Tema</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>Renk düzeni</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>Okyanus</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>Orman</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>Yüksek kontrast</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>Kır çiçekleri</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>Gün batımı ışıltısı</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>Koyu Romantik</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>Denizci</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>Tropikal</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>Altın saat</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>Yıldız dökümü</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>Eski vadi</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>Zirve ışığı</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>Açık</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>Koyu</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>Sistem</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Shared/MainLayout.zh.resx
+++ b/PaceLetics.Web/Resources/Shared/MainLayout.zh.resx
@@ -5,21 +5,4 @@
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Theme" xml:space="preserve"><value>主题</value></data>
-  <data name="ColorScheme" xml:space="preserve"><value>配色方案</value></data>
-  <data name="Theme_PaceLetics" xml:space="preserve"><value>PaceLetics</value></data>
-  <data name="Theme_Ocean" xml:space="preserve"><value>海洋</value></data>
-  <data name="Theme_Forest" xml:space="preserve"><value>森林</value></data>
-  <data name="Theme_HighContrast" xml:space="preserve"><value>高对比度</value></data>
-  <data name="Theme_Wildflowers" xml:space="preserve"><value>野花</value></data>
-  <data name="Theme_Afterglow" xml:space="preserve"><value>余晖</value></data>
-  <data name="Theme_DarkRomance" xml:space="preserve"><value>暗色浪漫</value></data>
-  <data name="Theme_Maritime" xml:space="preserve"><value>海事</value></data>
-  <data name="Theme_Tropical" xml:space="preserve"><value>热带</value></data>
-  <data name="Theme_GoldenHour" xml:space="preserve"><value>黄金时刻</value></data>
-  <data name="Theme_StellarForge" xml:space="preserve"><value>星辰熔炉</value></data>
-  <data name="Theme_ElderVale" xml:space="preserve"><value>古老山谷</value></data>
-  <data name="Theme_SummitBlaze" xml:space="preserve"><value>峰顶光焰</value></data>
-  <data name="Scheme_Light" xml:space="preserve"><value>浅色</value></data>
-  <data name="Scheme_Dark" xml:space="preserve"><value>深色</value></data>
-  <data name="Scheme_System" xml:space="preserve"><value>系统</value></data>
 </root>

--- a/PaceLetics.Web/Services/Theming/AppColorScheme.cs
+++ b/PaceLetics.Web/Services/Theming/AppColorScheme.cs
@@ -1,8 +1,0 @@
-namespace PaceLetics.Web.Services.Theming;
-
-public enum AppColorScheme
-{
-    Light,
-    Dark,
-    System
-}

--- a/PaceLetics.Web/Services/Theming/AppThemeCatalog.cs
+++ b/PaceLetics.Web/Services/Theming/AppThemeCatalog.cs
@@ -6,49 +6,34 @@ public static class AppThemeCatalog
 {
     public static IReadOnlyList<AppThemeDefinition> Themes { get; } =
     [
-        new(AppThemeName.PaceLetics, CreatePaceLeticsTheme(), Icons.Material.Filled.DirectionsRun),
-        new(AppThemeName.Ocean, CreateOceanTheme(), Icons.Material.Filled.Waves),
-        new(AppThemeName.Forest, CreateForestTheme(), Icons.Material.Filled.Park),
-        new(AppThemeName.HighContrast, CreateHighContrastTheme(), Icons.Material.Filled.Contrast),
-        new(AppThemeName.Wildflowers, CreateWildflowersTheme(), Icons.Material.Filled.LocalFlorist),
-        new(AppThemeName.Afterglow, CreateAfterglowTheme(), Icons.Material.Filled.WbTwilight),
-        new(AppThemeName.DarkRomance, CreateDarkRomanceTheme(), Icons.Material.Filled.Favorite),
-        new(AppThemeName.Maritime, CreateMaritimeTheme(), Icons.Material.Filled.Sailing),
-        new(AppThemeName.Tropical, CreateTropicalTheme(), Icons.Material.Filled.BeachAccess),
-        new(AppThemeName.GoldenHour, CreateGoldenHourTheme(), Icons.Material.Filled.WbSunny),
-        new(AppThemeName.StellarForge, CreateStellarForgeTheme(), Icons.Material.Filled.AutoAwesome),
-        new(AppThemeName.ElderVale, CreateElderValeTheme(), Icons.Material.Filled.Terrain),
-        new(AppThemeName.SummitBlaze, CreateSummitBlazeTheme(), Icons.Material.Filled.LocalFireDepartment)
+        new(AppThemeName.PaceLetics, "PaceLetics", CreatePaceLeticsTheme(), Icons.Material.Filled.DirectionsRun, IsDarkMode: true),
+        new(AppThemeName.Ocean, "Ocean", CreateOceanTheme(), Icons.Material.Filled.Waves, IsDarkMode: true),
+        new(AppThemeName.Forest, "Forest", CreateForestTheme(), Icons.Material.Filled.Park, IsDarkMode: true),
+        new(AppThemeName.HighContrast, "High Contrast", CreateHighContrastTheme(), Icons.Material.Filled.Contrast, IsDarkMode: false),
+        new(AppThemeName.Wildflowers, "Wildflowers", CreateWildflowersTheme(), Icons.Material.Filled.LocalFlorist, IsDarkMode: false),
+        new(AppThemeName.Afterglow, "Afterglow", CreateAfterglowTheme(), Icons.Material.Filled.WbTwilight, IsDarkMode: true),
+        new(AppThemeName.DarkRomance, "Dark Romance", CreateDarkRomanceTheme(), Icons.Material.Filled.Favorite, IsDarkMode: true),
+        new(AppThemeName.Maritime, "Maritime", CreateMaritimeTheme(), Icons.Material.Filled.Sailing, IsDarkMode: false),
+        new(AppThemeName.Tropical, "Tropical", CreateTropicalTheme(), Icons.Material.Filled.BeachAccess, IsDarkMode: false),
+        new(AppThemeName.GoldenHour, "Golden Hour", CreateGoldenHourTheme(), Icons.Material.Filled.WbSunny, IsDarkMode: false),
+        new(AppThemeName.StellarForge, "Stellar Forge", CreateStellarForgeTheme(), Icons.Material.Filled.AutoAwesome, IsDarkMode: true),
+        new(AppThemeName.SummitBlaze, "Summit Blaze", CreateSummitBlazeTheme(), Icons.Material.Filled.LocalFireDepartment, IsDarkMode: false)
     ];
+
+    public static AppThemeDefinition GetThemeDefinition(AppThemeName name)
+    {
+        return Themes.FirstOrDefault(theme => theme.Name == name)
+            ?? Themes[0];
+    }
 
     public static MudTheme GetTheme(AppThemeName name)
     {
-        return Themes.FirstOrDefault(theme => theme.Name == name)?.Theme
-            ?? Themes[0].Theme;
+        return GetThemeDefinition(name).Theme;
     }
 
     private static MudTheme CreatePaceLeticsTheme()
     {
         return CreateTheme(
-            light: new PaletteLight
-            {
-                Primary = "#FF2BD6",
-                Secondary = "#00E5FF",
-                Tertiary = "#B7FF2A",
-                Info = "#00B8FF",
-                Success = "#22E87A",
-                Warning = "#FFE14A",
-                Error = "#FF3B7D",
-                Background = "#FFF6FF",
-                BackgroundGray = "#F3E8FF",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#31116E",
-                AppbarText = "#FFF7FF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#2B154D",
-                TextPrimary = "#241136",
-                TextSecondary = "#6C4F82"
-            },
             dark: new PaletteDark
             {
                 Primary = "#FF43D1",
@@ -73,86 +58,48 @@ public static class AppThemeCatalog
     private static MudTheme CreateOceanTheme()
     {
         return CreateTheme(
-            light: new PaletteLight
-            {
-                Primary = "#006C80",
-                Secondary = "#6C5CE7",
-                Tertiary = "#FFB703",
-                Info = "#006C80",
-                Success = "#008A74",
-                Warning = "#D99500",
-                Error = "#D94A3D",
-                Background = "#F3FBFD",
-                BackgroundGray = "#E6F3F7",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#004E64",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#183238",
-                TextPrimary = "#173037",
-                TextSecondary = "#587078"
-            },
             dark: new PaletteDark
             {
-                Primary = "#35C2DC",
-                Secondary = "#A49BFF",
+                Primary = "#38C6FF",
+                Secondary = "#7AD7F0",
                 Tertiary = "#FFD166",
-                Info = "#35C2DC",
-                Success = "#48D6B8",
+                Info = "#38C6FF",
+                Success = "#43D9B8",
                 Warning = "#FFD166",
                 Error = "#FF7F76",
-                Background = "#0C171D",
-                BackgroundGray = "#13232B",
-                Surface = "#182A33",
-                AppbarBackground = "#071116",
-                AppbarText = "#EAF9FC",
-                DrawerBackground = "#101E25",
-                DrawerText = "#D7EDF2",
-                TextPrimary = "#EDF9FB",
-                TextSecondary = "#9DB9C1"
+                Background = "#06172B",
+                BackgroundGray = "#0A213B",
+                Surface = "#102B49",
+                AppbarBackground = "#03101F",
+                AppbarText = "#EAF8FF",
+                DrawerBackground = "#071B31",
+                DrawerText = "#D9F0FA",
+                TextPrimary = "#EDF8FF",
+                TextSecondary = "#A8C6D9"
             });
     }
 
     private static MudTheme CreateForestTheme()
     {
         return CreateTheme(
-            light: new PaletteLight
-            {
-                Primary = "#2E7D32",
-                Secondary = "#8E5A2A",
-                Tertiary = "#C2410C",
-                Info = "#3D6FA8",
-                Success = "#2E7D32",
-                Warning = "#A56B32",
-                Error = "#B84A3A",
-                Background = "#F8FAF3",
-                BackgroundGray = "#EFF3E6",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#24452B",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#283323",
-                TextPrimary = "#263122",
-                TextSecondary = "#68735F"
-            },
             dark: new PaletteDark
             {
-                Primary = "#78C86B",
-                Secondary = "#C9975D",
+                Primary = "#87D66B",
+                Secondary = "#D0A05F",
                 Tertiary = "#F08A5D",
-                Info = "#7FB2E8",
-                Success = "#78C86B",
-                Warning = "#C9975D",
+                Info = "#88B7E8",
+                Success = "#87D66B",
+                Warning = "#D0A05F",
                 Error = "#F08A5D",
-                Background = "#11170E",
-                BackgroundGray = "#1A2216",
-                Surface = "#202A1C",
-                AppbarBackground = "#0C120A",
-                AppbarText = "#EEF8EA",
-                DrawerBackground = "#151D12",
-                DrawerText = "#E0EBD9",
-                TextPrimary = "#F0F8EC",
-                TextSecondary = "#B3C1AA"
+                Background = "#1A1008",
+                BackgroundGray = "#24160B",
+                Surface = "#2D1E11",
+                AppbarBackground = "#120A05",
+                AppbarText = "#F5EFE5",
+                DrawerBackground = "#211309",
+                DrawerText = "#EFE2D0",
+                TextPrimary = "#F7EFE5",
+                TextSecondary = "#CAB59A"
             });
     }
 
@@ -179,27 +126,6 @@ public static class AppThemeCatalog
                 TextSecondary = "#222222",
                 LinesDefault = "#000000",
                 Divider = "#000000"
-            },
-            dark: new PaletteDark
-            {
-                Primary = "#FFFFFF",
-                Secondary = "#00D9FF",
-                Tertiary = "#FFD400",
-                Info = "#00D9FF",
-                Success = "#2EFF8F",
-                Warning = "#FFD400",
-                Error = "#FF5A5F",
-                Background = "#000000",
-                BackgroundGray = "#111111",
-                Surface = "#080808",
-                AppbarBackground = "#000000",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#000000",
-                DrawerText = "#FFFFFF",
-                TextPrimary = "#FFFFFF",
-                TextSecondary = "#E5E5E5",
-                LinesDefault = "#FFFFFF",
-                Divider = "#FFFFFF"
             });
     }
 
@@ -208,66 +134,28 @@ public static class AppThemeCatalog
         return CreateTheme(
             light: new PaletteLight
             {
-                Primary = "#6D8F2E",
-                Secondary = "#C55A8A",
-                Tertiary = "#E6A23C",
-                Info = "#5C7FA8",
-                Success = "#6D8F2E",
-                Warning = "#C98728",
-                Error = "#B95764",
-                Background = "#FBFAF3",
-                BackgroundGray = "#F0F4E7",
+                Primary = "#D22B2B",
+                Secondary = "#4F80E1",
+                Tertiary = "#F2C94C",
+                Info = "#4F80E1",
+                Success = "#5C8A2E",
+                Warning = "#D89A1A",
+                Error = "#C62828",
+                Background = "#FFFDF4",
+                BackgroundGray = "#F2F5E8",
                 Surface = "#FFFFFF",
-                AppbarBackground = "#4F6F27",
+                AppbarBackground = "#5C8A2E",
                 AppbarText = "#FFFFFF",
                 DrawerBackground = "#FFFFFF",
-                DrawerText = "#2F3526",
-                TextPrimary = "#2E3327",
-                TextSecondary = "#6F755F"
-            },
-            dark: new PaletteDark
-            {
-                Primary = "#A8D75F",
-                Secondary = "#F08DB8",
-                Tertiary = "#F4C36F",
-                Info = "#8FBDE8",
-                Success = "#A8D75F",
-                Warning = "#F4C36F",
-                Error = "#F08DB8",
-                Background = "#15170F",
-                BackgroundGray = "#202519",
-                Surface = "#252A1D",
-                AppbarBackground = "#0F130A",
-                AppbarText = "#F4F8E8",
-                DrawerBackground = "#1A2013",
-                DrawerText = "#E7EFD7",
-                TextPrimary = "#F5FAEA",
-                TextSecondary = "#C1CDA9"
+                DrawerText = "#2E3525",
+                TextPrimary = "#283022",
+                TextSecondary = "#68745C"
             });
     }
 
     private static MudTheme CreateAfterglowTheme()
     {
         return CreateTheme(
-            light: new PaletteLight
-            {
-                Primary = "#D45D4C",
-                Secondary = "#5B5BD6",
-                Tertiary = "#F0A202",
-                Info = "#5B5BD6",
-                Success = "#2F8F6B",
-                Warning = "#D98B00",
-                Error = "#D45D4C",
-                Background = "#FFF8F2",
-                BackgroundGray = "#F5ECE7",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#633D73",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#3B2D35",
-                TextPrimary = "#362B31",
-                TextSecondary = "#76656D"
-            },
             dark: new PaletteDark
             {
                 Primary = "#FF8A70",
@@ -292,33 +180,14 @@ public static class AppThemeCatalog
     private static MudTheme CreateDarkRomanceTheme()
     {
         return CreateTheme(
-            light: new PaletteLight
-            {
-                Primary = "#8F1D3A",
-                Secondary = "#3B2C5A",
-                Tertiary = "#B7791F",
-                Info = "#5B4A8C",
-                Success = "#477A53",
-                Warning = "#B7791F",
-                Error = "#8F1D3A",
-                Background = "#FBF5F7",
-                BackgroundGray = "#F1E7EC",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#4A1425",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#35252B",
-                TextPrimary = "#302228",
-                TextSecondary = "#7B6670"
-            },
             dark: new PaletteDark
             {
                 Primary = "#E85D84",
                 Secondary = "#9A85D6",
-                Tertiary = "#E0A23B",
+                Tertiary = "#D6A647",
                 Info = "#9A85D6",
                 Success = "#7DC48F",
-                Warning = "#E0A23B",
+                Warning = "#D6A647",
                 Error = "#E85D84",
                 Background = "#12090D",
                 BackgroundGray = "#211118",
@@ -337,41 +206,22 @@ public static class AppThemeCatalog
         return CreateTheme(
             light: new PaletteLight
             {
-                Primary = "#0B5E78",
-                Secondary = "#C43E35",
-                Tertiary = "#D9A441",
-                Info = "#0B5E78",
-                Success = "#2D8C72",
-                Warning = "#B8862B",
-                Error = "#C43E35",
-                Background = "#F5FAFC",
-                BackgroundGray = "#E8F1F4",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#123C52",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#253740",
-                TextPrimary = "#20323B",
-                TextSecondary = "#637781"
-            },
-            dark: new PaletteDark
-            {
-                Primary = "#58C4E0",
-                Secondary = "#F47B73",
-                Tertiary = "#F0C15D",
-                Info = "#58C4E0",
-                Success = "#69D2AE",
-                Warning = "#F0C15D",
-                Error = "#F47B73",
-                Background = "#0B141A",
-                BackgroundGray = "#121F27",
-                Surface = "#172832",
-                AppbarBackground = "#061015",
-                AppbarText = "#EAF8FC",
-                DrawerBackground = "#101C23",
-                DrawerText = "#DCECF1",
-                TextPrimary = "#EFFAFF",
-                TextSecondary = "#A5BBC4"
+                Primary = "#2F6F7E",
+                Secondary = "#A85F4D",
+                Tertiary = "#C9A66B",
+                Info = "#3C7F92",
+                Success = "#5F8E7A",
+                Warning = "#B58A45",
+                Error = "#A85F4D",
+                Background = "#F7EFE4",
+                BackgroundGray = "#E9DDD0",
+                Surface = "#FFFDF8",
+                AppbarBackground = "#4F7F8C",
+                AppbarText = "#FFFDF8",
+                DrawerBackground = "#FFFDF8",
+                DrawerText = "#3F4B4C",
+                TextPrimary = "#343F40",
+                TextSecondary = "#71807B"
             });
     }
 
@@ -396,25 +246,6 @@ public static class AppThemeCatalog
                 DrawerText = "#213733",
                 TextPrimary = "#1F3430",
                 TextSecondary = "#5D7771"
-            },
-            dark: new PaletteDark
-            {
-                Primary = "#29D3BD",
-                Secondary = "#FF957A",
-                Tertiary = "#B7E06A",
-                Info = "#5CC8FF",
-                Success = "#29D3BD",
-                Warning = "#B7E06A",
-                Error = "#FF957A",
-                Background = "#071815",
-                BackgroundGray = "#10241F",
-                Surface = "#17302A",
-                AppbarBackground = "#04110F",
-                AppbarText = "#E9FFFA",
-                DrawerBackground = "#0D1D19",
-                DrawerText = "#D8F2EC",
-                TextPrimary = "#ECFFFB",
-                TextSecondary = "#A3C6BE"
             });
     }
 
@@ -439,112 +270,32 @@ public static class AppThemeCatalog
                 DrawerText = "#3E2B35",
                 TextPrimary = "#36272F",
                 TextSecondary = "#806A73"
-            },
-            dark: new PaletteDark
-            {
-                Primary = "#FF8B70",
-                Secondary = "#B7A2FF",
-                Tertiary = "#FFD166",
-                Info = "#80B6FF",
-                Success = "#74D8A7",
-                Warning = "#FFD166",
-                Error = "#FF7194",
-                Background = "#171018",
-                BackgroundGray = "#241923",
-                Surface = "#2D202A",
-                AppbarBackground = "#100A12",
-                AppbarText = "#FFF0E8",
-                DrawerBackground = "#1C131B",
-                DrawerText = "#F5DFE8",
-                TextPrimary = "#FFF5ED",
-                TextSecondary = "#D4BBC6"
             });
     }
 
     private static MudTheme CreateStellarForgeTheme()
     {
         return CreateTheme(
-            light: new PaletteLight
-            {
-                Primary = "#2E5EEA",
-                Secondary = "#D83B52",
-                Tertiary = "#F0C84B",
-                Info = "#2E5EEA",
-                Success = "#2C9F7E",
-                Warning = "#B9891B",
-                Error = "#D83B52",
-                Background = "#F7F8FC",
-                BackgroundGray = "#E8ECF5",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#202849",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#242A3B",
-                TextPrimary = "#202536",
-                TextSecondary = "#687086"
-            },
             dark: new PaletteDark
             {
-                Primary = "#5F8BFF",
-                Secondary = "#FF5D72",
-                Tertiary = "#FFE169",
-                Info = "#5F8BFF",
+                Primary = "#FFE81F",
+                Secondary = "#4CC9F0",
+                Tertiary = "#FFB703",
+                Info = "#4CC9F0",
                 Success = "#49D4AA",
-                Warning = "#FFE169",
+                Warning = "#FFE81F",
                 Error = "#FF5D72",
-                Background = "#080A12",
-                BackgroundGray = "#121627",
-                Surface = "#1B2036",
-                AppbarBackground = "#05070D",
-                AppbarText = "#EEF3FF",
-                DrawerBackground = "#0E1220",
-                DrawerText = "#E2E8FF",
-                TextPrimary = "#F5F7FF",
-                TextSecondary = "#AEB8D2"
-            });
-    }
-
-    private static MudTheme CreateElderValeTheme()
-    {
-        return CreateTheme(
-            light: new PaletteLight
-            {
-                Primary = "#477A48",
-                Secondary = "#8A5F3C",
-                Tertiary = "#C9A34A",
-                Info = "#4E6FA8",
-                Success = "#477A48",
-                Warning = "#A6772A",
-                Error = "#A9483D",
-                Background = "#F8FAF0",
-                BackgroundGray = "#ECEFDF",
-                Surface = "#FFFFFF",
-                AppbarBackground = "#3A5134",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#FFFFFF",
-                DrawerText = "#2D3327",
-                TextPrimary = "#2A3025",
-                TextSecondary = "#69705F"
+                Background = "#05070D",
+                BackgroundGray = "#0E1322",
+                Surface = "#171C2F",
+                AppbarBackground = "#02040A",
+                AppbarText = "#FFE81F",
+                DrawerBackground = "#0A0F1B",
+                DrawerText = "#FFEFB0",
+                TextPrimary = "#FFF7C2",
+                TextSecondary = "#BFC7DA"
             },
-            dark: new PaletteDark
-            {
-                Primary = "#8BC47B",
-                Secondary = "#C99A66",
-                Tertiary = "#E8C76A",
-                Info = "#8AADF0",
-                Success = "#8BC47B",
-                Warning = "#E8C76A",
-                Error = "#E07A6E",
-                Background = "#10140D",
-                BackgroundGray = "#1B2116",
-                Surface = "#252D1F",
-                AppbarBackground = "#0A0E08",
-                AppbarText = "#F1F8E9",
-                DrawerBackground = "#151B11",
-                DrawerText = "#E4EDD9",
-                TextPrimary = "#F5FAEE",
-                TextSecondary = "#B9C5AD"
-            });
+            typography: CreateStellarForgeTypography());
     }
 
     private static MudTheme CreateSummitBlazeTheme()
@@ -568,52 +319,57 @@ public static class AppThemeCatalog
                 DrawerText = "#242424",
                 TextPrimary = "#202020",
                 TextSecondary = "#6B5D57"
-            },
-            dark: new PaletteDark
-            {
-                Primary = "#FF6A2A",
-                Secondary = "#56A7F2",
-                Tertiary = "#E8E8E8",
-                Info = "#56A7F2",
-                Success = "#4BD184",
-                Warning = "#FF9B3D",
-                Error = "#FF7043",
-                Background = "#111111",
-                BackgroundGray = "#1D1D1D",
-                Surface = "#272727",
-                AppbarBackground = "#0B0B0B",
-                AppbarText = "#FFFFFF",
-                DrawerBackground = "#171717",
-                DrawerText = "#F2F2F2",
-                TextPrimary = "#FFFFFF",
-                TextSecondary = "#C7C7C7"
             });
     }
 
-    private static MudTheme CreateTheme(PaletteLight light, PaletteDark dark)
+    private static MudTheme CreateTheme(
+        PaletteLight? light = null,
+        PaletteDark? dark = null,
+        Typography? typography = null)
     {
         return new MudTheme
         {
-            PaletteLight = light,
-            PaletteDark = dark,
+            PaletteLight = light ?? new PaletteLight(),
+            PaletteDark = dark ?? new PaletteDark(),
             LayoutProperties = new LayoutProperties
             {
                 DrawerWidthLeft = "260px",
                 DrawerWidthRight = "300px"
             },
-            Typography = new Typography
-            {
-                H1 = new H1Typography { FontSize = "2.5rem" },
-                H2 = new H2Typography { FontSize = "2rem" },
-                H3 = new H3Typography { FontSize = "1.6rem" },
-                H4 = new H4Typography { FontSize = "1.3rem" },
-                H5 = new H5Typography { FontSize = "1.1rem" },
-                H6 = new H6Typography { FontSize = "1rem" },
-                Subtitle1 = new Subtitle1Typography { FontSize = "0.95rem" },
-                Subtitle2 = new Subtitle2Typography { FontSize = "0.85rem" },
-                Body1 = new Body1Typography { FontSize = "0.9rem" },
-                Body2 = new Body2Typography { FontSize = "0.8rem" }
-            }
+            Typography = typography ?? CreateDefaultTypography()
         };
+    }
+
+    private static Typography CreateDefaultTypography()
+    {
+        return new Typography
+        {
+            H1 = new H1Typography { FontSize = "2.5rem" },
+            H2 = new H2Typography { FontSize = "2rem" },
+            H3 = new H3Typography { FontSize = "1.6rem" },
+            H4 = new H4Typography { FontSize = "1.3rem" },
+            H5 = new H5Typography { FontSize = "1.1rem" },
+            H6 = new H6Typography { FontSize = "1rem" },
+            Subtitle1 = new Subtitle1Typography { FontSize = "0.95rem" },
+            Subtitle2 = new Subtitle2Typography { FontSize = "0.85rem" },
+            Body1 = new Body1Typography { FontSize = "0.9rem" },
+            Body2 = new Body2Typography { FontSize = "0.8rem" }
+        };
+    }
+
+    private static Typography CreateStellarForgeTypography()
+    {
+        var typography = CreateDefaultTypography();
+        var displayFamily = new[] { "Arial Black", "Impact", "Segoe UI", "sans-serif" };
+
+        typography.Default = new DefaultTypography { FontFamily = displayFamily };
+        typography.H1 = new H1Typography { FontFamily = displayFamily, FontSize = "2.5rem", FontWeight = "700" };
+        typography.H2 = new H2Typography { FontFamily = displayFamily, FontSize = "2rem", FontWeight = "700" };
+        typography.H3 = new H3Typography { FontFamily = displayFamily, FontSize = "1.6rem", FontWeight = "700" };
+        typography.H4 = new H4Typography { FontFamily = displayFamily, FontSize = "1.3rem", FontWeight = "700" };
+        typography.H5 = new H5Typography { FontFamily = displayFamily, FontSize = "1.1rem", FontWeight = "700" };
+        typography.H6 = new H6Typography { FontFamily = displayFamily, FontSize = "1rem", FontWeight = "700" };
+
+        return typography;
     }
 }

--- a/PaceLetics.Web/Services/Theming/AppThemeDefinition.cs
+++ b/PaceLetics.Web/Services/Theming/AppThemeDefinition.cs
@@ -4,5 +4,7 @@ namespace PaceLetics.Web.Services.Theming;
 
 public sealed record AppThemeDefinition(
     AppThemeName Name,
+    string DisplayName,
     MudTheme Theme,
-    string Icon);
+    string Icon,
+    bool IsDarkMode);

--- a/PaceLetics.Web/Services/Theming/AppThemeName.cs
+++ b/PaceLetics.Web/Services/Theming/AppThemeName.cs
@@ -13,6 +13,5 @@ public enum AppThemeName
     Tropical,
     GoldenHour,
     StellarForge,
-    ElderVale,
     SummitBlaze
 }

--- a/PaceLetics.Web/Services/Theming/ThemePreferenceService.cs
+++ b/PaceLetics.Web/Services/Theming/ThemePreferenceService.cs
@@ -6,7 +6,6 @@ namespace PaceLetics.Web.Services.Theming;
 public sealed class ThemePreferenceService
 {
     private const string ThemeKey = "paceletics.theme.name";
-    private const string SchemeKey = "paceletics.theme.scheme";
     private readonly IJSRuntime _js;
 
     public ThemePreferenceService(IJSRuntime js)
@@ -17,43 +16,22 @@ public sealed class ThemePreferenceService
     public event Action? Changed;
 
     public AppThemeName ThemeName { get; private set; } = AppThemeName.PaceLetics;
-    public AppColorScheme ColorScheme { get; private set; } = AppColorScheme.System;
-    public bool SystemPrefersDarkMode { get; private set; }
     public IReadOnlyList<AppThemeDefinition> Themes => AppThemeCatalog.Themes;
+    public AppThemeDefinition CurrentThemeDefinition => AppThemeCatalog.GetThemeDefinition(ThemeName);
     public MudTheme CurrentTheme => AppThemeCatalog.GetTheme(ThemeName);
-
-    public bool IsDarkMode => ColorScheme switch
-    {
-        AppColorScheme.Dark => true,
-        AppColorScheme.Light => false,
-        _ => SystemPrefersDarkMode
-    };
+    public bool IsDarkMode => CurrentThemeDefinition.IsDarkMode;
 
     public async Task InitializeAsync(bool systemPrefersDarkMode)
     {
-        SystemPrefersDarkMode = systemPrefersDarkMode;
-
         var storedTheme = await GetLocalStorageItemAsync(ThemeKey);
         if (Enum.TryParse(storedTheme, ignoreCase: true, out AppThemeName themeName))
             ThemeName = themeName;
-
-        var storedScheme = await GetLocalStorageItemAsync(SchemeKey);
-        if (Enum.TryParse(storedScheme, ignoreCase: true, out AppColorScheme colorScheme))
-            ColorScheme = colorScheme;
 
         NotifyChanged();
     }
 
     public Task SetSystemPrefersDarkModeAsync(bool systemPrefersDarkMode)
     {
-        if (SystemPrefersDarkMode == systemPrefersDarkMode)
-            return Task.CompletedTask;
-
-        SystemPrefersDarkMode = systemPrefersDarkMode;
-
-        if (ColorScheme == AppColorScheme.System)
-            NotifyChanged();
-
         return Task.CompletedTask;
     }
 
@@ -64,16 +42,6 @@ public sealed class ThemePreferenceService
 
         ThemeName = themeName;
         await SetLocalStorageItemAsync(ThemeKey, themeName.ToString());
-        NotifyChanged();
-    }
-
-    public async Task SetColorSchemeAsync(AppColorScheme colorScheme)
-    {
-        if (ColorScheme == colorScheme)
-            return;
-
-        ColorScheme = colorScheme;
-        await SetLocalStorageItemAsync(SchemeKey, colorScheme.ToString());
         NotifyChanged();
     }
 

--- a/PaceLetics.Web/Shared/MainLayout.razor
+++ b/PaceLetics.Web/Shared/MainLayout.razor
@@ -45,25 +45,6 @@
                     </MudStack>
                 </MudMenuItem>
             }
-
-            <MudDivider />
-            <MudMenuItem Disabled="true">
-                <MudText Typo="Typo.caption" Color="Color.Secondary">@L["ColorScheme"]</MudText>
-            </MudMenuItem>
-            @foreach (var scheme in Enum.GetValues<AppColorScheme>())
-            {
-                <MudMenuItem OnClick="@(() => ThemePreferences.SetColorSchemeAsync(scheme))">
-                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="min-width:180px;">
-                        <MudIcon Icon="@GetColorSchemeIcon(scheme)" Size="Size.Small" />
-                        <MudText>@GetColorSchemeName(scheme)</MudText>
-                        <MudSpacer />
-                        @if (ThemePreferences.ColorScheme == scheme)
-                        {
-                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" />
-                        }
-                    </MudStack>
-                </MudMenuItem>
-            }
         </MudMenu>
         <CultureSelector />
         <LoginDisplay />
@@ -107,54 +88,12 @@
 
     private string GetThemeMenuIcon()
     {
-        return ThemePreferences.ColorScheme switch
-        {
-            AppColorScheme.Light => Icons.Material.Filled.LightMode,
-            AppColorScheme.Dark => Icons.Material.Filled.DarkMode,
-            _ => Icons.Material.Filled.Palette
-        };
-    }
-
-    private string GetColorSchemeIcon(AppColorScheme scheme)
-    {
-        return scheme switch
-        {
-            AppColorScheme.Light => Icons.Material.Filled.LightMode,
-            AppColorScheme.Dark => Icons.Material.Filled.DarkMode,
-            _ => Icons.Material.Filled.SettingsSuggest
-        };
+        return ThemePreferences.CurrentThemeDefinition.Icon;
     }
 
     private string GetThemeName(AppThemeName themeName)
     {
-        return themeName switch
-        {
-            AppThemeName.PaceLetics => L["Theme_PaceLetics"],
-            AppThemeName.Ocean => L["Theme_Ocean"],
-            AppThemeName.Forest => L["Theme_Forest"],
-            AppThemeName.HighContrast => L["Theme_HighContrast"],
-            AppThemeName.Wildflowers => L["Theme_Wildflowers"],
-            AppThemeName.Afterglow => L["Theme_Afterglow"],
-            AppThemeName.DarkRomance => L["Theme_DarkRomance"],
-            AppThemeName.Maritime => L["Theme_Maritime"],
-            AppThemeName.Tropical => L["Theme_Tropical"],
-            AppThemeName.GoldenHour => L["Theme_GoldenHour"],
-            AppThemeName.StellarForge => L["Theme_StellarForge"],
-            AppThemeName.ElderVale => L["Theme_ElderVale"],
-            AppThemeName.SummitBlaze => L["Theme_SummitBlaze"],
-            _ => themeName.ToString()
-        };
-    }
-
-    private string GetColorSchemeName(AppColorScheme scheme)
-    {
-        return scheme switch
-        {
-            AppColorScheme.Light => L["Scheme_Light"],
-            AppColorScheme.Dark => L["Scheme_Dark"],
-            AppColorScheme.System => L["Scheme_System"],
-            _ => scheme.ToString()
-        };
+        return AppThemeCatalog.GetThemeDefinition(themeName).DisplayName;
     }
 
     private void OnThemePreferenceChanged()


### PR DESCRIPTION
Summary
Reworked theme selection so each theme now controls whether it renders in light or dark mode.
Removed the separate Light/Dark/System color-scheme selector from the app bar theme menu.
Moved visible theme names into the theme catalog as English display names, making English the single source for theme labels.
Removed the ElderVale theme from the enum, catalog, menu, and legacy layout resources.
Simplified the theme catalog by keeping only the active palette for each theme instead of maintaining unused light/dark variants.
Theme Direction
Dark themes: PaceLetics, Ocean, Forest, Afterglow, Dark Romance, Stellar Forge.
Light themes: High Contrast, Wildflowers, Maritime, Tropical, Golden Hour, Summit Blaze.
Ocean now uses a deeper dark-blue background.
Forest now uses a dark-brown background.
Wildflowers has a brighter poppy/cornflower-inspired palette.
Maritime is light with a warmer beach/shabby-chic coastal palette.
Stellar Forge is dark with stronger Star-Wars-like yellow and heavier display typography.
Main Areas Changed
Theme catalog and palettes: PaceLetics.Web/Services/Theming/AppThemeCatalog.cs
Theme metadata: PaceLetics.Web/Services/Theming/AppThemeDefinition.cs
Theme enum cleanup: PaceLetics.Web/Services/Theming/AppThemeName.cs
Theme preference behavior: PaceLetics.Web/Services/Theming/ThemePreferenceService.cs
App bar theme menu: PaceLetics.Web/Shared/MainLayout.razor
Removed color-scheme enum: PaceLetics.Web/Services/Theming/AppColorScheme.cs
Removed obsolete translated theme and scheme labels from PaceLetics.Web/Resources/Shared/MainLayout*.resx
Verification
dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --filter AppThemeCatalogTests succeeded.
Search confirmed no remaining AppColorScheme, ColorScheme, Scheme_*, ElderVale, or localized Theme_* references in PaceLetics.Web and PaceLetics.Tests.
Notes
Existing NuGet vulnerability warnings for OpenMcdf and SharpCompress still appear during test restore/build and are unrelated to this change.
Existing analyzer/nullability warnings in component projects remain unrelated to this change.