### PR TITLE
Add theme-aware loading state service

### DIFF
--- a/PR_REPORT.md
+++ b/PR_REPORT.md
@@ -1,63 +1,53 @@
-# PR Report: Theme-Aware Pace and Race Color Codes
+# PR Report: Theme-Aware Loading State Service
 
 ## Summary
-- Replaced pace-zone PNG icons with theme-aware color-coded markers.
-- Added a dedicated seven-step pace-zone palette for every app theme.
-- Extended the pace zones page to display `Free`, `Recovery`, `E`, `M`, `T`, `I`, and `R`.
-- Reused the same colored pace markers in the training plan detail view.
-- Replaced race distance PNG icons with compact color-coded race labels.
-- Removed obsolete pace and race PNG assets from the web project.
+- Replaced the improvised text-based loading bar with a dedicated MudBlazor loading indicator.
+- Added a scoped loading state service for page and operation loading states.
+- Added a global loading host to the main layout so pages can report loading work centrally.
+- Migrated existing page-level loading flags to the new service.
+- Kept loader styling consistent with the existing app theme tokens.
 
 ## Implementation Details
-- Added `PaceZonePalette` to theme definitions so every `AppThemeDefinition` carries colors for:
-  - `Free`
-  - `Recovery`
-  - `Easy`
-  - `Marathon`
-  - `Threshold`
-  - `Intervall`
-  - `Repetition`
-- Exposed the active theme's pace-zone palette as CSS variables from `MainLayout`.
-- Updated shared app CSS with reusable zone classes:
-  - `.pl-pace-zone-free`
-  - `.pl-pace-zone-recovery`
-  - `.pl-pace-zone-easy`
-  - `.pl-pace-zone-marathon`
-  - `.pl-pace-zone-threshold`
-  - `.pl-pace-zone-intervall`
-  - `.pl-pace-zone-repetition`
-- Reworked `PaceInfo` so it renders text-based color markers instead of image icons.
-- Added `Free` and `Recovery` entries to the pace zones page, including localized English and German text.
-- Added colored pace markers to the training plan bottom-sheet segment details by mapping segment `PaceKey` values to the same CSS zone classes.
-- Reworked `RaceCard` so race distances render as colored labels such as `1K`, `3K`, `5K`, `10K`, `15K`, `21K`, and `42K`.
-- Removed now-unused PNG references from `PaceLetics.Web.csproj`.
+- Added `LoadingStateService` with:
+  - `Show(string label)`
+  - `RunAsync(string label, Func<Task> operation)`
+  - `RunAsync<T>(string label, Func<Task<T>> operation)`
+  - nested loading scope support
+- Registered `LoadingStateService` as scoped in the web app dependency injection container.
+- Added `LoadingHost` to `MainLayout` so active loading operations render through a single global host.
+- Reworked `LoadingScreen` to render `MudProgressCircular` instead of the previous `|||||` gradient text placeholder.
+- Added theme-aware loader CSS classes in `app-theme.css` using existing MudBlazor and PaceLetics CSS variables.
+- Updated `DataGridView` to reuse `LoadingScreen` instead of rendering raw emphasized loading text.
 
-## Removed Assets
-- `epace.png`
-- `mpace.png`
-- `tpace.png`
-- `ipace.png`
-- `rpace.png`
-- `icon_1k.png`
-- `icon_3k.png`
-- `icon_5k.png`
-- `icon_10k.png`
-- `icon_15k.png`
-- `icon_21k.png`
+## Migrated Pages
+- `Dashboard`
+- `Profiles`
+- `WorkoutArea`
+- `CourseManagement`
+- `MyCourses`
+- `RacePaces`
+- `TrainingPaces`
+- `TrainingIntervalls`
+
+## ViewModel Changes
+- Removed UI loading responsibility from `WorkoutAreaViewModel`.
+- Updated the related test to assert loaded workout preview data instead of checking a UI loading flag.
+
+## Tests
+- Added unit tests for `LoadingStateService`:
+  - verifies `RunAsync` activates and clears loading state
+  - verifies nested loading scopes restore the previous label
+- Updated `WorkoutViewModelTests` for the new separation between view model data and page loading state.
 
 ## Verification
-- `dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore` passed earlier with 104 tests.
-- A later normal `dotnet test` attempt was blocked because a Visual Studio-launched `PaceLetics.Web` process held files in `bin\Debug`.
-- To avoid stopping the developer's Visual Studio server, verification was rerun with a separate output directory:
-  - `dotnet build PaceLetics.Web\PaceLetics.Web.csproj --no-restore -p:OutDir=%TEMP%\paceletics-verify-build\`
-  - Result: build succeeded.
-- Browser verification of the pace zones page confirmed:
-  - Seven pace cards render.
-  - Pace cards contain no images.
-  - Pace-zone colors are applied through the active theme CSS variables.
-- Repository search confirmed no remaining references to removed pace or race icon PNG filenames.
+- `dotnet build PaceLeticsFramework.sln` passed.
+- `dotnet test PaceLeticsFramework.sln` passed with 106 tests.
+- Browser smoke check passed at `http://127.0.0.1:5127`.
+- Login page rendered successfully with no browser console errors.
+- Protected routes redirected to login as expected.
+- Repository search confirmed no remaining `MudExGradientText`, text-bar placeholder, or web `_isLoading` usage.
 
 ## Notes
 - Existing NuGet advisory warnings for `OpenMcdf` and `SharpCompress` still appear during build/test and are unrelated to this PR.
-- Existing analyzer/nullability warnings remain unrelated to this change.
-- The PR intentionally keeps the new markers text-based and theme-driven instead of introducing replacement image assets.
+- Initial local browser navigation to `localhost` was blocked by the browser client, but `127.0.0.1` worked.
+- The Azure SQL firewall warning appeared during local app startup in role seeding and is unrelated to the loader changes.

--- a/PaceLetics.Tests/LoadingStateServiceTests.cs
+++ b/PaceLetics.Tests/LoadingStateServiceTests.cs
@@ -1,0 +1,42 @@
+using PaceLetics.Web.Services.Loading;
+
+namespace PaceLetics.Tests;
+
+public sealed class LoadingStateServiceTests
+{
+    [Fact]
+    public async Task RunAsync_ActivatesLoadingAndClearsAfterCompletion()
+    {
+        var loading = new LoadingStateService();
+        var observedLoading = false;
+        var observedLabel = string.Empty;
+
+        await loading.RunAsync("Loading workouts", () =>
+        {
+            observedLoading = loading.IsLoading;
+            observedLabel = loading.Label;
+            return Task.CompletedTask;
+        });
+
+        Assert.True(observedLoading);
+        Assert.Equal("Loading workouts", observedLabel);
+        Assert.False(loading.IsLoading);
+        Assert.Equal(string.Empty, loading.Label);
+    }
+
+    [Fact]
+    public void Show_RestoresPreviousLabelWhenNestedScopeEnds()
+    {
+        var loading = new LoadingStateService();
+
+        using var outer = loading.Show("Outer");
+        using (loading.Show("Inner"))
+        {
+            Assert.True(loading.IsLoading);
+            Assert.Equal("Inner", loading.Label);
+        }
+
+        Assert.True(loading.IsLoading);
+        Assert.Equal("Outer", loading.Label);
+    }
+}

--- a/PaceLetics.Tests/WorkoutViewModelTests.cs
+++ b/PaceLetics.Tests/WorkoutViewModelTests.cs
@@ -12,7 +12,7 @@ public sealed class WorkoutViewModelTests
 
         viewModel.Initialize();
 
-        Assert.False(viewModel.IsLoading);
+        Assert.NotEmpty(viewModel.WorkoutPreviews);
         Assert.Contains(viewModel.WorkoutPreviews, preview => preview.Name == "Stabi Handout");
     }
 

--- a/PaceLetics.Web/Pages/Athletes/Dashboard.razor
+++ b/PaceLetics.Web/Pages/Athletes/Dashboard.razor
@@ -13,6 +13,7 @@
 @inject IAthleteData AthleteData
 @inject AuthenticationStateProvider GetAuthenticationStateAsync
 @inject IStringLocalizer<Dashboard> L
+@inject LoadingStateService Loading
 @inject ITrainingPlanService TrainingPlanService
 
 <PageTitle>@L["PageTitle"]</PageTitle>
@@ -20,45 +21,38 @@
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
 
-    @if (_isLoading)
-    {
-        <LoadingScreen Label="@L["Loading"]" />
-    }
-    else
-    {
-        <PageHeader Title="@L["Title"]" Subtitle="@L["WelcomeText", _name]" />
+    <PageHeader Title="@L["Title"]" Subtitle="@L["WelcomeText", _name]" />
 
-        <MudDivider Class="my-4" />
+    <MudDivider Class="my-4" />
 
-        <MudStack Spacing="4">
+    <MudStack Spacing="4">
 
-            <MudGrid Spacing="3">
-                <MudItem xs="12" sm="6" lg="4">
-                    <DashboardMetricTile Label="@L["Metric_Vdot"]"
-                                         Value="@GetVdotValue()"
-                                         Detail="@GetReferenceDetail()"
-                                         Icon="@Icons.Material.Filled.Speed"
-                                         Accent="blue"
-                                         Href="/Athletes/trainingpaces" />
-                </MudItem>
+        <MudGrid Spacing="3">
+            <MudItem xs="12" sm="6" lg="4">
+                <DashboardMetricTile Label="@L["Metric_Vdot"]"
+                                     Value="@GetVdotValue()"
+                                     Detail="@GetReferenceDetail()"
+                                     Icon="@Icons.Material.Filled.Speed"
+                                     Accent="blue"
+                                     Href="/Athletes/trainingpaces" />
+            </MudItem>
 
-                <MudItem xs="12" sm="6" lg="4">
-                    <DashboardMetricTile Label="@L["Metric_NextSession"]"
-                                         Value="@GetNextSessionValue()"
-                                         Detail="@GetNextSessionDetail()"
-                                         Icon="@Icons.Material.Filled.EventAvailable"
-                                         Accent="green"
-                                         Href="/Athletes/trainingplanpage" />
-                </MudItem>
-            </MudGrid>
+            <MudItem xs="12" sm="6" lg="4">
+                <DashboardMetricTile Label="@L["Metric_NextSession"]"
+                                     Value="@GetNextSessionValue()"
+                                     Detail="@GetNextSessionDetail()"
+                                     Icon="@Icons.Material.Filled.EventAvailable"
+                                     Accent="green"
+                                     Href="/Athletes/trainingplanpage" />
+            </MudItem>
+        </MudGrid>
 
-            <MudGrid Spacing="3">
-                <MudItem xs="12">
-					<DashboardNextTrainingSessionTile Session="_nextSession" />
-                </MudItem>
-            </MudGrid>
-        </MudStack>
-    }
+        <MudGrid Spacing="3">
+            <MudItem xs="12">
+                <DashboardNextTrainingSessionTile Session="_nextSession" />
+            </MudItem>
+        </MudGrid>
+    </MudStack>
 
 </MudContainer>
 
@@ -67,7 +61,6 @@
 
 @code
 {
-    bool _isLoading = true;
     AthleteModel? Athlete;
     string _name = String.Empty;
     IReadOnlyList<TrainingPlan> _trainingPlans = Array.Empty<TrainingPlan>();
@@ -77,27 +70,30 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var authstate = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
-        var user = authstate.User;
-        var id = user.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
-        Athlete = string.IsNullOrWhiteSpace(id)
-            ? null
-            : await AthleteData.GetAthlete(id);
-        _name = string.IsNullOrWhiteSpace(Athlete?.Name)
-            ? user.Identity?.Name ?? string.Empty
-            : Athlete.Name;
-        try
+        await Loading.RunAsync(L["Loading"], async () =>
         {
-            _trainingPlans = await TrainingPlanService.LoadTrainingPlansForUserAsync(id);
-        }
-        catch
-        {
-            _trainingPlans = Array.Empty<TrainingPlan>();
-        }
-        _activePlan = ResolveActivePlan(_trainingPlans, Athlete);
-        _nextSession = ResolveNextSession(_activePlan, _trainingPlans);
-        _referenceResult = Athlete?.ActiveReferenceResult;
-        _isLoading = false;
+            var authstate = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
+            var user = authstate.User;
+            var id = user.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
+            Athlete = string.IsNullOrWhiteSpace(id)
+                ? null
+                : await AthleteData.GetAthlete(id);
+            _name = string.IsNullOrWhiteSpace(Athlete?.Name)
+                ? user.Identity?.Name ?? string.Empty
+                : Athlete.Name;
+            try
+            {
+                _trainingPlans = await TrainingPlanService.LoadTrainingPlansForUserAsync(id);
+            }
+            catch
+            {
+                _trainingPlans = Array.Empty<TrainingPlan>();
+            }
+            _activePlan = ResolveActivePlan(_trainingPlans, Athlete);
+            _nextSession = ResolveNextSession(_activePlan, _trainingPlans);
+            _referenceResult = Athlete?.ActiveReferenceResult;
+        });
+
         await base.OnInitializedAsync();
     }
 

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -5,32 +5,27 @@
 @inject ICourseService CourseService
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
+@inject LoadingStateService Loading
 @inject IStringLocalizer<MyCourses> L
 
 <PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
-    @if (_isLoading)
+    <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
+
+    <MudDivider Class="my-4" />
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
     {
-        <LoadingScreen Label="@L["Loading"]" />
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">@_errorMessage</MudAlert>
+    }
+
+    @if (_courses.Count == 0)
+    {
+        <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoPublishedCourses"]</MudText>
     }
     else
     {
-        <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
-
-        <MudDivider Class="my-4" />
-
-        @if (!string.IsNullOrWhiteSpace(_errorMessage))
-        {
-            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">@_errorMessage</MudAlert>
-        }
-
-        @if (_courses.Count == 0)
-        {
-            <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoPublishedCourses"]</MudText>
-        }
-        else
-        {
             var selected = SelectedOverview;
             var joinedCourses = JoinedCourses.ToList();
             var availableCourses = AvailableCourses.ToList();
@@ -290,12 +285,10 @@
                     </MudPaper>
                 }
             </MudStack>
-        }
     }
 </MudContainer>
 
 @code {
-    private bool _isLoading = true;
     private string? _userId;
     private string? _errorMessage;
     private string? _selectedCourseId;
@@ -326,55 +319,53 @@
 
     private async Task LoadCoursesAsync()
     {
-        try
+        await Loading.RunAsync(L["Loading"], async () =>
         {
-            _isLoading = true;
-            _errorMessage = null;
-            _courses = await CourseService.GetCoursesForAthleteAsync(_userId ?? string.Empty);
-            _eventsByCourse = new Dictionary<string, IReadOnlyList<CourseEventDocument>>();
-            _registeredEvents = new Dictionary<string, CourseEventRegistrationDocument>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var course in _courses.Where(course => course.IsJoined).Select(course => course.Course))
+            try
             {
-                var courseEvents = await CourseService.GetEventsAsync(course.Id);
-                _eventsByCourse[course.Id] = courseEvents;
+                _errorMessage = null;
+                _courses = await CourseService.GetCoursesForAthleteAsync(_userId ?? string.Empty);
+                _eventsByCourse = new Dictionary<string, IReadOnlyList<CourseEventDocument>>();
+                _registeredEvents = new Dictionary<string, CourseEventRegistrationDocument>(StringComparer.OrdinalIgnoreCase);
 
-                foreach (var courseEvent in courseEvents)
+                foreach (var course in _courses.Where(course => course.IsJoined).Select(course => course.Course))
                 {
-                    var registration = await CourseService.GetEventRegistrationForAthleteAsync(
-                        course.Id,
-                        courseEvent.Id,
-                        _userId ?? string.Empty);
+                    var courseEvents = await CourseService.GetEventsAsync(course.Id);
+                    _eventsByCourse[course.Id] = courseEvents;
 
-                    if (registration?.Status == CourseEventRegistrationStatus.Registered)
-                        _registeredEvents[courseEvent.Id] = registration;
+                    foreach (var courseEvent in courseEvents)
+                    {
+                        var registration = await CourseService.GetEventRegistrationForAthleteAsync(
+                            course.Id,
+                            courseEvent.Id,
+                            _userId ?? string.Empty);
+
+                        if (registration?.Status == CourseEventRegistrationStatus.Registered)
+                            _registeredEvents[courseEvent.Id] = registration;
+                    }
+                }
+
+                var joinedCourses = JoinedCourses.ToList();
+                if (joinedCourses.Count == 0)
+                {
+                    _selectedCourseId = null;
+                    ResetDetailExpansion();
+                }
+                else if (string.IsNullOrWhiteSpace(_selectedCourseId)
+                         || joinedCourses.All(course => course.Course.Id != _selectedCourseId))
+                {
+                    _selectedCourseId = joinedCourses.First().Course.Id;
+                    ResetDetailExpansion();
                 }
             }
-
-            var joinedCourses = JoinedCourses.ToList();
-            if (joinedCourses.Count == 0)
+            catch
             {
+                _errorMessage = L["LoadError"];
+                _courses = Array.Empty<CourseOverview>();
                 _selectedCourseId = null;
                 ResetDetailExpansion();
             }
-            else if (string.IsNullOrWhiteSpace(_selectedCourseId)
-                     || joinedCourses.All(course => course.Course.Id != _selectedCourseId))
-            {
-                _selectedCourseId = joinedCourses.First().Course.Id;
-                ResetDetailExpansion();
-            }
-        }
-        catch
-        {
-            _errorMessage = L["LoadError"];
-            _courses = Array.Empty<CourseOverview>();
-            _selectedCourseId = null;
-            ResetDetailExpansion();
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        });
     }
 
     private void SelectCourse(string courseId)

--- a/PaceLetics.Web/Pages/Athletes/RacePaces.razor
+++ b/PaceLetics.Web/Pages/Athletes/RacePaces.razor
@@ -14,54 +14,48 @@
 @inject IDialogService dialogService
 @inject IVdotService vdotService
 @inject IPaceModelProvider pmProvider
+@inject LoadingStateService Loading
 @inject IStringLocalizer<RacePaces> L
 
 <PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
 
-    @if (_isLoading)
-    {
-        <LoadingScreen Label="@L["Loading"]" />
-    }
-    else
-    {
-        <PageHeader Title="@L["Title"]"
-                    Subtitle="@L["Subtitle"]" />
+    <PageHeader Title="@L["Title"]"
+                Subtitle="@L["Subtitle"]" />
 
-        <MudDivider Class="my-4" />
+    <MudDivider Class="my-4" />
 
-        <MudStack Spacing="3">
+    <MudStack Spacing="3">
 
-            @if (_athlete?.ActiveReferenceResult is null)
+        @if (_athlete?.ActiveReferenceResult is null)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+                @L["NoRaceWarning"]
+            </MudAlert>
+
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Warning"
+                       StartIcon="@Icons.Material.Filled.AddCircle"
+                       OnClick="AddAthlete">
+                @L["AddRace"]
+            </MudButton>
+        }
+        else
+        {
+            <RaceCard OnEditRaceCard="@AddAthlete" Model="@_athlete.ActiveReferenceResult" />
+
+            @if ((DateTime.Now - _athlete.ActiveReferenceResult.Date).TotalDays > 180)
             {
-                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
-                    @L["NoRaceWarning"]
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                    @L["RaceOldWarning"]
                 </MudAlert>
-
-                <MudButton Variant="Variant.Filled"
-                           Color="Color.Warning"
-                           StartIcon="@Icons.Material.Filled.AddCircle"
-                           OnClick="AddAthlete">
-                    @L["AddRace"]
-                </MudButton>
-            }
-            else
-            {
-                <RaceCard OnEditRaceCard="@AddAthlete" Model="@_athlete.ActiveReferenceResult" />
-
-                @if ((DateTime.Now - _athlete.ActiveReferenceResult.Date).TotalDays > 180)
-                {
-                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
-                        @L["RaceOldWarning"]
-                    </MudAlert>
-                }
-
-                <VdotCard Data="@_vdotData" />
             }
 
-        </MudStack>
-    }
+            <VdotCard Data="@_vdotData" />
+        }
+
+    </MudStack>
 
 </MudContainer>
 

--- a/PaceLetics.Web/Pages/Athletes/RacePaces.razor.cs
+++ b/PaceLetics.Web/Pages/Athletes/RacePaces.razor.cs
@@ -10,39 +10,37 @@ namespace PaceLetics.Web.Pages.Athletes
     public partial class RacePaces
     {
         private string _input = string.Empty;
-        private bool _isLoading = true;
         private AthleteModel _athlete = new AthleteModel();
         private double[] _vdotData { get; set; } = {0, 0};
         protected override async Task OnInitializedAsync()
         {
-            try
+            await Loading.RunAsync(L["Loading"], async () =>
             {
-                var authstate = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
-                var user = authstate.User;
-                var id = user.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
-
-                if (!string.IsNullOrEmpty(id))
+                try
                 {
-                    var athlete = await AthleteData.GetAthlete(id);
-                    if (athlete is null)
-                        return;
+                    var authstate = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
+                    var user = authstate.User;
+                    var id = user.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
 
-                    _athlete = athlete;
-                    _vdotData[0] = _athlete.Vdot;
-                    _vdotData[1] = 85 - _athlete.Vdot; // TODO: Magic number
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        var athlete = await AthleteData.GetAthlete(id);
+                        if (athlete is null)
+                            return;
+
+                        _athlete = athlete;
+                        _vdotData[0] = _athlete.Vdot;
+                        _vdotData[1] = 85 - _athlete.Vdot; // TODO: Magic number
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                await dialogService.ShowInformationAsync(
-                    L["LoadError_Title"],
-                    $"{L["LoadError_Message"]}\n{ex.Message}",
-                    Icons.Material.Filled.Error);
-            }
-            finally
-            {
-                _isLoading = false;
-            }
+                catch (Exception ex)
+                {
+                    await dialogService.ShowInformationAsync(
+                        L["LoadError_Title"],
+                        $"{L["LoadError_Message"]}\n{ex.Message}",
+                        Icons.Material.Filled.Error);
+                }
+            });
         }
 
         private async Task AddAthlete()
@@ -68,15 +66,7 @@ namespace PaceLetics.Web.Pages.Athletes
             _vdotData[1] = 85 - _athlete.Vdot; // TODO: Magic number
             _athlete.PaceModel = pmProvider[_athlete.Vdot];
 
-            _isLoading = true;
-            try
-            {
-                await AthleteData.UpdateAthlete(_athlete);
-            }
-            finally
-            {
-                _isLoading = false;
-            }
+            await Loading.RunAsync(L["Loading"], () => AthleteData.UpdateAthlete(_athlete));
         }
     }
 }

--- a/PaceLetics.Web/Pages/Athletes/TrainingIntervalls.razor
+++ b/PaceLetics.Web/Pages/Athletes/TrainingIntervalls.razor
@@ -10,6 +10,7 @@
 @inject AuthenticationStateProvider GetAuthenticationStateAsync
 @inject IAthleteData AthleteData
 @inject IDialogService DialogService
+@inject LoadingStateService Loading
 @inject IStringLocalizer<TrainingIntervalls> L
 @inject ITrainingPlanService TrainingPlanService
 
@@ -17,100 +18,91 @@
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
 
-    @if (_isLoading)
-    {
-        <LoadingScreen Label="@L["Loading"]" />
-    }
-    else
-    {
-        <PageHeader Title="@L["Title"]"
-                    Subtitle="@L["Subtitle"]" />
+    <PageHeader Title="@L["Title"]"
+                Subtitle="@L["Subtitle"]" />
 
-        <MudDivider Class="my-4" />
+    <MudDivider Class="my-4" />
 
-        <MudStack Spacing="3">
+    <MudStack Spacing="3">
 
-            @if (_athlete?.Vdot < 1 || _athlete?.PaceModel is null)
-            {
-                <MudAlert Severity="Severity.Warning">
-                    @L["NoRaceWarning"]
-                </MudAlert>
-            }
-            else if (_currentTraining is null)
-            {
-                <MudAlert Severity="Severity.Info">
-                    @L["NoTrainings"]
-                </MudAlert>
-            }
-            else
-            {
-                <MudPaper Class="pa-4 pl-training-panel" Elevation="0">
-                    <MudStack Spacing="3">
+        @if (_athlete?.Vdot < 1 || _athlete?.PaceModel is null)
+        {
+            <MudAlert Severity="Severity.Warning">
+                @L["NoRaceWarning"]
+            </MudAlert>
+        }
+        else if (_currentTraining is null)
+        {
+            <MudAlert Severity="Severity.Info">
+                @L["NoTrainings"]
+            </MudAlert>
+        }
+        else
+        {
+            <MudPaper Class="pa-4 pl-training-panel" Elevation="0">
+                <MudStack Spacing="3">
 
-                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
-                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="min-width:0;">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="min-width:0;">
+                            <div class="pl-training-icon">
+                                <MudIcon Icon="@Icons.Material.Filled.Timeline" Size="Size.Medium" />
+                            </div>
+
+                            <MudStack Spacing="0" Style="min-width:0;">
+                                <MudText Typo="Typo.h6">
+                                    @_currentTraining.Name
+                                </MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    ID: @_currentTraining.Id / @L["PlannedOn"] @_currentTraining.Date.ToString("dd.MM.yyyy")
+                                </MudText>
+                            </MudStack>
+                        </MudStack>
+                    </MudStack>
+
+                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                        <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
+                            @_currentTraining.Sets Set(s)
+                        </MudChip>
+                        <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">
+                            @($"{_currentTraining.TotalDistance / 1000.0:0.0} km")
+                        </MudChip>
+                        <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">
+                            @_currentTraining.Distances.Count Intervall(e)
+                        </MudChip>
+                    </MudStack>
+
+                    <MudDivider />
+
+                    <MudStack Spacing="0">
+                        @foreach (var row in TableRows)
+                        {
+                            <div class="@GetIntervalRowClass(row)">
                                 <div class="pl-training-icon">
-                                    <MudIcon Icon="@Icons.Material.Filled.Timeline" Size="Size.Medium" />
+                                    <MudIcon Icon="@(row.IsPause ? Icons.Material.Filled.SelfImprovement : Icons.Material.Filled.Speed)"
+                                             Size="Size.Small" />
                                 </div>
 
                                 <MudStack Spacing="0" Style="min-width:0;">
-                                    <MudText Typo="Typo.h6">
-                                        @_currentTraining.Name
-                                    </MudText>
+                                    <MudText Typo="Typo.body2">@GetRowTitle(row)</MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        ID: @_currentTraining.Id / @L["PlannedOn"] @_currentTraining.Date.ToString("dd.MM.yyyy")
+                                        @(row.IsPause ? "Recovery" : "Intervall")
                                     </MudText>
                                 </MudStack>
-                            </MudStack>
-                        </MudStack>
 
-                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
-                            <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Filled">
-                                @_currentTraining.Sets Set(s)
-                            </MudChip>
-                            <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">
-                                @($"{_currentTraining.TotalDistance / 1000.0:0.0} km")
-                            </MudChip>
-                            <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Outlined">
-                                @_currentTraining.Distances.Count Intervall(e)
-                            </MudChip>
-                        </MudStack>
-
-                        <MudDivider />
-
-                        <MudStack Spacing="0">
-                            @foreach (var row in TableRows)
-                            {
-                                <div class="@GetIntervalRowClass(row)">
-                                    <div class="pl-training-icon">
-                                        <MudIcon Icon="@(row.IsPause ? Icons.Material.Filled.SelfImprovement : Icons.Material.Filled.Speed)"
-                                                 Size="Size.Small" />
-                                    </div>
-
-                                    <MudStack Spacing="0" Style="min-width:0;">
-                                        <MudText Typo="Typo.body2">@GetRowTitle(row)</MudText>
-                                        <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                            @(row.IsPause ? "Recovery" : "Intervall")
-                                        </MudText>
-                                    </MudStack>
-
-                                    <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                        @($"{GetRowDistance(row)} m")
-                                    </MudText>
-                                </div>
-                            }
-                        </MudStack>
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                    @($"{GetRowDistance(row)} m")
+                                </MudText>
+                            </div>
+                        }
                     </MudStack>
-                </MudPaper>
-            }
-        </MudStack>
-    }
+                </MudStack>
+            </MudPaper>
+        }
+    </MudStack>
 
 </MudContainer>
 
 @code {
-    private bool _isLoading = true;
-
     private AthleteModel? _athlete;
     private IntervallSession? _currentTraining;
 
@@ -149,7 +141,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        try
+        await Loading.RunAsync(L["Loading"], async () =>
         {
             var authState = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
             var userID = authState.User.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
@@ -179,11 +171,7 @@
                 .FirstOrDefault();
 
             _currentTraining = upcoming ?? sessions.OrderByDescending(t => t.Date).FirstOrDefault();
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+        });
 
 
     }

--- a/PaceLetics.Web/Pages/Athletes/TrainingPaces.razor
+++ b/PaceLetics.Web/Pages/Athletes/TrainingPaces.razor
@@ -9,42 +9,36 @@
 @inject IAthleteData AthleteData
 @inject IDialogService dialogService
 @inject IJSRuntime JSRuntime
+@inject LoadingStateService Loading
 @inject IStringLocalizer<TrainingPaces> L
 
 <PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-8 pb-8" MaxWidth="MaxWidth.Small">
-    @if (_isLoading)
-    {
-        <LoadingScreen Label="@L["Loading"]" />
-    }
-    else
-    {
-        <PageHeader Title="@L["Title"]"
-                    Subtitle="@L["Subtitle"]" />
+    <PageHeader Title="@L["Title"]"
+                Subtitle="@L["Subtitle"]" />
 
-        <MudDivider Class="my-4" />
+    <MudDivider Class="my-4" />
 
-        <MudStack Spacing="3">
-            @if (_athlete?.Vdot < 1)
-            {
-                <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
-                    @L["NoRaceWarning"]
-                </MudAlert>
-            }
+    <MudStack Spacing="3">
+        @if (_athlete?.Vdot < 1)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+                @L["NoRaceWarning"]
+            </MudAlert>
+        }
 
-            <PaceInfo EPaceLow="@_lowerPace.Easy"
-                      EPaceHigh="@_upperPace.Easy"
-                      RecoveryPaceLow="@_lowerPace.Easy.Add(TimeSpan.FromSeconds(30))"
-                      RecoveryPaceHigh="@_upperPace.Easy.Add(TimeSpan.FromSeconds(30))"
-                      MPaceLow="@_lowerPace.Marathon"
-                      MPaceHigh="@_upperPace.Marathon"
-                      TPaceLow="@_lowerPace.Threshold"
-                      TPaceHigh="@_upperPace.Threshold"
-                      IPaceLow="@_lowerPace.Intervall"
-                      IPaceHigh="@_upperPace.Intervall"
-                      RPaceLow="@_lowerPace.Repetition"
-                      RPaceHigh="@_upperPace.Repetition" />
-        </MudStack>
-    }
+        <PaceInfo EPaceLow="@_lowerPace.Easy"
+                  EPaceHigh="@_upperPace.Easy"
+                  RecoveryPaceLow="@_lowerPace.Easy.Add(TimeSpan.FromSeconds(30))"
+                  RecoveryPaceHigh="@_upperPace.Easy.Add(TimeSpan.FromSeconds(30))"
+                  MPaceLow="@_lowerPace.Marathon"
+                  MPaceHigh="@_upperPace.Marathon"
+                  TPaceLow="@_lowerPace.Threshold"
+                  TPaceHigh="@_upperPace.Threshold"
+                  IPaceLow="@_lowerPace.Intervall"
+                  IPaceHigh="@_upperPace.Intervall"
+                  RPaceLow="@_lowerPace.Repetition"
+                  RPaceHigh="@_upperPace.Repetition" />
+    </MudStack>
 </MudContainer>

--- a/PaceLetics.Web/Pages/Athletes/TrainingPaces.razor.cs
+++ b/PaceLetics.Web/Pages/Athletes/TrainingPaces.razor.cs
@@ -1,4 +1,4 @@
-using MudBlazor;
+﻿using MudBlazor;
 using MudBlazor.Extensions;
 using PaceLetics.AthleteModule.CodeBase.Models;
 using PaceLetics.CoreModule.Infrastructure.Models;
@@ -8,41 +8,38 @@ namespace PaceLetics.Web.Pages.Athletes
 {
     public partial class TrainingPaces
     {
-        private bool _isLoading = true;
-
         private AthleteModel? _athlete;
         private PaceModel _upperPace = new();
         private PaceModel _lowerPace = new();
 
         protected override async Task OnInitializedAsync()
         {
-            try
+            await Loading.RunAsync(L["Loading"], async () =>
             {
-                var authState = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
-                var userID = authState.User.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
-
-                if (!string.IsNullOrEmpty(userID))
+                try
                 {
-                    _athlete = await AthleteData.GetAthlete(userID);
+                    var authState = await GetAuthenticationStateAsync.GetAuthenticationStateAsync();
+                    var userID = authState.User.FindFirst(u => u.Type.Contains("nameidentifier"))?.Value;
 
-                    if (_athlete?.PaceModel is not null)
+                    if (!string.IsNullOrEmpty(userID))
                     {
-                        _upperPace = _athlete.PaceModel;
-                        _lowerPace = _athlete.PaceModel.Reduce(0.975);
+                        _athlete = await AthleteData.GetAthlete(userID);
+
+                        if (_athlete?.PaceModel is not null)
+                        {
+                            _upperPace = _athlete.PaceModel;
+                            _lowerPace = _athlete.PaceModel.Reduce(0.975);
+                        }
                     }
                 }
-            }
-            catch
-            {
-                await dialogService.ShowInformationAsync(
-                    "Achtung",
-                    "Es gab ein Problem beim Laden deiner Daten. Bitte versuche es sp�ter erneut.",
-                    Icons.Material.Filled.Error);
-            }
-            finally
-            {
-                _isLoading = false;
-            }
+                catch
+                {
+                    await dialogService.ShowInformationAsync(
+                        "Achtung",
+                        "Es gab ein Problem beim Laden deiner Daten. Bitte versuche es später erneut.",
+                        Icons.Material.Filled.Error);
+                }
+            });
         }
     }
 }

--- a/PaceLetics.Web/Pages/Profiles.razor
+++ b/PaceLetics.Web/Pages/Profiles.razor
@@ -3,16 +3,13 @@
 @using AthleteDataAccessLibrary.Contracts
 @using PaceLetics.AthleteModule.CodeBase.Models
 @inject IAthleteData AthleteData
+@inject LoadingStateService Loading
 @inject IStringLocalizer<Profiles> L
 
 <PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
-    @if (_isLoading)
-    {
-        <LoadingScreen Label="@L["Loading"]" />
-    }
-    else if (_selectedProfile is not null)
+    @if (_selectedProfile is not null)
     {
         <PageHeader Title="@_selectedProfile.PublicUserName" Subtitle="@GetRoleDisplayName(_selectedProfile.PublicRole)">
             <Actions>
@@ -135,35 +132,34 @@
     [Parameter]
     public string? PublicUserName { get; set; }
 
-    private bool _isLoading = true;
     private bool _profileNotFound;
     private List<PublicProfileModel> _profiles = new();
     private PublicProfileModel? _selectedProfile;
 
     protected override async Task OnParametersSetAsync()
     {
-        _isLoading = true;
-        _profileNotFound = false;
-        _selectedProfile = null;
-
-        _profiles = (await AthleteData.GetAthletes())
-            .Select(athlete => athlete.PublicProfile)
-            .Where(profile => profile is not null
-                && profile.IsProfileVisible
-                && !string.IsNullOrWhiteSpace(profile.PublicUserName)
-                && profile.PublicUserName != "NA")
-            .OrderBy(profile => profile.PublicUserName)
-            .ToList();
-
-        if (!string.IsNullOrWhiteSpace(PublicUserName))
+        await Loading.RunAsync(L["Loading"], async () =>
         {
-            var normalizedPublicUserName = NormalizePublicUserName(PublicUserName);
-            _selectedProfile = _profiles.FirstOrDefault(profile =>
-                profile.NormalizedPublicUserName == normalizedPublicUserName);
-            _profileNotFound = _selectedProfile is null;
-        }
+            _profileNotFound = false;
+            _selectedProfile = null;
 
-        _isLoading = false;
+            _profiles = (await AthleteData.GetAthletes())
+                .Select(athlete => athlete.PublicProfile)
+                .Where(profile => profile is not null
+                    && profile.IsProfileVisible
+                    && !string.IsNullOrWhiteSpace(profile.PublicUserName)
+                    && profile.PublicUserName != "NA")
+                .OrderBy(profile => profile.PublicUserName)
+                .ToList();
+
+            if (!string.IsNullOrWhiteSpace(PublicUserName))
+            {
+                var normalizedPublicUserName = NormalizePublicUserName(PublicUserName);
+                _selectedProfile = _profiles.FirstOrDefault(profile =>
+                    profile.NormalizedPublicUserName == normalizedPublicUserName);
+                _profileNotFound = _selectedProfile is null;
+            }
+        });
     }
 
     private static string GetProfileHref(PublicProfileModel profile)

--- a/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
@@ -11,28 +11,23 @@
 @inject IAthleteData AthleteData
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
+@inject LoadingStateService Loading
 @inject IStringLocalizer<CourseManagement> L
 
 <PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Medium">
-    @if (_isLoading)
+    <PageHeader Title="@L["Title"]"
+                Subtitle="@L["Subtitle"]" />
+
+    <MudDivider Class="my-4" />
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
     {
-        <LoadingScreen Label="@L["Loading"]" />
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">@_errorMessage</MudAlert>
     }
-    else
-    {
-        <PageHeader Title="@L["Title"]"
-                    Subtitle="@L["Subtitle"]" />
 
-        <MudDivider Class="my-4" />
-
-        @if (!string.IsNullOrWhiteSpace(_errorMessage))
-        {
-            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">@_errorMessage</MudAlert>
-        }
-
-        <MudStack Spacing="4">
+    <MudStack Spacing="4">
             <MudPaper Elevation="1" Class="pa-4">
                 <MudStack Spacing="3">
                     <MudText Typo="Typo.h6">@L["CreateCourseTitle"]</MudText>
@@ -412,12 +407,10 @@
                     </MudStack>
                 </MudPaper>
             }
-        </MudStack>
-    }
+    </MudStack>
 </MudContainer>
 
 @code {
-    private bool _isLoading = true;
     private string? _userId;
     private string _displayName = string.Empty;
     private string? _errorMessage;
@@ -481,47 +474,45 @@
 
     private async Task LoadAsync()
     {
-        try
+        await Loading.RunAsync(L["Loading"], async () =>
         {
-            _isLoading = true;
-            _errorMessage = null;
+            try
+            {
+                _errorMessage = null;
 
-            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
-            var user = authState.User;
-            _userId = user.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
+                var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                var user = authState.User;
+                _userId = user.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
 
-            if (string.IsNullOrWhiteSpace(_userId))
-                throw new InvalidOperationException(L["TrainerNotResolved"]);
+                if (string.IsNullOrWhiteSpace(_userId))
+                    throw new InvalidOperationException(L["TrainerNotResolved"]);
 
-            var athlete = await AthleteData.GetAthlete(_userId);
-            _displayName = GetDisplayName(athlete, user.Identity?.Name ?? _userId);
+                var athlete = await AthleteData.GetAthlete(_userId);
+                _displayName = GetDisplayName(athlete, user.Identity?.Name ?? _userId);
 
-            var athletes = (await AthleteData.GetAthletes()).ToList();
-            _athleteDisplayNamesById = athletes
-                .ToDictionary(athlete => athlete.Id, athlete => GetDisplayName(athlete, athlete.Id), StringComparer.OrdinalIgnoreCase);
+                var athletes = (await AthleteData.GetAthletes()).ToList();
+                _athleteDisplayNamesById = athletes
+                    .ToDictionary(athlete => athlete.Id, athlete => GetDisplayName(athlete, athlete.Id), StringComparer.OrdinalIgnoreCase);
 
-            _trainerCandidates = athletes
-                .Where(athlete => athlete.Id != _userId
-                    && athlete.Roles.AssignedRoles.Contains(ApplicationRoles.Trainer))
-                .Select(athlete => new TrainerCandidate(athlete.Id, GetDisplayName(athlete, athlete.Id)))
-                .OrderBy(trainer => trainer.DisplayName)
-                .ToList();
+                _trainerCandidates = athletes
+                    .Where(athlete => athlete.Id != _userId
+                        && athlete.Roles.AssignedRoles.Contains(ApplicationRoles.Trainer))
+                    .Select(athlete => new TrainerCandidate(athlete.Id, GetDisplayName(athlete, athlete.Id)))
+                    .OrderBy(trainer => trainer.DisplayName)
+                    .ToList();
 
-            _courses = (await CourseService.GetCoursesForTrainerAsync(_userId)).ToList();
-            _trainingPlans = TrainingPlanService.LoadTrainingPlans().ToList();
-            EnsureSelection();
-            await LoadSelectedCourseEventsAsync();
-        }
-        catch (Exception ex)
-        {
-            _errorMessage = ex.Message;
-            _courses = new();
-            _selectedCourseEvents = new();
-        }
-        finally
-        {
-            _isLoading = false;
-        }
+                _courses = (await CourseService.GetCoursesForTrainerAsync(_userId)).ToList();
+                _trainingPlans = TrainingPlanService.LoadTrainingPlans().ToList();
+                EnsureSelection();
+                await LoadSelectedCourseEventsAsync();
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                _courses = new();
+                _selectedCourseEvents = new();
+            }
+        });
     }
 
     private void EnsureSelection()

--- a/PaceLetics.Web/Pages/Workouts/WorkoutArea.razor
+++ b/PaceLetics.Web/Pages/Workouts/WorkoutArea.razor
@@ -1,44 +1,38 @@
 @page "/Workouts/workoutarea"
 @inject WorkoutAreaViewModel ViewModel
+@inject LoadingStateService Loading
 @inject IStringLocalizer<WorkoutArea> L
 
 <PageTitle>@L["PageTitle"]</PageTitle>
 
 <MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
 
-    @if (ViewModel.IsLoading)
-    {
-        <LoadingScreen Label="@L["Loading"]" />
-    }
-    else
-    {
-        <PageHeader Title="@L["Title"]"
-                    Subtitle="@L["Subtitle"]" />
+    <PageHeader Title="@L["Title"]"
+                Subtitle="@L["Subtitle"]" />
 
-        <MudDivider Class="my-4" />
+    <MudDivider Class="my-4" />
 
-        <MudStack Spacing="3" AlignItems="AlignItems.Stretch">
+    <MudStack Spacing="3" AlignItems="AlignItems.Stretch">
 
-            <MudText Typo="Typo.body1" Style="opacity:.8;">
-                @L["IntroText"]
+        <MudText Typo="Typo.body1" Style="opacity:.8;">
+            @L["IntroText"]
+        </MudText>
+
+        @if (!ViewModel.WorkoutPreviews.Any())
+        {
+            <MudText Typo="Typo.body2" Style="opacity:.7;">
+                @L["NoWorkouts"]
             </MudText>
-
-            @if (!ViewModel.WorkoutPreviews.Any())
+        }
+        else
+        {
+            @foreach (var item in ViewModel.WorkoutPreviews)
             {
-                <MudText Typo="Typo.body2" Style="opacity:.7;">
-                    @L["NoWorkouts"]
-                </MudText>
+                <PaceLetics.TrainingModule.Components.Workouts.WorkoutGroupPreviewElement Preview="@item" />
             }
-            else
-            {
-                @foreach (var item in ViewModel.WorkoutPreviews)
-                {
-                    <PaceLetics.TrainingModule.Components.Workouts.WorkoutGroupPreviewElement Preview="@item" />
-                }
-            }
+        }
 
-        </MudStack>
-    }
+    </MudStack>
 
 </MudContainer>
 
@@ -46,10 +40,12 @@
 
 
 @code {
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        ViewModel.Initialize();
+        await Loading.RunAsync(L["Loading"], () =>
+        {
+            ViewModel.Initialize();
+            return Task.CompletedTask;
+        });
     }
-
-
 }

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -27,6 +27,7 @@ using PaceLetics.CoreModule.Infrastructure.Services;
 using PaceLetics.Web.Services.Courses;
 using PaceLetics.Web.Services.RunningAnalysis;
 using PaceLetics.Web.Services.Theming;
+using PaceLetics.Web.Services.Loading;
 using PaceLetics.Web.Localization;
 using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
 using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Services;
@@ -120,6 +121,7 @@ builder.Services.AddScoped<ICourseRunningAnalysisRegistrationAdapter, CourseRunn
 builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddScoped<ITrainingPlanService, TrainingPlanService>();
 builder.Services.AddScoped<ThemePreferenceService>();
+builder.Services.AddScoped<LoadingStateService>();
 builder.Services.AddSingleton<DashboardMessageFeedOptions>();
 builder.Services.AddScoped<IAthleteMessageProvider, ReferenceRunDashboardMessageProvider>();
 builder.Services.AddScoped<IAthleteMessageProvider, UpcomingTrainingDashboardMessageProvider>();

--- a/PaceLetics.Web/Services/Loading/LoadingStateService.cs
+++ b/PaceLetics.Web/Services/Loading/LoadingStateService.cs
@@ -1,0 +1,85 @@
+namespace PaceLetics.Web.Services.Loading;
+
+public sealed class LoadingStateService
+{
+    private readonly Stack<LoadingState> _states = new();
+
+    public event Action? Changed;
+
+    public bool IsLoading => _states.Count > 0;
+    public string Label => _states.TryPeek(out var state) ? state.Label : string.Empty;
+
+    public IDisposable Show(string label)
+    {
+        var state = new LoadingState(string.IsNullOrWhiteSpace(label) ? "Loading..." : label);
+        _states.Push(state);
+        NotifyChanged();
+
+        return new LoadingScope(this, state);
+    }
+
+    public async Task RunAsync(string label, Func<Task> operation)
+    {
+        using var scope = Show(label);
+        await operation();
+    }
+
+    public async Task<T> RunAsync<T>(string label, Func<Task<T>> operation)
+    {
+        using var scope = Show(label);
+        return await operation();
+    }
+
+    private void Hide(LoadingState state)
+    {
+        if (_states.Count == 0)
+            return;
+
+        if (_states.Peek() == state)
+        {
+            _states.Pop();
+        }
+        else
+        {
+            var remainingStates = _states
+                .Where(existingState => existingState != state)
+                .Reverse()
+                .ToArray();
+
+            _states.Clear();
+            foreach (var remainingState in remainingStates)
+                _states.Push(remainingState);
+        }
+
+        NotifyChanged();
+    }
+
+    private void NotifyChanged()
+    {
+        Changed?.Invoke();
+    }
+
+    private sealed record LoadingState(string Label);
+
+    private sealed class LoadingScope : IDisposable
+    {
+        private readonly LoadingStateService _service;
+        private readonly LoadingState _state;
+        private bool _disposed;
+
+        public LoadingScope(LoadingStateService service, LoadingState state)
+        {
+            _service = service;
+            _state = state;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            _service.Hide(_state);
+        }
+    }
+}

--- a/PaceLetics.Web/Shared/DataGridView.razor
+++ b/PaceLetics.Web/Shared/DataGridView.razor
@@ -3,7 +3,7 @@
 
 @if (Athletes == null)
 {
-    <p><em>@L["Loading"]</em></p>
+    <LoadingScreen Label="@L["Loading"]" />
 }
 else
 {

--- a/PaceLetics.Web/Shared/LoadingHost.razor
+++ b/PaceLetics.Web/Shared/LoadingHost.razor
@@ -1,0 +1,26 @@
+@implements IDisposable
+@inject PaceLetics.Web.Services.Loading.LoadingStateService Loading
+
+@if (Loading.IsLoading)
+{
+    <div class="pl-overlay pl-loading-overlay" role="status" aria-live="polite" aria-busy="true">
+        <LoadingScreen Label="@Loading.Label" />
+    </div>
+}
+
+@code {
+    protected override void OnInitialized()
+    {
+        Loading.Changed += OnLoadingChanged;
+    }
+
+    private void OnLoadingChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        Loading.Changed -= OnLoadingChanged;
+    }
+}

--- a/PaceLetics.Web/Shared/LoadingScreen.razor
+++ b/PaceLetics.Web/Shared/LoadingScreen.razor
@@ -1,28 +1,23 @@
-﻿@using MudBlazor;
-@using MudBlazor.Extensions.Core;
+@using MudBlazor
 
-<MudGrid Class="d-flex justify-center">
-    <MudCard>
-        <MudAlert Severity="Severity.Info">
-            @Label
-        </MudAlert>
-        <MudExGradientText Palette="palette" Align="Align.Center">
-            |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-        </MudExGradientText>
-    </MudCard>
-</MudGrid>
+<div class="pl-loading">
+    <MudPaper Elevation="0" Class="pl-loading-panel">
+        <MudProgressCircular Class="pl-loading-symbol"
+                             Color="Color.Primary"
+                             Size="@Size.Large"
+                             StrokeWidth="4"
+                             Indeterminate="true" />
+
+        @if (!string.IsNullOrWhiteSpace(Label))
+        {
+            <MudText Class="pl-loading-label" Typo="Typo.body2" Align="Align.Center">
+                @Label
+            </MudText>
+        }
+    </MudPaper>
+</div>
 
 @code {
-
     [Parameter]
     public string Label { get; set; } = string.Empty;
-
-    List<MudExColor> palette = new List<MudExColor>()
-    {
-        MudExColor.DrawerBackground,
-        MudExColor.Primary,
-        MudExColor.DrawerBackground,
-        MudExColor.DrawerBackground,
-        MudExColor.Secondary
-    };
 }

--- a/PaceLetics.Web/Shared/MainLayout.razor
+++ b/PaceLetics.Web/Shared/MainLayout.razor
@@ -60,6 +60,8 @@
     <MudMainContent Style="margin-top: 24px;">
         @Body
     </MudMainContent>
+
+    <LoadingHost />
 </MudLayout>
 
 @code {

--- a/PaceLetics.Web/ViewModels/Workouts/WorkoutAreaViewModel.cs
+++ b/PaceLetics.Web/ViewModels/Workouts/WorkoutAreaViewModel.cs
@@ -13,7 +13,6 @@ public sealed class WorkoutAreaViewModel
         _workoutCatalog = workoutCatalog;
     }
 
-    public bool IsLoading { get; private set; } = true;
     public IReadOnlyList<WorkoutPreview> WorkoutPreviews => _workoutPreviews;
 
     public void Initialize()
@@ -28,7 +27,5 @@ public sealed class WorkoutAreaViewModel
 
             _workoutPreviews.Add(_workoutCatalog.GetWorkoutPreview(ids.First()));
         }
-
-        IsLoading = false;
     }
 }

--- a/PaceLetics.Web/_Imports.razor
+++ b/PaceLetics.Web/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.JSInterop
 @using PaceLetics.Web
 @using PaceLetics.Web.Data
+@using PaceLetics.Web.Services.Loading
 @using PaceLetics.Web.Services.Theming
 @using PaceLetics.Web.Shared
 @using PaceLetics.Web.ViewModels.Workouts

--- a/PaceLetics.Web/wwwroot/css/app-theme.css
+++ b/PaceLetics.Web/wwwroot/css/app-theme.css
@@ -39,6 +39,45 @@
     background: var(--pl-overlay-background);
 }
 
+.pl-loading-overlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.pl-loading {
+    display: flex;
+    min-height: 180px;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+}
+
+.pl-loading-panel {
+    display: flex;
+    min-width: min(280px, 100%);
+    max-width: 360px;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    padding: 24px;
+    border: 1px solid color-mix(in srgb, var(--mud-palette-primary) 28%, var(--mud-palette-lines-default));
+    border-radius: var(--pl-radius);
+    background: color-mix(in srgb, var(--mud-palette-primary) var(--pl-loading-accent, 7%), var(--mud-palette-surface));
+    box-shadow: var(--mud-elevation-6);
+}
+
+.pl-loading-symbol {
+    color: var(--mud-palette-primary);
+}
+
+.pl-loading-label {
+    max-width: 100%;
+    color: var(--mud-palette-text-secondary);
+    overflow-wrap: anywhere;
+}
+
 .pl-modal-overlay {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Summary
Replaced the improvised text-based loading bar with a dedicated MudBlazor loading indicator.
Added a scoped loading state service for page and operation loading states.
Added a global loading host to the main layout so pages can report loading work centrally.
Migrated existing page-level loading flags to the new service.
Kept loader styling consistent with the existing app theme tokens.
Implementation Details
Added LoadingStateService with:
Show(string label)
RunAsync(string label, Func<Task> operation)
RunAsync<T>(string label, Func<Task<T>> operation)
nested loading scope support
Registered LoadingStateService as scoped in the web app dependency injection container.
Added LoadingHost to MainLayout so active loading operations render through a single global host.
Reworked LoadingScreen to render MudProgressCircular instead of the previous ||||| gradient text placeholder.
Added theme-aware loader CSS classes in app-theme.css using existing MudBlazor and PaceLetics CSS variables.
Updated DataGridView to reuse LoadingScreen instead of rendering raw emphasized loading text.
Migrated Pages
Dashboard
Profiles
WorkoutArea
CourseManagement
MyCourses
RacePaces
TrainingPaces
TrainingIntervalls
ViewModel Changes
Removed UI loading responsibility from WorkoutAreaViewModel.
Updated the related test to assert loaded workout preview data instead of checking a UI loading flag.
Tests
Added unit tests for LoadingStateService:
verifies RunAsync activates and clears loading state
verifies nested loading scopes restore the previous label
Updated WorkoutViewModelTests for the new separation between view model data and page loading state.
Verification
dotnet build PaceLeticsFramework.sln passed.
dotnet test PaceLeticsFramework.sln passed with 106 tests.
Browser smoke check passed at http://127.0.0.1:5127.
Login page rendered successfully with no browser console errors.
Protected routes redirected to login as expected.
Repository search confirmed no remaining MudExGradientText, text-bar placeholder, or web _isLoading usage.
Notes
Existing NuGet advisory warnings for OpenMcdf and SharpCompress still appear during build/test and are unrelated to this PR.
Initial local browser navigation to localhost was blocked by the browser client, but 127.0.0.1 worked.
The Azure SQL firewall warning appeared during local app startup in role seeding and is unrelated to the loader changes.