### PR TITLE
Integrate running analysis workflows

### DIFF
--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IRunningAnalysisService.cs
@@ -4,6 +4,10 @@ namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
 
 public interface IRunningAnalysisService
 {
+    Task<RunningAnalysisEvent> PrepareEventAsync(
+        RunningAnalysisEventRequest request,
+        CancellationToken cancellationToken = default);
+
     Task<RunningAnalysisParticipant> RegisterParticipantAsync(
         RunningAnalysisRegistration registration,
         CancellationToken cancellationToken = default);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisEventRequest.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Models/RunningAnalysisEventRequest.cs
@@ -1,0 +1,8 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
+
+public sealed record RunningAnalysisEventRequest(
+    string ExternalEventId,
+    string CourseId,
+    string Title,
+    DateTime StartsAt,
+    DateTime EndsAt);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/RunningAnalysisService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/RunningAnalysisService.cs
@@ -24,13 +24,53 @@ public sealed class RunningAnalysisService : IRunningAnalysisService
         _clock = clock;
     }
 
+    public async Task<RunningAnalysisEvent> PrepareEventAsync(
+        RunningAnalysisEventRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateEventRequest(request);
+
+        var analysisEvent = await _repository.GetEventByExternalEventIdAsync(
+            request.ExternalEventId,
+            cancellationToken);
+
+        if (analysisEvent is null)
+        {
+            analysisEvent = new RunningAnalysisEvent
+            {
+                ExternalEventId = request.ExternalEventId.Trim(),
+                CourseId = request.CourseId.Trim(),
+                CreatedAt = _clock.UtcNow
+            };
+        }
+
+        analysisEvent.CourseId = request.CourseId.Trim();
+        analysisEvent.Title = request.Title.Trim();
+        analysisEvent.StartsAt = request.StartsAt;
+        analysisEvent.EndsAt = request.EndsAt;
+        analysisEvent.UpdatedAt = _clock.UtcNow;
+
+        if (analysisEvent.Status == RunningAnalysisEventStatus.Draft)
+            analysisEvent.Status = RunningAnalysisEventStatus.Prepared;
+
+        await _repository.UpsertEventAsync(analysisEvent, cancellationToken);
+        return analysisEvent;
+    }
+
     public async Task<RunningAnalysisParticipant> RegisterParticipantAsync(
         RunningAnalysisRegistration registration,
         CancellationToken cancellationToken = default)
     {
         ValidateRegistration(registration);
 
-        var analysisEvent = await GetOrCreateEventAsync(registration, cancellationToken);
+        var analysisEvent = await PrepareEventAsync(
+            new RunningAnalysisEventRequest(
+                registration.ExternalEventId,
+                registration.CourseId,
+                registration.EventTitle,
+                registration.StartsAt,
+                registration.EndsAt),
+            cancellationToken);
         var participant = await _repository.GetParticipantAsync(
             analysisEvent.Id,
             registration.AthleteUserId,
@@ -208,32 +248,6 @@ public sealed class RunningAnalysisService : IRunningAnalysisService
         }
     }
 
-    private async Task<RunningAnalysisEvent> GetOrCreateEventAsync(
-        RunningAnalysisRegistration registration,
-        CancellationToken cancellationToken)
-    {
-        var analysisEvent = await _repository.GetEventByExternalEventIdAsync(
-            registration.ExternalEventId,
-            cancellationToken);
-
-        if (analysisEvent is null)
-        {
-            analysisEvent = new RunningAnalysisEvent
-            {
-                ExternalEventId = registration.ExternalEventId.Trim(),
-                CourseId = registration.CourseId.Trim(),
-                CreatedAt = _clock.UtcNow
-            };
-        }
-
-        analysisEvent.Title = registration.EventTitle.Trim();
-        analysisEvent.StartsAt = registration.StartsAt;
-        analysisEvent.EndsAt = registration.EndsAt;
-        analysisEvent.UpdatedAt = _clock.UtcNow;
-        await _repository.UpsertEventAsync(analysisEvent, cancellationToken);
-        return analysisEvent;
-    }
-
     private async Task ProvisionParticipantFolderAsync(
         RunningAnalysisEvent analysisEvent,
         RunningAnalysisParticipant participant,
@@ -339,6 +353,21 @@ public sealed class RunningAnalysisService : IRunningAnalysisService
 
         if (string.IsNullOrWhiteSpace(registration.AthleteUserId))
             throw new InvalidOperationException("An athlete user id is required.");
+    }
+
+    private static void ValidateEventRequest(RunningAnalysisEventRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ExternalEventId))
+            throw new InvalidOperationException("A source event id is required.");
+
+        if (string.IsNullOrWhiteSpace(request.CourseId))
+            throw new InvalidOperationException("A course id is required.");
+
+        if (string.IsNullOrWhiteSpace(request.Title))
+            throw new InvalidOperationException("A running analysis title is required.");
+
+        if (request.EndsAt <= request.StartsAt)
+            throw new InvalidOperationException("The running analysis end must be after the start.");
     }
 
     private static string Normalize(string value, string fallback)

--- a/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisLinks.razor
+++ b/PaceLetics.RunningAnalysisModule.Components/RunningAnalysisLinks.razor
@@ -3,7 +3,7 @@
 <MudStack Spacing="2">
     @if (Items.Count == 0)
     {
-        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">No analyses available.</MudAlert>
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">@EmptyText</MudAlert>
     }
     else
     {
@@ -24,7 +24,7 @@
                                    Color="Color.Primary"
                                    Variant="Variant.Outlined"
                                    StartIcon="@Icons.Material.Filled.FolderOpen">
-                            Open
+                            @OpenText
                         </MudButton>
                     }
                     else
@@ -41,4 +41,6 @@
 
 @code {
     [Parameter] public IReadOnlyList<RunningAnalysisLink> Items { get; set; } = Array.Empty<RunningAnalysisLink>();
+    [Parameter] public string EmptyText { get; set; } = "No analyses available.";
+    [Parameter] public string OpenText { get; set; } = "Open";
 }

--- a/PaceLetics.RunningAnalysisModule.Components/wwwroot/runningAnalysisMediaRecorder.js
+++ b/PaceLetics.RunningAnalysisModule.Components/wwwroot/runningAnalysisMediaRecorder.js
@@ -86,6 +86,10 @@ export function disposeRecorder(videoElement) {
   recorders.delete(videoElement);
 }
 
+export function isOnline() {
+  return navigator.onLine;
+}
+
 function stopStream(videoElement, stream) {
   if (stream) {
     for (const track of stream.getTracks()) {

--- a/PaceLetics.Tests/RunningAnalysisServiceTests.cs
+++ b/PaceLetics.Tests/RunningAnalysisServiceTests.cs
@@ -9,6 +9,36 @@ namespace PaceLetics.Tests;
 public sealed class RunningAnalysisServiceTests
 {
     [Fact]
+    public async Task PrepareEvent_CreatesPreparedEvent()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var service = CreateService(repository, new FakeRunningAnalysisStorageProvider(), new FakeUserDriveFolderRegistry());
+
+        var analysisEvent = await service.PrepareEventAsync(CreateEventRequest());
+
+        Assert.Equal("course-event-1", analysisEvent.ExternalEventId);
+        Assert.Equal("course-1", analysisEvent.CourseId);
+        Assert.Equal(RunningAnalysisEventStatus.Prepared, analysisEvent.Status);
+        Assert.Single(repository.Events.Values);
+    }
+
+    [Fact]
+    public async Task PrepareEvent_UpdatesExistingEventWithoutResettingProgress()
+    {
+        var repository = new InMemoryRunningAnalysisRepository();
+        var service = CreateService(repository, new FakeRunningAnalysisStorageProvider(), new FakeUserDriveFolderRegistry());
+        var analysisEvent = await service.PrepareEventAsync(CreateEventRequest());
+        await service.StartAnalysisAsync(analysisEvent.Id);
+
+        var updated = await service.PrepareEventAsync(CreateEventRequest(title: "Updated analysis"));
+
+        Assert.Equal(analysisEvent.Id, updated.Id);
+        Assert.Equal("Updated analysis", updated.Title);
+        Assert.Equal(RunningAnalysisEventStatus.InProgress, updated.Status);
+        Assert.Single(repository.Events.Values);
+    }
+
+    [Fact]
     public async Task RegisterParticipant_CreatesFolderAndGrantsWriteAccess()
     {
         var repository = new InMemoryRunningAnalysisRepository();
@@ -202,6 +232,16 @@ public sealed class RunningAnalysisServiceTests
             DisplayName: "Runner One",
             Email: "runner@example.com",
             RegistrationId: "registration-1");
+    }
+
+    private static RunningAnalysisEventRequest CreateEventRequest(string title = "Running analysis")
+    {
+        return new RunningAnalysisEventRequest(
+            ExternalEventId: "course-event-1",
+            CourseId: "course-1",
+            Title: title,
+            StartsAt: new DateTime(2026, 6, 5, 18, 0, 0, DateTimeKind.Utc),
+            EndsAt: new DateTime(2026, 6, 5, 20, 0, 0, DateTimeKind.Utc));
     }
 
     private sealed record FixedRunningAnalysisClock(DateTime UtcNow) : IRunningAnalysisClock;

--- a/PaceLetics.Web/Pages/Athletes/MyAnalyses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyAnalyses.razor
@@ -1,0 +1,62 @@
+@page "/Athletes/analyses"
+@attribute [Authorize]
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models
+@using PaceLetics.RunningAnalysisModule.Components
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IRunningAnalysisService RunningAnalysisService
+@inject LoadingStateService Loading
+@inject IStringLocalizer<MyAnalyses> L
+
+<PageTitle>@L["PageTitle"]</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
+    <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
+
+    <MudDivider Class="my-4" />
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_errorMessage</MudAlert>
+    }
+    else
+    {
+        <RunningAnalysisLinks Items="_analyses"
+                              EmptyText="@L["NoAnalyses"]"
+                              OpenText="@L["OpenFolder"]" />
+    }
+</MudContainer>
+
+@code {
+    private string? _userId;
+    private string? _errorMessage;
+    private IReadOnlyList<RunningAnalysisLink> _analyses = Array.Empty<RunningAnalysisLink>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        await Loading.RunAsync(L["Loading"], async () =>
+        {
+            try
+            {
+                _errorMessage = null;
+                var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                _userId = authState.User.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
+
+                if (string.IsNullOrWhiteSpace(_userId))
+                    throw new InvalidOperationException(L["AthleteNotResolved"]);
+
+                _analyses = await RunningAnalysisService.GetAnalysesForAthleteAsync(_userId);
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                _analyses = Array.Empty<RunningAnalysisLink>();
+            }
+        });
+    }
+}

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -1,8 +1,12 @@
 @page "/Athletes/courses"
 @attribute [Authorize]
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models
 @using PaceLetics.Web.Services.Courses
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject ICourseService CourseService
+@inject IRunningAnalysisService RunningAnalysisService
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
 @inject LoadingStateService Loading
@@ -220,20 +224,46 @@
                                     <MudStack Spacing="1">
                                         @foreach (var courseEvent in GetVisibleEvents(courseEvents))
                                         {
+                                            var analysisLink = GetAnalysisLink(courseEvent.Id);
                                             <div class="pl-list-row" style="display:grid; grid-template-columns:1fr auto; gap:12px; align-items:center;">
                                                 <div>
-                                                    <MudText Typo="Typo.body2">@courseEvent.Title</MudText>
+                                                    <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:6px; flex-wrap:wrap;">
+                                                        <MudText Typo="Typo.body2">@courseEvent.Title</MudText>
+                                                        @if (IsRunningAnalysisEvent(courseEvent))
+                                                        {
+                                                            <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">
+                                                                @L["RunningAnalysis"]
+                                                            </MudChip>
+                                                        }
+                                                    </MudStack>
                                                     <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatEventDate(courseEvent)</MudText>
+                                                    @if (IsRunningAnalysisEvent(courseEvent) && IsRegisteredForEvent(courseEvent.Id))
+                                                    {
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatAnalysisFolderStatus(analysisLink)</MudText>
+                                                    }
                                                 </div>
                                                 @if (IsRegisteredForEvent(courseEvent.Id))
                                                 {
-                                                    <MudTooltip Text="@L["CancelRegistration"]">
-                                                        <MudIconButton Size="Size.Small"
-                                                                       Color="Color.Default"
-                                                                       Icon="@Icons.Material.Filled.Logout"
-                                                                       OnClick="@(() => CancelEventRegistrationAsync(course.Id, courseEvent.Id))"
-                                                                       aria-label="@L["CancelRegistration"]" />
-                                                    </MudTooltip>
+                                                    <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:4px;">
+                                                        @if (IsAnalysisFolderReady(analysisLink))
+                                                        {
+                                                            <MudTooltip Text="@L["OpenAnalysisFolder"]">
+                                                                <MudIconButton Size="Size.Small"
+                                                                               Color="Color.Primary"
+                                                                               Icon="@Icons.Material.Filled.FolderOpen"
+                                                                               OnClick="@(() => OpenAnalysisFolderAsync(analysisLink!.DriveFolderUrl!))"
+                                                                               aria-label="@L["OpenAnalysisFolder"]" />
+                                                            </MudTooltip>
+                                                        }
+
+                                                        <MudTooltip Text="@L["CancelRegistration"]">
+                                                            <MudIconButton Size="Size.Small"
+                                                                           Color="Color.Default"
+                                                                           Icon="@Icons.Material.Filled.Logout"
+                                                                           OnClick="@(() => CancelEventRegistrationAsync(course.Id, courseEvent.Id))"
+                                                                           aria-label="@L["CancelRegistration"]" />
+                                                        </MudTooltip>
+                                                    </MudStack>
                                                 }
                                                 else
                                                 {
@@ -295,6 +325,7 @@
     private IReadOnlyList<CourseOverview> _courses = Array.Empty<CourseOverview>();
     private Dictionary<string, IReadOnlyList<CourseEventDocument>> _eventsByCourse = new();
     private Dictionary<string, CourseEventRegistrationDocument> _registeredEvents = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, RunningAnalysisLink> _analysisLinksByExternalEventId = new(StringComparer.OrdinalIgnoreCase);
     private bool _isCoursePickerOpen;
     private bool _showAllDates;
     private bool _showAllEvents;
@@ -327,6 +358,9 @@
                 _courses = await CourseService.GetCoursesForAthleteAsync(_userId ?? string.Empty);
                 _eventsByCourse = new Dictionary<string, IReadOnlyList<CourseEventDocument>>();
                 _registeredEvents = new Dictionary<string, CourseEventRegistrationDocument>(StringComparer.OrdinalIgnoreCase);
+                _analysisLinksByExternalEventId = (await RunningAnalysisService.GetAnalysesForAthleteAsync(_userId ?? string.Empty))
+                    .GroupBy(analysis => analysis.ExternalEventId, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
 
                 foreach (var course in _courses.Where(course => course.IsJoined).Select(course => course.Course))
                 {
@@ -485,6 +519,47 @@
     private bool IsRegisteredForEvent(string eventId)
     {
         return _registeredEvents.ContainsKey(eventId);
+    }
+
+    private static bool IsRunningAnalysisEvent(CourseEventDocument courseEvent)
+    {
+        return string.Equals(courseEvent.EventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private RunningAnalysisLink? GetAnalysisLink(string eventId)
+    {
+        return _analysisLinksByExternalEventId.TryGetValue(eventId, out var analysis)
+            ? analysis
+            : null;
+    }
+
+    private static bool IsAnalysisFolderReady(RunningAnalysisLink? analysis)
+    {
+        return analysis?.FolderStatus == RunningAnalysisFolderStatus.Ready
+            && analysis.PermissionStatus == RunningAnalysisPermissionStatus.Granted
+            && !string.IsNullOrWhiteSpace(analysis.DriveFolderUrl);
+    }
+
+    private string FormatAnalysisFolderStatus(RunningAnalysisLink? analysis)
+    {
+        if (analysis is null)
+            return L["AnalysisPreparing"];
+
+        if (IsAnalysisFolderReady(analysis))
+            return L["AnalysisReady"];
+
+        if (analysis.FolderStatus == RunningAnalysisFolderStatus.Failed
+            || analysis.PermissionStatus == RunningAnalysisPermissionStatus.Failed)
+        {
+            return L["AnalysisFailed"];
+        }
+
+        return L["AnalysisPreparing"];
+    }
+
+    private Task OpenAnalysisFolderAsync(string folderUrl)
+    {
+        return JS.InvokeVoidAsync("open", folderUrl, "_blank").AsTask();
     }
 
     private void ResetDetailExpansion()

--- a/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
@@ -10,6 +10,7 @@
 @inject ITrainingPlanService TrainingPlanService
 @inject IAthleteData AthleteData
 @inject IJSRuntime JS
+@inject NavigationManager Navigation
 @inject ISnackbar Snackbar
 @inject LoadingStateService Loading
 @inject IStringLocalizer<CourseManagement> L
@@ -269,6 +270,16 @@
                                                                 }
                                                             </MudStack>
                                                             <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:4px;">
+                                                                @if (IsRunningAnalysisEvent(courseEvent))
+                                                                {
+                                                                    <MudButton Size="Size.Small"
+                                                                               Variant="Variant.Text"
+                                                                               Color="Color.Primary"
+                                                                               StartIcon="@Icons.Material.Filled.Videocam"
+                                                                               OnClick="@(() => OpenRunningAnalysis(course, courseEvent))">
+                                                                        @L["StartRunningAnalysis"]
+                                                                    </MudButton>
+                                                                }
                                                                 <MudButton Size="Size.Small"
                                                                            Variant="Variant.Text"
                                                                            Color="Color.Primary"
@@ -886,6 +897,16 @@
         return string.Equals(eventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase)
             ? Color.Primary
             : Color.Default;
+    }
+
+    private static bool IsRunningAnalysisEvent(CourseEventDocument courseEvent)
+    {
+        return string.Equals(courseEvent.EventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void OpenRunningAnalysis(CourseDocument course, CourseEventDocument courseEvent)
+    {
+        Navigation.NavigateTo($"/Trainers/courses/{course.Id}/events/{courseEvent.Id}/running-analysis");
     }
 
     private string GetTrainingPlanName(string trainingPlanId)

--- a/PaceLetics.Web/Pages/Trainers/RunningAnalysisSession.razor
+++ b/PaceLetics.Web/Pages/Trainers/RunningAnalysisSession.razor
@@ -1,0 +1,411 @@
+@page "/Trainers/courses/{CourseId}/events/{EventId}/running-analysis"
+@attribute [Authorize(Roles = ApplicationRoles.Trainer)]
+@implements IAsyncDisposable
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Enums
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models
+@using PaceLetics.RunningAnalysisModule.Components
+@using PaceLetics.Web.Services.Courses
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ICourseService CourseService
+@inject IRunningAnalysisService RunningAnalysisService
+@inject IJSRuntime JS
+@inject NavigationManager Navigation
+@inject ISnackbar Snackbar
+@inject LoadingStateService Loading
+@inject IStringLocalizer<RunningAnalysisSession> L
+
+<PageTitle>@L["PageTitle"]</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Medium">
+    <MudStack Spacing="3">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+            <PageHeader Title="@(_courseEvent?.Title ?? L["Title"].ToString())"
+                        Subtitle="@GetHeaderSubtitle()" />
+
+            <MudButton Variant="Variant.Text"
+                       StartIcon="@Icons.Material.Filled.ArrowBack"
+                       OnClick="@(() => Navigation.NavigateTo("/Trainers/courses"))">
+                @L["BackToCourses"]
+            </MudButton>
+        </MudStack>
+
+        @if (!string.IsNullOrWhiteSpace(_errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_errorMessage</MudAlert>
+        }
+        else if (_analysisEvent is not null)
+        {
+            <MudPaper Elevation="1" Class="pa-4">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:8px; flex-wrap:wrap;">
+                        <MudChip T="string" Size="Size.Small" Color="@GetStatusColor()" Variant="Variant.Outlined">
+                            @FormatStatus(_analysisEvent.Status)
+                        </MudChip>
+                        <MudChip T="string"
+                                 Size="Size.Small"
+                                 Color="@(_isOnline ? Color.Success : Color.Error)"
+                                 Variant="Variant.Outlined">
+                            @(_isOnline ? L["Online"] : L["Offline"])
+                        </MudChip>
+                    </MudStack>
+
+                    <MudStack Row="true" Style="gap:8px; flex-wrap:wrap;">
+                        @if (_analysisEvent.Status != RunningAnalysisEventStatus.InProgress
+                             && _analysisEvent.Status != RunningAnalysisEventStatus.Completed)
+                        {
+                            <MudButton Color="Color.Primary"
+                                       Variant="Variant.Filled"
+                                       StartIcon="@Icons.Material.Filled.PlayArrow"
+                                       OnClick="StartAnalysisAsync">
+                                @L["StartAnalysis"]
+                            </MudButton>
+                        }
+
+                        @if (_analysisEvent.Status != RunningAnalysisEventStatus.Completed)
+                        {
+                            <MudButton Color="Color.Primary"
+                                       Variant="Variant.Outlined"
+                                       StartIcon="@Icons.Material.Filled.DoneAll"
+                                       OnClick="CompleteAnalysisAsync">
+                                @L["CompleteAnalysis"]
+                            </MudButton>
+                        }
+                    </MudStack>
+                </MudStack>
+            </MudPaper>
+
+            @if (_analysisEvent.Status == RunningAnalysisEventStatus.Completed)
+            {
+                <MudAlert Severity="Severity.Success" Variant="Variant.Outlined">
+                    @L["CompletedMessage"]
+                </MudAlert>
+            }
+
+            @if (_isCaptureMode && CurrentParticipant is not null)
+            {
+                <RunningAnalysisCapturePanel ParticipantName="@CurrentParticipant.DisplayName"
+                                             IsOnline="@(_isOnline && _analysisEvent.Status != RunningAnalysisEventStatus.Completed)"
+                                             IsRecording="_isRecording"
+                                             OnStartRecording="EnsureAnalysisStartedAsync"
+                                             OnStopRecording="OnStopRecordingAsync"
+                                             OnRecorded="UploadRecordingAsync"
+                                             IsRecordingChanged="OnRecordingChangedAsync"
+                                             OnRetake="RetakeAsync"
+                                             OnNextParticipant="NextParticipantAsync"
+                                             OnBackToRoster="BackToRosterAsync" />
+            }
+            else
+            {
+                <MudPaper Elevation="1" Class="pa-4">
+                    <MudStack Spacing="2">
+                        <MudText Typo="Typo.h6">@L["Roster"]</MudText>
+                        <RunningAnalysisRoster Items="_roster"
+                                               SelectedParticipantId="_selectedParticipantId"
+                                               SelectedParticipantIdChanged="OnParticipantSelectedAsync"
+                                               OnRecord="OpenCaptureAsync" />
+                    </MudStack>
+                </MudPaper>
+            }
+        }
+    </MudStack>
+</MudContainer>
+
+@code {
+    [Parameter] public string? CourseId { get; set; }
+    [Parameter] public string? EventId { get; set; }
+
+    private string? _userId;
+    private string? _errorMessage;
+    private CourseDocument? _course;
+    private CourseEventDocument? _courseEvent;
+    private RunningAnalysisEvent? _analysisEvent;
+    private IReadOnlyList<RunningAnalysisRosterItem> _roster = Array.Empty<RunningAnalysisRosterItem>();
+    private string? _selectedParticipantId;
+    private bool _isCaptureMode;
+    private bool _isRecording;
+    private bool _isOnline = true;
+    private IJSObjectReference? _recorderModule;
+
+    private RunningAnalysisRosterItem? CurrentParticipant =>
+        string.IsNullOrWhiteSpace(_selectedParticipantId)
+            ? null
+            : _roster.FirstOrDefault(participant => participant.ParticipantId == _selectedParticipantId);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        await Loading.RunAsync(L["Loading"], async () =>
+        {
+            try
+            {
+                _errorMessage = null;
+                await RefreshOnlineStateAsync();
+
+                var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                _userId = authState.User.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
+
+                if (string.IsNullOrWhiteSpace(_userId))
+                    throw new InvalidOperationException(L["TrainerNotResolved"]);
+
+                var courses = await CourseService.GetCoursesForTrainerAsync(_userId);
+                _course = courses.FirstOrDefault(course => course.Id == CourseId)
+                    ?? throw new InvalidOperationException(L["CourseNotFound"]);
+
+                var events = await CourseService.GetEventsAsync(_course.Id);
+                _courseEvent = events.FirstOrDefault(courseEvent => courseEvent.Id == EventId)
+                    ?? throw new InvalidOperationException(L["EventNotFound"]);
+
+                if (!string.Equals(_courseEvent.EventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException(L["NotRunningAnalysis"]);
+
+                _analysisEvent = await RunningAnalysisService.PrepareEventAsync(
+                    new RunningAnalysisEventRequest(
+                        _courseEvent.Id,
+                        _course.Id,
+                        _courseEvent.Title,
+                        _courseEvent.StartsAt,
+                        _courseEvent.EndsAt));
+
+                await LoadRosterAsync();
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                _roster = Array.Empty<RunningAnalysisRosterItem>();
+            }
+        });
+    }
+
+    private async Task LoadRosterAsync()
+    {
+        if (_analysisEvent is null)
+            return;
+
+        _roster = await RunningAnalysisService.GetRosterAsync(_analysisEvent.Id);
+
+        if (!string.IsNullOrWhiteSpace(_selectedParticipantId)
+            && _roster.All(participant => participant.ParticipantId != _selectedParticipantId))
+        {
+            _selectedParticipantId = null;
+            _isCaptureMode = false;
+        }
+    }
+
+    private async Task StartAnalysisAsync()
+    {
+        if (_analysisEvent is null)
+            return;
+
+        try
+        {
+            _analysisEvent = await RunningAnalysisService.StartAnalysisAsync(_analysisEvent.Id);
+            Snackbar.Add(L["StartSuccess"], Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task EnsureAnalysisStartedAsync()
+    {
+        await RefreshOnlineStateAsync();
+
+        if (_analysisEvent is null
+            || _analysisEvent.Status == RunningAnalysisEventStatus.InProgress)
+        {
+            return;
+        }
+
+        if (_analysisEvent.Status == RunningAnalysisEventStatus.Completed)
+            throw new InvalidOperationException(L["CompletedCannotRecord"]);
+
+        _analysisEvent = await RunningAnalysisService.StartAnalysisAsync(_analysisEvent.Id);
+    }
+
+    private async Task CompleteAnalysisAsync()
+    {
+        if (_analysisEvent is null)
+            return;
+
+        var confirmed = await JS.InvokeAsync<bool>("confirm", L["CompleteConfirm"].ToString());
+        if (!confirmed)
+            return;
+
+        try
+        {
+            _analysisEvent = await RunningAnalysisService.CompleteAnalysisAsync(_analysisEvent.Id);
+            _isCaptureMode = false;
+            _isRecording = false;
+            Snackbar.Add(L["CompleteSuccess"], Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private Task OnParticipantSelectedAsync(string participantId)
+    {
+        _selectedParticipantId = participantId;
+        return Task.CompletedTask;
+    }
+
+    private async Task OpenCaptureAsync(string participantId)
+    {
+        await RefreshOnlineStateAsync();
+        _selectedParticipantId = participantId;
+        _isCaptureMode = true;
+    }
+
+    private Task BackToRosterAsync()
+    {
+        _isCaptureMode = false;
+        return Task.CompletedTask;
+    }
+
+    private Task OnRecordingChangedAsync(bool isRecording)
+    {
+        _isRecording = isRecording;
+        return Task.CompletedTask;
+    }
+
+    private Task OnStopRecordingAsync()
+    {
+        _isRecording = false;
+        return Task.CompletedTask;
+    }
+
+    private Task RetakeAsync()
+    {
+        Snackbar.Add(L["RetakeHint"], Severity.Info);
+        return Task.CompletedTask;
+    }
+
+    private async Task NextParticipantAsync()
+    {
+        if (_roster.Count == 0)
+        {
+            _isCaptureMode = false;
+            return;
+        }
+
+        var currentIndex = _roster.ToList().FindIndex(participant => participant.ParticipantId == _selectedParticipantId);
+        var next = currentIndex >= 0 && currentIndex < _roster.Count - 1
+            ? _roster[currentIndex + 1]
+            : null;
+
+        if (next is null)
+        {
+            _isCaptureMode = false;
+            Snackbar.Add(L["NoNextParticipant"], Severity.Info);
+            return;
+        }
+
+        await OpenCaptureAsync(next.ParticipantId);
+    }
+
+    private async Task UploadRecordingAsync(RunningAnalysisRecordedVideo video)
+    {
+        if (_analysisEvent is null || CurrentParticipant is null)
+            return;
+
+        await RefreshOnlineStateAsync();
+
+        try
+        {
+            using var content = new MemoryStream(video.Data);
+            var recording = await RunningAnalysisService.UploadRecordingAsync(
+                _analysisEvent.Id,
+                CurrentParticipant.ParticipantId,
+                BuildFileName(CurrentParticipant, video.FileExtension),
+                video.ContentType,
+                content,
+                _isOnline);
+
+            await LoadRosterAsync();
+
+            if (recording.UploadStatus == RunningAnalysisUploadStatus.Uploaded)
+            {
+                Snackbar.Add(L["UploadSuccess"], Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add(recording.ErrorMessage ?? L["UploadFailed"], Severity.Warning);
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task RefreshOnlineStateAsync()
+    {
+        try
+        {
+            _recorderModule ??= await JS.InvokeAsync<IJSObjectReference>(
+                "import",
+                "./_content/PaceLetics.RunningAnalysisModule.Components/runningAnalysisMediaRecorder.js");
+            _isOnline = await _recorderModule.InvokeAsync<bool>("isOnline");
+        }
+        catch
+        {
+            _isOnline = true;
+        }
+    }
+
+    private string GetHeaderSubtitle()
+    {
+        if (_course is null || _courseEvent is null)
+            return L["Subtitle"];
+
+        return string.Format(L["SubtitleWithCourse"], _course.Name, _courseEvent.StartsAt, _courseEvent.EndsAt);
+    }
+
+    private Color GetStatusColor()
+    {
+        return _analysisEvent?.Status switch
+        {
+            RunningAnalysisEventStatus.InProgress => Color.Primary,
+            RunningAnalysisEventStatus.Completed => Color.Success,
+            RunningAnalysisEventStatus.Prepared => Color.Info,
+            _ => Color.Default
+        };
+    }
+
+    private string FormatStatus(RunningAnalysisEventStatus status)
+    {
+        return status switch
+        {
+            RunningAnalysisEventStatus.Prepared => L["Status_Prepared"],
+            RunningAnalysisEventStatus.InProgress => L["Status_InProgress"],
+            RunningAnalysisEventStatus.Completed => L["Status_Completed"],
+            _ => L["Status_Draft"]
+        };
+    }
+
+    private static string BuildFileName(RunningAnalysisRosterItem participant, string extension)
+    {
+        var safeName = new string(participant.DisplayName
+            .Trim()
+            .Select(character => char.IsLetterOrDigit(character) ? character : '-')
+            .ToArray());
+
+        safeName = string.IsNullOrWhiteSpace(safeName) ? participant.ParticipantId : safeName;
+        extension = string.IsNullOrWhiteSpace(extension) ? "webm" : extension.Trim().TrimStart('.');
+
+        return $"{DateTime.UtcNow:yyyyMMdd-HHmmss}-{safeName}.{extension}";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_recorderModule is not null)
+            await _recorderModule.DisposeAsync();
+    }
+}

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyAnalyses.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyAnalyses.de.resx
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Meine Analysen</value></data>
+  <data name="Title" xml:space="preserve"><value>Meine Analysen</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Deine freigegebenen Laufanalyse-Ordner</value></data>
+  <data name="Loading" xml:space="preserve"><value>Analysen werden geladen</value></data>
+  <data name="NoAnalyses" xml:space="preserve"><value>Noch keine Analysen verfuegbar.</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Ordner oeffnen</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>Athlet:in konnte nicht ermittelt werden.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyAnalyses.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyAnalyses.en.resx
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>My analyses</value></data>
+  <data name="Title" xml:space="preserve"><value>My analyses</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Your shared running analysis folders</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading analyses</value></data>
+  <data name="NoAnalyses" xml:space="preserve"><value>No analyses available yet.</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>The athlete could not be resolved.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.de.resx
@@ -24,6 +24,11 @@
   <data name="ShowLess" xml:space="preserve"><value>Weniger</value></data>
   <data name="NoUpcomingDates" xml:space="preserve"><value>Keine kommenden Termine.</value></data>
   <data name="NoEvents" xml:space="preserve"><value>Aktuell sind keine Events eingestellt.</value></data>
+  <data name="RunningAnalysis" xml:space="preserve"><value>Laufanalyse</value></data>
+  <data name="AnalysisPreparing" xml:space="preserve"><value>Analyseordner wird vorbereitet.</value></data>
+  <data name="AnalysisReady" xml:space="preserve"><value>Analyseordner ist bereit.</value></data>
+  <data name="AnalysisFailed" xml:space="preserve"><value>Analyseordner konnte nicht vorbereitet werden.</value></data>
+  <data name="OpenAnalysisFolder" xml:space="preserve"><value>Analyseordner oeffnen</value></data>
   <data name="CancelRegistration" xml:space="preserve"><value>Abmelden</value></data>
   <data name="Register" xml:space="preserve"><value>Anmelden</value></data>
   <data name="NoTrainingPlans" xml:space="preserve"><value>Noch keine Trainingsplaene veroeffentlicht.</value></data>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.en.resx
@@ -24,6 +24,11 @@
   <data name="ShowLess" xml:space="preserve"><value>Less</value></data>
   <data name="NoUpcomingDates" xml:space="preserve"><value>No upcoming dates.</value></data>
   <data name="NoEvents" xml:space="preserve"><value>No events are currently listed.</value></data>
+  <data name="RunningAnalysis" xml:space="preserve"><value>Running analysis</value></data>
+  <data name="AnalysisPreparing" xml:space="preserve"><value>Analysis folder is being prepared.</value></data>
+  <data name="AnalysisReady" xml:space="preserve"><value>Analysis folder is ready.</value></data>
+  <data name="AnalysisFailed" xml:space="preserve"><value>Analysis folder could not be prepared.</value></data>
+  <data name="OpenAnalysisFolder" xml:space="preserve"><value>Open analysis folder</value></data>
   <data name="CancelRegistration" xml:space="preserve"><value>Cancel</value></data>
   <data name="Register" xml:space="preserve"><value>Register</value></data>
   <data name="NoTrainingPlans" xml:space="preserve"><value>No training plans published yet.</value></data>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
@@ -38,6 +38,7 @@
   <data name="EventType" xml:space="preserve"><value>Eventtyp</value></data>
   <data name="EventType_General" xml:space="preserve"><value>Allgemein</value></data>
   <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Laufanalyse</value></data>
+  <data name="StartRunningAnalysis" xml:space="preserve"><value>Analyse starten</value></data>
   <data name="AddEvent" xml:space="preserve"><value>Event hinzufuegen</value></data>
   <data name="TrainingPlans" xml:space="preserve"><value>Trainingsplaene</value></data>
   <data name="NoPublishedPlan" xml:space="preserve"><value>Noch kein Plan veroeffentlicht.</value></data>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.en.resx
@@ -38,6 +38,7 @@
   <data name="EventType" xml:space="preserve"><value>Event type</value></data>
   <data name="EventType_General" xml:space="preserve"><value>General</value></data>
   <data name="EventType_RunningAnalysis" xml:space="preserve"><value>Running analysis</value></data>
+  <data name="StartRunningAnalysis" xml:space="preserve"><value>Start analysis</value></data>
   <data name="AddEvent" xml:space="preserve"><value>Add event</value></data>
   <data name="TrainingPlans" xml:space="preserve"><value>Training plans</value></data>
   <data name="NoPublishedPlan" xml:space="preserve"><value>No plan published yet.</value></data>

--- a/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalysisSession.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalysisSession.de.resx
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Laufanalyse</value></data>
+  <data name="Title" xml:space="preserve"><value>Laufanalyse</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Laufanalyse durchfuehren</value></data>
+  <data name="SubtitleWithCourse" xml:space="preserve"><value>{0}, {1:dd.MM.yyyy HH:mm} bis {2:HH:mm} Uhr</value></data>
+  <data name="Loading" xml:space="preserve"><value>Laufanalyse wird geladen</value></data>
+  <data name="BackToCourses" xml:space="preserve"><value>Zurueck zu Kursen</value></data>
+  <data name="Online" xml:space="preserve"><value>Online</value></data>
+  <data name="Offline" xml:space="preserve"><value>Offline</value></data>
+  <data name="StartAnalysis" xml:space="preserve"><value>Analyse starten</value></data>
+  <data name="CompleteAnalysis" xml:space="preserve"><value>Analyse abschliessen</value></data>
+  <data name="CompletedMessage" xml:space="preserve"><value>Analyse abgeschlossen.</value></data>
+  <data name="Roster" xml:space="preserve"><value>Teilnehmende</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>Trainer:in konnte nicht ermittelt werden.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>Der Kurs wurde nicht gefunden.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>Das Event wurde nicht gefunden.</value></data>
+  <data name="NotRunningAnalysis" xml:space="preserve"><value>Dieses Event ist keine Laufanalyse.</value></data>
+  <data name="Status_Draft" xml:space="preserve"><value>Entwurf</value></data>
+  <data name="Status_Prepared" xml:space="preserve"><value>Vorbereitet</value></data>
+  <data name="Status_InProgress" xml:space="preserve"><value>Laeuft</value></data>
+  <data name="Status_Completed" xml:space="preserve"><value>Abgeschlossen</value></data>
+  <data name="StartSuccess" xml:space="preserve"><value>Analyse wurde gestartet.</value></data>
+  <data name="CompleteConfirm" xml:space="preserve"><value>Analyse wirklich abschliessen?</value></data>
+  <data name="CompleteSuccess" xml:space="preserve"><value>Analyse wurde abgeschlossen.</value></data>
+  <data name="CompletedCannotRecord" xml:space="preserve"><value>Eine abgeschlossene Analyse kann nicht erneut aufnehmen.</value></data>
+  <data name="RetakeHint" xml:space="preserve"><value>Starte die Aufnahme erneut fuer diesen Teilnehmenden.</value></data>
+  <data name="NoNextParticipant" xml:space="preserve"><value>Keine weiteren Teilnehmenden.</value></data>
+  <data name="UploadSuccess" xml:space="preserve"><value>Aufnahme wurde hochgeladen.</value></data>
+  <data name="UploadFailed" xml:space="preserve"><value>Upload fehlgeschlagen.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalysisSession.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalysisSession.en.resx
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Running analysis</value></data>
+  <data name="Title" xml:space="preserve"><value>Running analysis</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Run the analysis session</value></data>
+  <data name="SubtitleWithCourse" xml:space="preserve"><value>{0}, {1:MM/dd/yyyy HH:mm} to {2:HH:mm}</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading running analysis</value></data>
+  <data name="BackToCourses" xml:space="preserve"><value>Back to courses</value></data>
+  <data name="Online" xml:space="preserve"><value>Online</value></data>
+  <data name="Offline" xml:space="preserve"><value>Offline</value></data>
+  <data name="StartAnalysis" xml:space="preserve"><value>Start analysis</value></data>
+  <data name="CompleteAnalysis" xml:space="preserve"><value>Complete analysis</value></data>
+  <data name="CompletedMessage" xml:space="preserve"><value>Analysis completed.</value></data>
+  <data name="Roster" xml:space="preserve"><value>Participants</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>The coach could not be resolved.</value></data>
+  <data name="CourseNotFound" xml:space="preserve"><value>The course was not found.</value></data>
+  <data name="EventNotFound" xml:space="preserve"><value>The event was not found.</value></data>
+  <data name="NotRunningAnalysis" xml:space="preserve"><value>This event is not a running analysis.</value></data>
+  <data name="Status_Draft" xml:space="preserve"><value>Draft</value></data>
+  <data name="Status_Prepared" xml:space="preserve"><value>Prepared</value></data>
+  <data name="Status_InProgress" xml:space="preserve"><value>In progress</value></data>
+  <data name="Status_Completed" xml:space="preserve"><value>Completed</value></data>
+  <data name="StartSuccess" xml:space="preserve"><value>Analysis was started.</value></data>
+  <data name="CompleteConfirm" xml:space="preserve"><value>Complete this analysis?</value></data>
+  <data name="CompleteSuccess" xml:space="preserve"><value>Analysis was completed.</value></data>
+  <data name="CompletedCannotRecord" xml:space="preserve"><value>A completed analysis cannot record again.</value></data>
+  <data name="RetakeHint" xml:space="preserve"><value>Start recording again for this participant.</value></data>
+  <data name="NoNextParticipant" xml:space="preserve"><value>No more participants.</value></data>
+  <data name="UploadSuccess" xml:space="preserve"><value>Recording was uploaded.</value></data>
+  <data name="UploadFailed" xml:space="preserve"><value>Upload failed.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Laufdaten</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pacebereiche</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>Meine Kurse</value></data>
+  <data name="Nav_Analyses" xml:space="preserve"><value>Meine Analysen</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Kurse verwalten</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Trainingsplanung</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
+  <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
+  <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>

--- a/PaceLetics.Web/Shared/NavMenu.razor
+++ b/PaceLetics.Web/Shared/NavMenu.razor
@@ -5,6 +5,7 @@
     <MudNavLink Href="/Athletes/racepaces" Match="NavLinkMatch.Prefix">@L["Nav_RaceData"]</MudNavLink>
     <MudNavLink Href="/Athletes/trainingpaces" Match="NavLinkMatch.Prefix">@L["Nav_PaceZones"]</MudNavLink>
     <MudNavLink Href="/Athletes/courses" Match="NavLinkMatch.Prefix">@L["Nav_Courses"]</MudNavLink>
+    <MudNavLink Href="/Athletes/analyses" Match="NavLinkMatch.Prefix">@L["Nav_Analyses"]</MudNavLink>
     <AuthorizeView Roles="@ApplicationRoles.Trainer">
         <Authorized>
             <MudNavLink Href="/Trainers/courses" Match="NavLinkMatch.Prefix">@L["Nav_TrainerCourses"]</MudNavLink>


### PR DESCRIPTION
Implemented the app integration for the running analysis module.

What changed:

Added a trainer workflow to start running analyses from course events.
Added a dedicated trainer session page with participant roster, camera recording, upload handling, retake/next controls, and completion state.
Added a new athlete page, “My Analyses”, showing shared Google Drive analysis folders.
Added navigation entry for “My Analyses”.
Extended MyCourses to mark running analysis events, show folder preparation status, and link to the Drive folder once ready.
Added PrepareEventAsync to the running analysis service so analysis events can be initialized before the first participant registration.
Added localization for the new trainer and athlete UI.
Verification:

dotnet build PaceLeticsFramework.sln --no-restore passed.
dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore passed: 108/108 tests.
Local app responds on http://localhost:5218.