### PR TITLE
Persist athlete message feed state

### DIFF
--- a/PR_REPORT.md
+++ b/PR_REPORT.md
@@ -1,34 +1,43 @@
-# PR Report: Theme Catalog Refresh
+# PR Report: Persistent Message Feed State
 
 ## Summary
-- Reworked theme selection so each theme now controls whether it renders in light or dark mode.
-- Removed the separate Light/Dark/System color-scheme selector from the app bar theme menu.
-- Moved visible theme names into the theme catalog as English display names, making English the single source for theme labels.
-- Removed the `ElderVale` theme from the enum, catalog, menu, and legacy layout resources.
-- Simplified the theme catalog by keeping only the active palette for each theme instead of maintaining unused light/dark variants.
+- Reworked the athlete message feed so read and deleted message state is persisted server-side per user.
+- Added `IsRead` / `IsUnread` state to `AthleteMessage`, while keeping message generation provider-driven.
+- Replaced the right-anchored `MudMenu` feed with a viewport-centered overlay to prevent the panel from being clipped on the right side.
+- Added a delete action to each feed message, with localized tooltip/ARIA labels.
+- Updated the feed badge and warning button state so only unread messages ask for user attention.
 
-## Theme Direction
-- Dark themes: PaceLetics, Ocean, Forest, Afterglow, Dark Romance, Stellar Forge.
-- Light themes: High Contrast, Wildflowers, Maritime, Tropical, Golden Hour, Summit Blaze.
-- Ocean now uses a deeper dark-blue background.
-- Forest now uses a dark-brown background.
-- Wildflowers has a brighter poppy/cornflower-inspired palette.
-- Maritime is light with a warmer beach/shabby-chic coastal palette.
-- Stellar Forge is dark with stronger Star-Wars-like yellow and heavier display typography.
+## Implementation Details
+- Added a Cosmos-backed message feed state store:
+  - `AthleteMessageFeedStateDocument`
+  - `IAthleteMessageFeedStateStore`
+  - `CosmosAthleteMessageFeedStateStore`
+- Persisted user state stores stable generated message IDs with read/deleted flags and timestamps.
+- The feed still rebuilds current messages from `IAthleteMessageProvider` implementations; persisted state is applied afterward.
+- Deleted messages are filtered out when the feed is rendered.
+- Opening the feed marks currently visible unread messages as read and persists that state.
+- Deleting a message marks it read and deleted, removes it from the current feed immediately, and persists the change.
 
-## Main Areas Changed
-- Theme catalog and palettes: `PaceLetics.Web/Services/Theming/AppThemeCatalog.cs`
-- Theme metadata: `PaceLetics.Web/Services/Theming/AppThemeDefinition.cs`
-- Theme enum cleanup: `PaceLetics.Web/Services/Theming/AppThemeName.cs`
-- Theme preference behavior: `PaceLetics.Web/Services/Theming/ThemePreferenceService.cs`
-- App bar theme menu: `PaceLetics.Web/Shared/MainLayout.razor`
-- Removed color-scheme enum: `PaceLetics.Web/Services/Theming/AppColorScheme.cs`
-- Removed obsolete translated theme and scheme labels from `PaceLetics.Web/Resources/Shared/MainLayout*.resx`
+## UI Changes
+- The feed panel is now fixed-positioned and horizontally centered in the viewport.
+- The feed width remains responsive via `min(390px, calc(100vw - 24px))`.
+- Feed tiles now separate the navigation link area from the delete icon, preventing delete clicks from triggering navigation.
+- Read messages render with normal emphasis; unread messages retain stronger tile emphasis.
+
+## Configuration
+- Registered `IAthleteMessageFeedStateStore` in DI.
+- Fixed `AthleteDataOptions` binding so `CourseContainerName` is read from configuration instead of always falling back to the default.
 
 ## Verification
-- `dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --filter AppThemeCatalogTests` succeeded.
-- Search confirmed no remaining `AppColorScheme`, `ColorScheme`, `Scheme_*`, `ElderVale`, or localized `Theme_*` references in `PaceLetics.Web` and `PaceLetics.Tests`.
+- `dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore` succeeded.
+- Added unit coverage for default unread state, feed state document IDs, read state, and delete state.
+- Browser verification on `http://localhost:5117` confirmed:
+  - The feed overlay is centered (`centerDelta = 0`).
+  - The overlay is not clipped left or right.
+  - Delete buttons render for feed messages.
+  - Opening the feed marks messages as read.
+  - Deleting a message removes it immediately and the deletion remains after reload.
 
 ## Notes
-- Existing NuGet vulnerability warnings for `OpenMcdf` and `SharpCompress` still appear during test restore/build and are unrelated to this change.
-- Existing analyzer/nullability warnings in component projects remain unrelated to this change.
+- Existing NuGet vulnerability warnings for `OpenMcdf` and `SharpCompress` still appear during test/build and are unrelated to this change.
+- Existing component analyzer/nullability warnings remain unrelated to this change.

--- a/PaceLetics.CoreModule.Infrastructure/Models/AthleteMessage.cs
+++ b/PaceLetics.CoreModule.Infrastructure/Models/AthleteMessage.cs
@@ -11,5 +11,9 @@ public sealed record AthleteMessage(
     string? ActionHref,
     string? ActionLabelKey,
     int Priority,
-    IReadOnlyList<object> BodyArguments);
+    IReadOnlyList<object> BodyArguments,
+    bool IsRead = false)
+{
+    public bool IsUnread => !IsRead;
+}
 

--- a/PaceLetics.Tests/DashboardMessageFeedStateTests.cs
+++ b/PaceLetics.Tests/DashboardMessageFeedStateTests.cs
@@ -1,0 +1,71 @@
+using MudBlazor;
+using PaceLetics.CoreModule.Infrastructure.Models;
+using PaceLetics.Web.Services.DashboardMessages;
+
+namespace PaceLetics.Tests;
+
+public sealed class DashboardMessageFeedStateTests
+{
+    [Fact]
+    public void AthleteMessage_DefaultsToUnread()
+    {
+        var message = CreateMessage("message-1");
+
+        Assert.False(message.IsRead);
+        Assert.True(message.IsUnread);
+    }
+
+    [Fact]
+    public void Create_UsesStableDocumentIdAndPartition()
+    {
+        var state = AthleteMessageFeedStateDocument.Create("athlete-1");
+
+        Assert.Equal("athlete-message-feed:athlete-1", state.Id);
+        Assert.Equal("athlete-message-feed:athlete-1", state.CourseId);
+        Assert.Equal("athlete-1", state.AthleteUserId);
+        Assert.Equal(AthleteMessageFeedDocumentTypes.State, state.DocumentType);
+    }
+
+    [Fact]
+    public void MarkRead_MarksSelectedMessagesAsRead()
+    {
+        var state = AthleteMessageFeedStateDocument.Create("athlete-1");
+        var readAt = new DateTime(2026, 6, 5, 8, 30, 0, DateTimeKind.Utc);
+
+        state.MarkRead(new[] { "message-1", "message-2" }, readAt);
+
+        Assert.True(state.IsRead("message-1"));
+        Assert.True(state.IsRead("message-2"));
+        Assert.False(state.IsRead("message-3"));
+        Assert.False(state.IsDeleted("message-1"));
+    }
+
+    [Fact]
+    public void Delete_MarksMessageAsReadAndDeleted()
+    {
+        var state = AthleteMessageFeedStateDocument.Create("athlete-1");
+        var deletedAt = new DateTime(2026, 6, 5, 9, 0, 0, DateTimeKind.Utc);
+
+        state.Delete("message-1", deletedAt);
+
+        Assert.True(state.IsRead("message-1"));
+        Assert.True(state.IsDeleted("message-1"));
+        Assert.Equal(deletedAt, state.Messages.Single().ReadAt);
+        Assert.Equal(deletedAt, state.Messages.Single().DeletedAt);
+    }
+
+    private static AthleteMessage CreateMessage(string id)
+    {
+        return new AthleteMessage(
+            id,
+            "Test",
+            Severity.Info,
+            "Title",
+            "Body",
+            Icons.Material.Filled.Info,
+            null,
+            null,
+            10,
+            Array.Empty<object>());
+    }
+}

--- a/PaceLetics.Web/Configuration/ConfigurationExtensions.cs
+++ b/PaceLetics.Web/Configuration/ConfigurationExtensions.cs
@@ -17,7 +17,8 @@ public static class PaceLeticsConfiguration
         var options = new AthleteDataOptions
         {
             DatabaseName = section[nameof(AthleteDataOptions.DatabaseName)] ?? defaults.DatabaseName,
-            AthleteContainerName = section[nameof(AthleteDataOptions.AthleteContainerName)] ?? defaults.AthleteContainerName
+            AthleteContainerName = section[nameof(AthleteDataOptions.AthleteContainerName)] ?? defaults.AthleteContainerName,
+            CourseContainerName = section[nameof(AthleteDataOptions.CourseContainerName)] ?? defaults.CourseContainerName
         };
 
         options.Validate();

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -124,6 +124,7 @@ builder.Services.AddSingleton<DashboardMessageFeedOptions>();
 builder.Services.AddScoped<IAthleteMessageProvider, ReferenceRunDashboardMessageProvider>();
 builder.Services.AddScoped<IAthleteMessageProvider, UpcomingTrainingDashboardMessageProvider>();
 builder.Services.AddScoped<IAthleteMessageFeedService, AthleteMessageFeedService>();
+builder.Services.AddScoped<IAthleteMessageFeedStateStore, CosmosAthleteMessageFeedStateStore>();
 
 
 //builder.Services.AddMudServices();

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ar.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ar.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; موجود في خطة تدريبك غدًا.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; موجود في خطة تدريبك بتاريخ {1:d}.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>فتح خطة التدريب</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>حذف الرسالة</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>معلومة</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>حسنًا</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>مهم</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.da.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.da.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; er på din træningsplan i morgen.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; er på din træningsplan den {1:d}.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Åbn træningsplan</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Slet besked</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>Ok</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Vigtigt</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.de.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.de.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>Morgen steht "{0}" auf deinem Trainingsplan.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>Am {1:d} steht "{0}" auf deinem Trainingsplan.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Trainingsplan öffnen</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Nachricht loeschen</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>Ok</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Wichtig</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.en.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.en.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>"{0}" is on your training plan tomorrow.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>"{0}" is on your training plan on {1:d}.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Open training plan</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Delete message</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>Ok</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Important</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.es.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.es.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; está en tu plan de entrenamiento de mañana.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; está en tu plan de entrenamiento el {1:d}.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Abrir plan de entrenamiento</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Eliminar mensaje</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>Aceptar</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Importante</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fa.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fa.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; فردا در برنامه تمرینی شماست.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; در تاریخ {1:d} در برنامه تمرینی شماست.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>باز کردن برنامه تمرینی</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>حذف پیام</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>اطلاعات</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>باشه</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>مهم</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fr.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.fr.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; est prévu dans votre plan d’entraînement demain.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; est prévu dans votre plan d’entraînement le {1:d}.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Ouvrir le plan d’entraînement</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Supprimer le message</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>OK</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Important</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>"{0}" is on your training plan tomorrow.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>"{0}" is on your training plan on {1:d}.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Open training plan</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Delete message</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Info</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>Ok</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Important</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ru.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.ru.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; завтра в вашем плане тренировок.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; в вашем плане тренировок на {1:d}.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Открыть план тренировок</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Удалить сообщение</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Инфо</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>ОК</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Важно</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.tr.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.tr.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>&quot;{0}&quot; yarın antrenman planında.</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>&quot;{0}&quot; {1:d} tarihinde antrenman planında.</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>Antrenman planını aç</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>Mesaji sil</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>Bilgi</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>Tamam</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>Önemli</value></data>

--- a/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.zh.resx
+++ b/PaceLetics.Web/Resources/Shared/DashboardMessageFeed.zh.resx
@@ -17,6 +17,7 @@
   <data name="UpcomingTrainingTomorrow_Body" xml:space="preserve"><value>“{0}” 明天在你的训练计划中。</value></data>
   <data name="UpcomingTraining_Body" xml:space="preserve"><value>“{0}” 安排在 {1:d} 的训练计划中。</value></data>
   <data name="UpcomingTraining_Action" xml:space="preserve"><value>打开训练计划</value></data>
+  <data name="DeleteMessage" xml:space="preserve"><value>删除消息</value></data>
   <data name="Severity_Info" xml:space="preserve"><value>信息</value></data>
   <data name="Severity_Success" xml:space="preserve"><value>确定</value></data>
   <data name="Severity_Warning" xml:space="preserve"><value>重要</value></data>

--- a/PaceLetics.Web/Services/DashboardMessages/AthleteMessageFeedStateDocument.cs
+++ b/PaceLetics.Web/Services/DashboardMessages/AthleteMessageFeedStateDocument.cs
@@ -1,0 +1,129 @@
+using PaceLetics.CoreModule.Infrastructure.Interfaces;
+
+namespace PaceLetics.Web.Services.DashboardMessages;
+
+public static class AthleteMessageFeedDocumentTypes
+{
+    public const string State = "athleteMessageFeedState";
+}
+
+public sealed class AthleteMessageFeedStateDocument : IQueryItem
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string CourseId { get; set; } = string.Empty;
+
+    public string DocumentType { get; set; } = AthleteMessageFeedDocumentTypes.State;
+
+    public string AthleteUserId { get; set; } = string.Empty;
+
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public List<AthleteMessageStateEntry> Messages { get; set; } = new();
+
+    public static AthleteMessageFeedStateDocument Create(string athleteUserId)
+    {
+        return new AthleteMessageFeedStateDocument
+        {
+            Id = AthleteMessageFeedStateIds.Document(athleteUserId),
+            CourseId = AthleteMessageFeedStateIds.Partition(athleteUserId),
+            AthleteUserId = athleteUserId
+        };
+    }
+
+    public bool IsRead(string messageId)
+    {
+        return Find(messageId)?.IsRead == true;
+    }
+
+    public bool IsDeleted(string messageId)
+    {
+        return Find(messageId)?.IsDeleted == true;
+    }
+
+    public void MarkRead(IEnumerable<string> messageIds, DateTime readAt)
+    {
+        foreach (var messageId in messageIds.Where(id => !string.IsNullOrWhiteSpace(id)).Distinct(StringComparer.Ordinal))
+        {
+            var entry = GetOrCreate(messageId);
+            if (entry.IsRead)
+                continue;
+
+            entry.IsRead = true;
+            entry.ReadAt = readAt;
+        }
+
+        UpdatedAt = readAt;
+    }
+
+    public void Delete(string messageId, DateTime deletedAt)
+    {
+        if (string.IsNullOrWhiteSpace(messageId))
+            return;
+
+        var entry = GetOrCreate(messageId);
+        entry.IsRead = true;
+        entry.ReadAt ??= deletedAt;
+        entry.IsDeleted = true;
+        entry.DeletedAt = deletedAt;
+        UpdatedAt = deletedAt;
+    }
+
+    public void Normalize()
+    {
+        if (string.IsNullOrWhiteSpace(AthleteUserId))
+            return;
+
+        Id = AthleteMessageFeedStateIds.Document(AthleteUserId);
+        CourseId = AthleteMessageFeedStateIds.Partition(AthleteUserId);
+        DocumentType = AthleteMessageFeedDocumentTypes.State;
+
+        Messages = Messages
+            .Where(message => !string.IsNullOrWhiteSpace(message.MessageId))
+            .GroupBy(message => message.MessageId, StringComparer.Ordinal)
+            .Select(group => group.Last())
+            .ToList();
+    }
+
+    private AthleteMessageStateEntry? Find(string messageId)
+    {
+        return Messages.FirstOrDefault(message => message.MessageId == messageId);
+    }
+
+    private AthleteMessageStateEntry GetOrCreate(string messageId)
+    {
+        var entry = Find(messageId);
+        if (entry is not null)
+            return entry;
+
+        entry = new AthleteMessageStateEntry { MessageId = messageId };
+        Messages.Add(entry);
+        return entry;
+    }
+}
+
+public sealed class AthleteMessageStateEntry
+{
+    public string MessageId { get; set; } = string.Empty;
+
+    public bool IsRead { get; set; }
+
+    public DateTime? ReadAt { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public DateTime? DeletedAt { get; set; }
+}
+
+public static class AthleteMessageFeedStateIds
+{
+    public static string Document(string athleteUserId)
+    {
+        return $"athlete-message-feed:{athleteUserId}";
+    }
+
+    public static string Partition(string athleteUserId)
+    {
+        return $"athlete-message-feed:{athleteUserId}";
+    }
+}

--- a/PaceLetics.Web/Services/DashboardMessages/CosmosAthleteMessageFeedStateStore.cs
+++ b/PaceLetics.Web/Services/DashboardMessages/CosmosAthleteMessageFeedStateStore.cs
@@ -1,0 +1,48 @@
+using AthleteDataAccessLibrary;
+using AthleteDataAccessLibrary.Contracts;
+
+namespace PaceLetics.Web.Services.DashboardMessages;
+
+public sealed class CosmosAthleteMessageFeedStateStore : IAthleteMessageFeedStateStore
+{
+    private readonly IDataAccess _db;
+    private readonly AthleteDataOptions _options;
+
+    public CosmosAthleteMessageFeedStateStore(IDataAccess db, AthleteDataOptions options)
+    {
+        _db = db;
+        _options = options;
+        _options.Validate();
+    }
+
+    public async Task<AthleteMessageFeedStateDocument> GetAsync(string athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return AthleteMessageFeedStateDocument.Create(string.Empty);
+
+        var state = await _db.LoadItem<AthleteMessageFeedStateDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            AthleteMessageFeedStateIds.Document(athleteUserId),
+            AthleteMessageFeedStateIds.Partition(athleteUserId));
+
+        state ??= AthleteMessageFeedStateDocument.Create(athleteUserId);
+        state.AthleteUserId = athleteUserId;
+        state.Normalize();
+
+        return state;
+    }
+
+    public Task SaveAsync(AthleteMessageFeedStateDocument state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        state.Normalize();
+        state.UpdatedAt = DateTime.UtcNow;
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            state,
+            state.CourseId);
+    }
+}

--- a/PaceLetics.Web/Services/DashboardMessages/IAthleteMessageFeedStateStore.cs
+++ b/PaceLetics.Web/Services/DashboardMessages/IAthleteMessageFeedStateStore.cs
@@ -1,0 +1,8 @@
+namespace PaceLetics.Web.Services.DashboardMessages;
+
+public interface IAthleteMessageFeedStateStore
+{
+    Task<AthleteMessageFeedStateDocument> GetAsync(string athleteUserId);
+
+    Task SaveAsync(AthleteMessageFeedStateDocument state);
+}

--- a/PaceLetics.Web/Shared/AthleteMessageFeedButton.razor
+++ b/PaceLetics.Web/Shared/AthleteMessageFeedButton.razor
@@ -1,53 +1,53 @@
-@using System.Text.Json
 @using AthleteDataAccessLibrary.Contracts
 @using PaceLetics.AthleteModule.CodeBase.Models
 @using PaceLetics.CoreModule.Infrastructure.Models
 @using PaceLetics.CoreModule.Infrastructure.Services
+@using PaceLetics.Web.Services.DashboardMessages
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IAthleteData AthleteData
 @inject IAthleteMessageFeedService AthleteMessageFeedService
-@inject IJSRuntime JS
+@inject IAthleteMessageFeedStateStore MessageFeedStateStore
 @inject IStringLocalizer<DashboardMessageFeed> L
 
 @if (_isAuthenticated)
 {
-    <MudMenu AnchorOrigin="Origin.BottomRight"
-             TransformOrigin="Origin.TopRight"
-             PopoverClass="pl-message-popover"
-             ListClass="pa-0"
-             OpenChanged="HandleMenuOpenChanged">
-        <ActivatorContent>
-            <MudBadge Content="@_unreadCount"
-                      Visible="@ShowUnreadBadge"
-                      Color="Color.Warning"
-                      Overlap="true"
-                      Class="pl-message-badge">
-                <MudTooltip Text="@L["FeedTitle"]">
-                    <MudIconButton Icon="@Icons.Material.Filled.Alarm"
-                                   Color="@MessageButtonColor"
-                                   Class="@MessageButtonClass"
-                                   OnClick="@context.ToggleAsync"
-                                   aria-label="@L["FeedTitle"]" />
-                </MudTooltip>
-            </MudBadge>
-        </ActivatorContent>
-        <ChildContent>
-            <div class="pl-message-menu-panel" @onclick:stopPropagation="true">
-                <DashboardMessageFeed Messages="_messages" Framed="false" />
-            </div>
-        </ChildContent>
-    </MudMenu>
+    <MudBadge Content="@_unreadCount"
+              Visible="@ShowUnreadBadge"
+              Color="Color.Warning"
+              Overlap="true"
+              Class="pl-message-badge">
+        <MudTooltip Text="@L["FeedTitle"]">
+            <MudIconButton Icon="@Icons.Material.Filled.Alarm"
+                           Color="@MessageButtonColor"
+                           Class="@MessageButtonClass"
+                           OnClick="ToggleFeedAsync"
+                           aria-label="@L["FeedTitle"]" />
+        </MudTooltip>
+    </MudBadge>
+
+    @if (_isOpen)
+    {
+        <div class="pl-message-overlay-backdrop" @onclick="CloseFeed"></div>
+        <div class="pl-message-menu-panel" @onclick:stopPropagation="true">
+            <DashboardMessageFeed Messages="_messages"
+                                  Framed="false"
+                                  AllowDelete="true"
+                                  OnDelete="DeleteMessageAsync" />
+        </div>
+    }
 }
 
 @code {
     private IReadOnlyList<AthleteMessage> _messages = Array.Empty<AthleteMessage>();
-    private HashSet<string> _readMessageIds = new(StringComparer.Ordinal);
+    private AthleteMessageFeedStateDocument _messageState = AthleteMessageFeedStateDocument.Create(string.Empty);
     private bool _isAuthenticated;
-    private bool _readStateLoaded;
+    private bool _isOpen;
+    private bool _stateLoaded;
+    private bool _statePersistenceAvailable = true;
     private int _unreadCount;
-    private string? _storageKey;
+    private string? _stateUserId;
 
-    private bool ShowUnreadBadge => _readStateLoaded && _unreadCount > 0;
+    private bool ShowUnreadBadge => _stateLoaded && _unreadCount > 0;
 
     private Color MessageButtonColor => ShowUnreadBadge ? Color.Warning : Color.Inherit;
 
@@ -67,7 +67,7 @@
             ? userId
             : user.Identity?.Name ?? "current";
 
-        _storageKey = $"paceletics.messageFeed.read.{storageUserId}";
+        _stateUserId = storageUserId;
 
         AthleteModel? athlete = null;
         try
@@ -92,44 +92,42 @@
             athlete?.ActiveReferenceResult,
             athlete?.SelectedTrainingPlanId,
             DateTime.Today));
-    }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (!firstRender || !_isAuthenticated)
-            return;
-
-        await LoadReadStateAsync();
+        await LoadMessageStateAsync();
+        _messages = ApplyMessageState(_messages);
         RefreshUnreadCount();
-        _readStateLoaded = true;
-        StateHasChanged();
+        _stateLoaded = true;
     }
 
-    private async Task HandleMenuOpenChanged(bool open)
+    private async Task ToggleFeedAsync()
     {
-        if (!open)
+        _isOpen = !_isOpen;
+
+        if (!_isOpen)
             return;
 
         await MarkCurrentMessagesReadAsync();
     }
 
-    private async Task LoadReadStateAsync()
+    private void CloseFeed()
     {
-        if (string.IsNullOrWhiteSpace(_storageKey))
+        _isOpen = false;
+    }
+
+    private async Task LoadMessageStateAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_stateUserId))
             return;
 
         try
         {
-            var json = await JS.InvokeAsync<string?>("localStorage.getItem", _storageKey);
-            var ids = string.IsNullOrWhiteSpace(json)
-                ? Array.Empty<string>()
-                : JsonSerializer.Deserialize<string[]>(json) ?? Array.Empty<string>();
-
-            _readMessageIds = new HashSet<string>(ids, StringComparer.Ordinal);
+            _messageState = await MessageFeedStateStore.GetAsync(_stateUserId);
+            _statePersistenceAvailable = true;
         }
         catch
         {
-            _readMessageIds = new HashSet<string>(StringComparer.Ordinal);
+            _messageState = AthleteMessageFeedStateDocument.Create(_stateUserId);
+            _statePersistenceAvailable = false;
         }
     }
 
@@ -138,33 +136,60 @@
         if (_messages.Count == 0)
             return;
 
-        foreach (var message in _messages)
-        {
-            _readMessageIds.Add(message.Id);
-        }
+        var unreadIds = _messages
+            .Where(message => message.IsUnread)
+            .Select(message => message.Id)
+            .ToArray();
+
+        if (unreadIds.Length == 0)
+            return;
+
+        _messageState.MarkRead(unreadIds, DateTime.UtcNow);
+        var unreadIdSet = unreadIds.ToHashSet(StringComparer.Ordinal);
+        _messages = _messages
+            .Select(message => unreadIdSet.Contains(message.Id) ? message with { IsRead = true } : message)
+            .ToList();
 
         RefreshUnreadCount();
-        await PersistReadStateAsync();
+        await PersistMessageStateAsync();
     }
 
-    private async Task PersistReadStateAsync()
+    private async Task DeleteMessageAsync(AthleteMessage message)
     {
-        if (string.IsNullOrWhiteSpace(_storageKey))
+        _messageState.Delete(message.Id, DateTime.UtcNow);
+        _messages = _messages
+            .Where(current => current.Id != message.Id)
+            .ToList();
+
+        RefreshUnreadCount();
+        await PersistMessageStateAsync();
+    }
+
+    private async Task PersistMessageStateAsync()
+    {
+        if (!_statePersistenceAvailable)
             return;
 
         try
         {
-            var json = JsonSerializer.Serialize(_readMessageIds.OrderBy(id => id));
-            await JS.InvokeVoidAsync("localStorage.setItem", _storageKey, json);
+            await MessageFeedStateStore.SaveAsync(_messageState);
         }
         catch
         {
-            // localStorage is a convenience for highlighting only.
+            _statePersistenceAvailable = false;
         }
     }
 
     private void RefreshUnreadCount()
     {
-        _unreadCount = _messages.Count(message => !_readMessageIds.Contains(message.Id));
+        _unreadCount = _messages.Count(message => message.IsUnread);
+    }
+
+    private IReadOnlyList<AthleteMessage> ApplyMessageState(IReadOnlyList<AthleteMessage> messages)
+    {
+        return messages
+            .Where(message => !_messageState.IsDeleted(message.Id))
+            .Select(message => message with { IsRead = _messageState.IsRead(message.Id) })
+            .ToList();
     }
 }

--- a/PaceLetics.Web/Shared/DashboardMessageFeed.razor
+++ b/PaceLetics.Web/Shared/DashboardMessageFeed.razor
@@ -21,6 +21,12 @@ else
     [Parameter]
     public bool Framed { get; set; } = true;
 
+    [Parameter]
+    public bool AllowDelete { get; set; }
+
+    [Parameter]
+    public EventCallback<AthleteMessage> OnDelete { get; set; }
+
     private RenderFragment FeedContent => @<MudStack Spacing="3">
         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Style="min-width:0;">
@@ -54,7 +60,11 @@ else
                                            Detail="@L[message.BodyKey, message.BodyArguments.ToArray()]"
                                            Icon="@message.Icon"
                                            Severity="@message.Severity"
-                                           Href="@message.ActionHref" />
+                                           Href="@message.ActionHref"
+                                           IsRead="@message.IsRead"
+                                           ShowDelete="@(AllowDelete && OnDelete.HasDelegate)"
+                                           DeleteLabel="@L["DeleteMessage"]"
+                                           OnDelete="@(() => OnDelete.InvokeAsync(message))" />
                 }
             </MudStack>
         }

--- a/PaceLetics.Web/Shared/DashboardNewsFeedTile.razor
+++ b/PaceLetics.Web/Shared/DashboardNewsFeedTile.razor
@@ -1,50 +1,65 @@
-﻿@if (!string.IsNullOrWhiteSpace(Href))
-{
-    <MudLink Href="@Href" Underline="Underline.None">
-        @TileContent
-    </MudLink>
-}
-else
-{
-    @TileContent
-}
+@TileContent
 
 @code {
     private RenderFragment TileContent => @<MudPaper Elevation="0"
-                                                     Class="@TileClass">
-        <MudStack Row="true"
-                  AlignItems="AlignItems.Center"
-                  Spacing="2"
-                  Class="pa-3">
-
-            <MudAvatar Color="@Color"
-                       Variant="Variant.Filled"
-                       Size="Size.Medium"
-                       Class="pl-feed-tile-icon">
-                <MudIcon Icon="@Icon" Size="Size.Small" />
-            </MudAvatar>
-
-            <MudStack Spacing="0" Style="flex:1; min-width:0;">
-                <MudText Typo="Typo.body2">
-                    @Title
-                </MudText>
-
-                @if (!string.IsNullOrWhiteSpace(Detail))
-                {
-                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                        @Detail
-                    </MudText>
-                }
-            </MudStack>
-
+                                                      Class="@TileClass">
+        <div class="pl-feed-tile-layout">
             @if (!string.IsNullOrWhiteSpace(Href))
             {
-                <MudIcon Icon="@Icons.Material.Filled.ArrowForward"
-                         Size="Size.Small"
-                         Color="Color.Secondary" />
+                <MudLink Href="@Href"
+                         Underline="Underline.None"
+                         Class="pl-feed-tile-main">
+                    @MainContent
+
+                    <MudIcon Icon="@Icons.Material.Filled.ArrowForward"
+                             Size="Size.Small"
+                             Color="Color.Secondary" />
+                </MudLink>
+            }
+            else
+            {
+                <div class="pl-feed-tile-main">
+                    @MainContent
+                </div>
+            }
+
+            @if (ShowDelete)
+            {
+                <span class="pl-feed-tile-actions" @onclick:stopPropagation="true">
+                    <MudTooltip Text="@DeleteLabel">
+                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                       Size="Size.Small"
+                                       Color="Color.Secondary"
+                                       Class="pl-feed-tile-delete"
+                                       OnClick="HandleDeleteAsync"
+                                       aria-label="@DeleteLabel" />
+                    </MudTooltip>
+                </span>
+            }
+        </div>
+    </MudPaper>;
+
+    private RenderFragment MainContent => @<text>
+        <MudAvatar Color="@Color"
+                   Variant="Variant.Filled"
+                   Size="Size.Medium"
+                   Class="pl-feed-tile-icon">
+            <MudIcon Icon="@Icon" Size="Size.Small" />
+        </MudAvatar>
+
+        <MudStack Spacing="0" Style="flex:1; min-width:0;">
+            <MudText Typo="Typo.body2" Class="pl-feed-tile-title">
+                @Title
+            </MudText>
+
+            @if (!string.IsNullOrWhiteSpace(Detail))
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    @Detail
+                </MudText>
             }
         </MudStack>
-    </MudPaper>;
+    </text>;
 
     [Parameter, EditorRequired]
     public string Title { get; set; } = string.Empty;
@@ -61,6 +76,23 @@ else
     [Parameter]
     public string? Href { get; set; }
 
+    [Parameter]
+    public bool IsRead { get; set; }
+
+    [Parameter]
+    public bool ShowDelete { get; set; }
+
+    [Parameter]
+    public string DeleteLabel { get; set; } = "Delete message";
+
+    [Parameter]
+    public EventCallback OnDelete { get; set; }
+
+    private Task HandleDeleteAsync()
+    {
+        return OnDelete.InvokeAsync();
+    }
+
     private Color Color => Severity switch
     {
         Severity.Success => Color.Success,
@@ -72,10 +104,12 @@ else
 
     private string TileClass => Severity switch
     {
-        Severity.Success => "pl-feed-tile pl-feed-tile-success",
-        Severity.Warning => "pl-feed-tile pl-feed-tile-warning",
-        Severity.Error => "pl-feed-tile pl-feed-tile-error",
-        Severity.Info => "pl-feed-tile pl-feed-tile-info",
-        _ => "pl-feed-tile"
+        Severity.Success => $"pl-feed-tile pl-feed-tile-success {ReadStateClass}",
+        Severity.Warning => $"pl-feed-tile pl-feed-tile-warning {ReadStateClass}",
+        Severity.Error => $"pl-feed-tile pl-feed-tile-error {ReadStateClass}",
+        Severity.Info => $"pl-feed-tile pl-feed-tile-info {ReadStateClass}",
+        _ => $"pl-feed-tile {ReadStateClass}"
     };
+
+    private string ReadStateClass => IsRead ? "pl-feed-tile-read" : "pl-feed-tile-unread";
 }

--- a/PaceLetics.Web/wwwroot/css/app-theme.css
+++ b/PaceLetics.Web/wwwroot/css/app-theme.css
@@ -169,11 +169,26 @@
     color: var(--pl-metric-accent, var(--mud-palette-primary));
 }
 
+.pl-message-overlay-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1298;
+    background: transparent;
+}
+
 .pl-message-menu-panel {
+    position: fixed;
+    top: 72px;
+    left: 50%;
+    z-index: 1299;
+    transform: translateX(-50%);
     width: min(390px, calc(100vw - 24px));
     max-height: min(640px, calc(100vh - 88px));
     overflow: auto;
     border-radius: var(--pl-radius);
+    border: 1px solid var(--mud-palette-lines-default);
+    background: var(--mud-palette-surface);
+    box-shadow: var(--mud-elevation-8);
 }
 
 .pl-message-button-unread {
@@ -206,6 +221,52 @@
     border: 1px solid color-mix(in srgb, var(--pl-feed-accent) 28%, var(--mud-palette-lines-default));
     border-radius: var(--pl-radius);
     background: color-mix(in srgb, var(--pl-feed-accent) 7%, var(--mud-palette-surface));
+}
+
+.pl-feed-tile-layout {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 12px;
+}
+
+.pl-feed-tile-main {
+    display: grid;
+    grid-template-columns: 42px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+    color: inherit;
+    text-decoration: none;
+}
+
+.pl-feed-tile-main:hover {
+    color: inherit;
+    text-decoration: none;
+}
+
+.pl-feed-tile-actions {
+    display: inline-flex;
+    flex: 0 0 auto;
+}
+
+.pl-feed-tile-delete {
+    opacity: .72;
+}
+
+.pl-feed-tile-delete:hover,
+.pl-feed-tile-delete:focus-visible {
+    opacity: 1;
+}
+
+.pl-feed-tile-unread {
+    border-color: color-mix(in srgb, var(--pl-feed-accent) 44%, var(--mud-palette-lines-default));
+    background: color-mix(in srgb, var(--pl-feed-accent) 12%, var(--mud-palette-surface));
+}
+
+.pl-feed-tile-unread .pl-feed-tile-title {
+    font-weight: 600;
 }
 
 .pl-feed-tile-info {


### PR DESCRIPTION
Summary
Reworked the athlete message feed so read and deleted message state is persisted server-side per user.
Added IsRead / IsUnread state to AthleteMessage, while keeping message generation provider-driven.
Replaced the right-anchored MudMenu feed with a viewport-centered overlay to prevent the panel from being clipped on the right side.
Added a delete action to each feed message, with localized tooltip/ARIA labels.
Updated the feed badge and warning button state so only unread messages ask for user attention.
Implementation Details
Added a Cosmos-backed message feed state store:
AthleteMessageFeedStateDocument
IAthleteMessageFeedStateStore
CosmosAthleteMessageFeedStateStore
Persisted user state stores stable generated message IDs with read/deleted flags and timestamps.
The feed still rebuilds current messages from IAthleteMessageProvider implementations; persisted state is applied afterward.
Deleted messages are filtered out when the feed is rendered.
Opening the feed marks currently visible unread messages as read and persists that state.
Deleting a message marks it read and deleted, removes it from the current feed immediately, and persists the change.
UI Changes
The feed panel is now fixed-positioned and horizontally centered in the viewport.
The feed width remains responsive via min(390px, calc(100vw - 24px)).
Feed tiles now separate the navigation link area from the delete icon, preventing delete clicks from triggering navigation.
Read messages render with normal emphasis; unread messages retain stronger tile emphasis.
Configuration
Registered IAthleteMessageFeedStateStore in DI.
Fixed AthleteDataOptions binding so CourseContainerName is read from configuration instead of always falling back to the default.
Verification
dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore succeeded.
Added unit coverage for default unread state, feed state document IDs, read state, and delete state.
Browser verification on http://localhost:5117 confirmed:
The feed overlay is centered (centerDelta = 0).
The overlay is not clipped left or right.
Delete buttons render for feed messages.
Opening the feed marks messages as read.
Deleting a message removes it immediately and the deletion remains after reload.
Notes
Existing NuGet vulnerability warnings for OpenMcdf and SharpCompress still appear during test/build and are unrelated to this change.
Existing component analyzer/nullability warnings remain unrelated to this change.