### PR TITLE
Codex/running analysis trainer entry and secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,10 @@ FodyWeavers.xsd
 /WorkoutTest/WorkoutTest.csproj
 /WorkoutTest/Program.cs
 /ModelTests
+
+# Local app configuration and Google Drive secrets
+PaceLetics.Web/appsettings.Local.json
+PaceLetics.Web/appsettings.*.Local.json
+*service-account*.json
+*google-drive-credentials*.json
+.secrets/

--- a/PaceLetics.RunningAnalysisModule.CodeBase/README.md
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/README.md
@@ -31,6 +31,29 @@ for an event of type `RunningAnalysis`.
 - `IRunningAnalysisClock`
   Keeps time-dependent behavior testable.
 
+## Google Drive Credentials
+
+Do not place a Google service-account key in `PaceLetics.Web/appsettings.json`.
+The repository only contains non-secret defaults. Configure real credentials
+through one of these untracked channels:
+
+```powershell
+dotnet user-secrets set "RunningAnalysis:GoogleDrive:RootFolderId" "<central-folder-id>" --project PaceLetics.Web
+dotnet user-secrets set "RunningAnalysis:GoogleDrive:ServiceAccountJsonPath" "C:\secure\paceletics-google-drive-service-account.json" --project PaceLetics.Web
+```
+
+or environment variables:
+
+```powershell
+$env:RunningAnalysis__GoogleDrive__RootFolderId = "<central-folder-id>"
+$env:RunningAnalysis__GoogleDrive__ServiceAccountJsonPath = "C:\secure\paceletics-google-drive-service-account.json"
+```
+
+For local development only, copy `PaceLetics.Web/appsettings.Local.example.json`
+to `PaceLetics.Web/appsettings.Local.json`. The local file is ignored by git.
+Share the central Google Drive folder with the service-account email and set its
+folder id as `RunningAnalysis:GoogleDrive:RootFolderId`.
+
 ## Next Adapters
 
 - Course event adapter: call registration when an athlete registers for a running

--- a/PaceLetics.RunningAnalysisModule.CodeBase/README.md
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/README.md
@@ -296,30 +296,31 @@ Die Konfiguration liegt im Abschnitt:
 
 ```json
 {
-  "RunningAnalysis": {
-    "GoogleDrive": {
-      "ApplicationName": "PaceLetics",
-      "RootFolderId": "",
-      "RootFolderName": "PaceLetics Laufanalysen"
-    }
+  "PaceLeticsUserData": {
+    "ApplicationName": "PaceLetics",
+    "RootFolderId": "",
+    "RootFolderName": "paceletics_user_data"
   }
 }
 ```
 
 Echte Zugangsdaten duerfen nicht in `PaceLetics.Web/appsettings.json`.
 Die getrackte Datei enthaelt nur nicht-geheime Defaults.
+Die neue primaere Konfiguration heisst `PaceLeticsUserData`. Alte Werte unter
+`RunningAnalysis:GoogleDrive` werden noch als Fallback gelesen, damit bestehende
+Umgebungen nicht sofort brechen.
 
 ### Empfohlene lokale Konfiguration mit User-Secrets
 
 ```powershell
-dotnet user-secrets set "RunningAnalysis:GoogleDrive:RootFolderId" "<central-folder-id>" --project PaceLetics.Web
-dotnet user-secrets set "RunningAnalysis:GoogleDrive:ServiceAccountJsonPath" "C:\secure\paceletics-google-drive-service-account.json" --project PaceLetics.Web
+dotnet user-secrets set "PaceLeticsUserData:RootFolderId" "<central-folder-id>" --project PaceLetics.Web
+dotnet user-secrets set "PaceLeticsUserData:ServiceAccountJsonPath" "C:\secure\paceletics-google-drive-service-account.json" --project PaceLetics.Web
 ```
 
 Alternativ kann der komplette JSON-Inhalt gesetzt werden:
 
 ```powershell
-dotnet user-secrets set "RunningAnalysis:GoogleDrive:ServiceAccountJson" "<service-account-json>" --project PaceLetics.Web
+dotnet user-secrets set "PaceLeticsUserData:ServiceAccountJson" "<service-account-json>" --project PaceLetics.Web
 ```
 
 Das ist praktisch fuer Hosting-Umgebungen, aber fuer lokale Entwicklung ist ein
@@ -328,14 +329,14 @@ Dateipfad meist lesbarer.
 ### Konfiguration mit Environment-Variablen
 
 ```powershell
-$env:RunningAnalysis__GoogleDrive__RootFolderId = "<central-folder-id>"
-$env:RunningAnalysis__GoogleDrive__ServiceAccountJsonPath = "C:\secure\paceletics-google-drive-service-account.json"
+$env:PaceLeticsUserData__RootFolderId = "<central-folder-id>"
+$env:PaceLeticsUserData__ServiceAccountJsonPath = "C:\secure\paceletics-google-drive-service-account.json"
 ```
 
 oder:
 
 ```powershell
-$env:RunningAnalysis__GoogleDrive__ServiceAccountJson = "<service-account-json>"
+$env:PaceLeticsUserData__ServiceAccountJson = "<service-account-json>"
 ```
 
 ### Lokale Datei fuer Entwicklung
@@ -356,7 +357,7 @@ optional geladen.
 5. Zentralen Drive-Ordner erstellen.
 6. Zentralen Drive-Ordner mit der Service-Account-E-Mail teilen.
 7. Die Folder-ID des zentralen Ordners als
-   `RunningAnalysis:GoogleDrive:RootFolderId` konfigurieren.
+   `PaceLeticsUserData:RootFolderId` konfigurieren.
 
 Ohne `RootFolderId` versucht der Adapter, einen Root-Ordner ueber
 `RootFolderName` zu finden oder anzulegen. Fuer produktive Nutzung ist eine

--- a/PaceLetics.RunningAnalysisModule.CodeBase/README.md
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/README.md
@@ -1,64 +1,510 @@
-# Running Analysis Module
+# Laufanalyse-Modul
 
-This module owns the running-analysis workflow independently from the course module.
-The course/event system should integrate through a thin adapter that calls
-`IRunningAnalysisService.RegisterParticipantAsync` after a participant registers
-for an event of type `RunningAnalysis`.
+Das Laufanalyse-Modul bildet einen eigenstaendigen Workflow fuer
+Laufanalyse-Events ab. Die Kursverwaltung bleibt die Quelle fuer Kurse, Events
+und Registrierungen. Das Laufanalyse-Modul uebernimmt danach die Analyse-spezifischen
+Aufgaben: Teilnehmende verwalten, Google-Drive-Ordner bereitstellen,
+Kameraaufnahmen hochladen und Analyse-Links fuer Athletes anzeigen.
 
-## Implemented Core Rules
+## Zielbild
 
-- A running-analysis event is created or updated from an external event id.
-- Participant provisioning starts during registration.
-- Existing participant folders can be reused through `IUserDriveFolderRegistry`.
-- New participant folders are created in one central Drive area through
-  `IRunningAnalysisStorageProvider`.
-- Participant folders are shared with participant write access.
-- Provisioning failures do not cancel the registration. The participant is stored
-  with failed folder/permission status and can be retried by a later adapter.
-- Recordings require an online connection.
-- A recording only becomes primary after a successful upload.
-- Failed uploads are stored, but they do not replace the current primary recording.
+- Trainer erstellen in einem Kurs ein Event vom Typ `RunningAnalysis`.
+- Athletes registrieren sich fuer dieses Event.
+- Bei der Registrierung wird ein persoenlicher Google-Drive-Ordner vorbereitet.
+- Athletes sehen den Ordnerlink unter `Meine Analysen`.
+- Trainer starten am Analysetag die Session, waehlen Teilnehmende aus und nehmen
+  Videos im Browser auf.
+- Jede erfolgreiche Aufnahme wird in den persoenlichen Drive-Ordner des
+  Teilnehmenden hochgeladen und als primaere Aufnahme markiert.
+- Der Workflow benoetigt fuer Aufnahme und Upload eine Online-Verbindung.
 
-## Integration Ports
+## Projektstruktur
 
-- `IRunningAnalysisRepository`
-  Persists analysis events, participants, and recordings.
-- `IRunningAnalysisStorageProvider`
-  Creates Drive folders, grants permissions, and uploads recordings.
-- `IUserDriveFolderRegistry`
-  Finds reusable folders from this or other modules and records newly created
-  participant folders.
-- `IRunningAnalysisClock`
-  Keeps time-dependent behavior testable.
+- `PaceLetics.RunningAnalysisModule.CodeBase`
+  Enthaelt Domain-Modelle, Service-Interfaces, Kernlogik und Regeln.
+- `PaceLetics.RunningAnalysisModule.Components`
+  Enthaelt wiederverwendbare Razor-Komponenten fuer Roster, Linkliste,
+  Kameraansicht und Browser-MediaRecorder.
+- `PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive`
+  Implementiert den Storage-Port fuer Google Drive.
+- `PaceLetics.Web.Services.RunningAnalysis`
+  Verbindet das Modul mit Cosmos DB, Kursregistrierungen und der Web-App.
+- `PaceLetics.Web.Pages.Trainers`
+  Stellt Trainer-Uebersicht und Analyse-Session bereit.
+- `PaceLetics.Web.Pages.Athletes`
+  Stellt Kursregistrierung und Analyse-Links fuer Athletes bereit.
 
-## Google Drive Credentials
+## Rollen und Navigation
 
-Do not place a Google service-account key in `PaceLetics.Web/appsettings.json`.
-The repository only contains non-secret defaults. Configure real credentials
-through one of these untracked channels:
+### Trainer
+
+Trainer benoetigen die ASP.NET-Identity-Rolle `ApplicationRoles.Trainer`.
+Nur dann erscheinen die Trainerbereiche in der Navigation.
+
+Wichtige Seiten:
+
+- `/Trainers/courses`
+  Kursverwaltung. Hier werden Kurse, Termine und Events gepflegt.
+- `/Trainers/running-analyses`
+  Direkte Uebersicht aller Laufanalyse-Events der eigenen Trainerkurse.
+- `/Trainers/courses/{CourseId}/events/{EventId}/running-analysis`
+  Durchfuehrung einer konkreten Laufanalyse-Session.
+
+### Athlete
+
+Athletes benoetigen nur eine normale Anmeldung. Sie nutzen:
+
+- `/Athletes/courses`
+  Kursbeitritt, Eventregistrierung und eventbezogener Ordnerstatus.
+- `/Athletes/analyses`
+  Uebersicht der eigenen Analyse-Ordnerlinks.
+
+Trainer koennen gleichzeitig Athlete sein. Deshalb kann ein Trainer sowohl
+`Meine Analysen` als auch `Laufanalysen` sehen.
+
+## Bedienung fuer Trainer
+
+### 1. Laufanalyse-Event erstellen
+
+1. Als Trainer anmelden.
+2. `Kurse verwalten` oeffnen.
+3. Einen Kurs auswaehlen oder erstellen.
+4. Im Eventbereich ein neues Event anlegen.
+5. Als Eventtyp `Laufanalyse` auswaehlen.
+6. Titel, Start, Ende, optional Ort, Beschreibung, Kapazitaet und Deadline
+   setzen.
+7. Event speichern.
+
+Das Event ist ab dann fuer Athletes im Kurs sichtbar. Erst bei der
+Athlete-Registrierung werden Teilnehmende und Drive-Ordner vorbereitet.
+
+### 2. Drive-Konfiguration pruefen
+
+Die Seite `Laufanalysen` zeigt Warnungen, wenn Google Drive noch nicht
+konfiguriert ist:
+
+- Fehlende Service-Account-Zugangsdaten verhindern Ordneranlage, Freigaben und
+  Uploads.
+- Eine fehlende `RootFolderId` ist nicht zwingend blockierend. Dann versucht der
+  Adapter, den Root-Ordner ueber den konfigurierten Namen zu finden oder
+  anzulegen.
+
+Der Drive-Zugang ist zentral. Es gibt keinen eigenen Drive-Account pro Trainer.
+Das Modul schreibt mit einem Service Account in einen zentralen Drive-Bereich.
+Teilnehmende bekommen nur Links auf ihre freigegebenen Ordner.
+
+### 3. Analyse starten
+
+Es gibt zwei Einstiege:
+
+1. `Laufanalysen` oeffnen und beim passenden Event `Analyse starten` waehlen.
+2. Oder `Kurse verwalten` oeffnen, im Eventbereich das Laufanalyse-Event suchen
+   und dort `Analyse starten` waehlen.
+
+Beim Oeffnen der Session wird das Laufanalyse-Event vorbereitet oder aktualisiert.
+Die Session zeigt:
+
+- Eventstatus: `Entwurf`, `Vorbereitet`, `Laeuft`, `Abgeschlossen`.
+- Online-Status des Browsers.
+- Roster aller registrierten Teilnehmenden.
+- Aufnahmeaktionen fuer den ausgewaehlten Teilnehmenden.
+
+### 4. Teilnehmende aufnehmen
+
+1. In der Roster-Liste einen Teilnehmenden auswaehlen.
+2. `Record` bzw. die Aufnahmeaktion oeffnen.
+3. Browser-Kamera freigeben.
+4. `Start` druecken.
+5. Teilnehmenden vorbeilaufen lassen.
+6. `Stop` druecken.
+7. Die Aufnahme wird automatisch hochgeladen.
+
+Danach stehen zur Verfuegung:
+
+- `Again`
+  Beim selben Teilnehmenden bleiben und eine weitere Aufnahme starten.
+- `Next`
+  Zum naechsten Teilnehmenden wechseln.
+- `List`
+  Zurueck zur Roster-Liste.
+
+Trainer koennen jederzeit zur Liste zurueckgehen, einen Teilnehmenden erneut
+auswaehlen und eine weitere Aufnahme machen. Jede erfolgreiche neue Aufnahme
+wird zur primaeren Aufnahme. Vorherige erfolgreiche Aufnahmen bleiben im Drive.
+
+### 5. Analyse abschliessen
+
+Nach der Session `Analyse abschliessen` waehlen. Das setzt den Status auf
+`Completed` und blendet weitere Aufnahmen fuer diese Session aus.
+
+## Bedienung fuer Athletes
+
+### 1. Kurs beitreten
+
+1. Als Athlete anmelden.
+2. `Meine Kurse` oeffnen.
+3. Einen Kurs hinzufuegen oder einen bestehenden Kurs auswaehlen.
+
+### 2. Fuer Laufanalyse registrieren
+
+1. Im Kurs den Eventbereich ansehen.
+2. Ein Event mit Chip `Laufanalyse` suchen.
+3. Registrieren.
+
+Direkt nach der Registrierung startet im Hintergrund die Ordnerbereitstellung.
+Die Registrierung bleibt gueltig, auch wenn die Drive-Bereitstellung fehlschlaegt.
+Der Fehler wird im Laufanalyse-Modul gespeichert und kann spaeter untersucht
+oder durch erneute Bereitstellung behoben werden.
+
+### 3. Analyse-Ordner oeffnen
+
+Athletes finden ihren Ordnerlink an zwei Stellen:
+
+- Im jeweiligen Kurs unter dem registrierten Laufanalyse-Event.
+- Unter `Meine Analysen`.
+
+Der Link ist erst nutzbar, wenn Ordner und Berechtigung bereit sind. Der
+Ordnerstatus kann sinngemaess sein:
+
+- Vorbereitung laeuft.
+- Ordner ist bereit.
+- Bereitstellung ist fehlgeschlagen.
+
+Die Freigabe erfolgt an die E-Mail-Adresse des Identity-Users. Der Ordner wird
+mit Schreibrechten freigegeben. Neue Trainer-Aufnahmen landen automatisch in
+diesem Ordner.
+
+## Was im Hintergrund passiert
+
+### Registrierung
+
+1. `CourseService.RegisterForEventAsync` registriert den Athlete fuer ein
+   Kurs-Event.
+2. Nur wenn `CourseEventDocument.EventType == CourseEventTypes.RunningAnalysis`,
+   ruft der Kursservice den Adapter
+   `ICourseRunningAnalysisRegistrationAdapter` auf.
+3. `CourseRunningAnalysisRegistrationAdapter` ermittelt User, Athlete-Profil,
+   Anzeigenamen und E-Mail-Adresse.
+4. Der Adapter ruft
+   `IRunningAnalysisService.RegisterParticipantAsync` mit einer
+   `RunningAnalysisRegistration` auf.
+
+### Event-Vorbereitung
+
+`RunningAnalysisService.PrepareEventAsync` erstellt oder aktualisiert ein
+`RunningAnalysisEvent` anhand der externen Kurs-Event-ID.
+
+Wichtige Felder:
+
+- `ExternalEventId`: ID des Kurs-Events.
+- `CourseId`: Kurs-ID.
+- `Title`, `StartsAt`, `EndsAt`: aus dem Kurs-Event.
+- `Status`: startet als `Prepared`, sobald das Event vorbereitet wurde.
+- `DriveFolderId`, `DriveFolderUrl`: Drive-Referenz des Event-Ordners.
+
+### Participant-Provisioning
+
+Nach der Registrierung wird ein `RunningAnalysisParticipant` erstellt oder
+aktualisiert.
+
+Der Service versucht dann:
+
+1. Ueber `IUserDriveFolderRegistry.FindReusableFolderAsync` einen vorhandenen
+   Ordner fuer denselben Kurs, dasselbe Event und denselben Athlete zu finden.
+2. Falls keiner existiert, ueber `IRunningAnalysisStorageProvider` einen
+   Event-Ordner im zentralen Drive-Bereich zu sichern.
+3. Darunter einen Teilnehmenden-Ordner anzulegen.
+4. Die Ordnerreferenz ueber `IUserDriveFolderRegistry.SaveFolderReferenceAsync`
+   zu speichern.
+5. Den Ordner fuer die Athlete-E-Mail mit `writer`-Rechten freizugeben.
+
+Wenn ein Schritt fehlschlaegt:
+
+- Die Kursregistrierung wird nicht zurueckgerollt.
+- Der Participant bleibt gespeichert.
+- `FolderStatus`, `PermissionStatus` und `ProvisioningError` dokumentieren den
+  Zustand.
+
+### Ordnerstruktur in Google Drive
+
+Der Google-Drive-Provider arbeitet in einem zentralen Root-Bereich.
+
+Typische Struktur:
+
+```text
+PaceLetics Laufanalysen
+  2026-06-06 Laufanalyse Kurs A
+    Anna Beispiel - abc123
+      20260606-153000-Anna-Beispiel.webm
+    Max Beispiel - def456
+      20260606-153900-Max-Beispiel.webm
+```
+
+Event-Ordner:
+
+```text
+yyyy-MM-dd {EventTitle}
+```
+
+Participant-Ordner:
+
+```text
+{DisplayName} - {letzte 6 Zeichen der AthleteUserId}
+```
+
+Dateinamen fuer Aufnahmen:
+
+```text
+yyyyMMdd-HHmmss-{DisplayName}.{webm|mp4}
+```
+
+### Aufnahme und Upload
+
+1. Die Trainer-Session laedt das Roster ueber
+   `IRunningAnalysisService.GetRosterAsync`.
+2. Beim Oeffnen der Kamera wird der Browser-Online-Status ueber
+   `runningAnalysisMediaRecorder.js` abgefragt.
+3. `RunningAnalysisMediaRecorder` verwendet `navigator.mediaDevices.getUserMedia`
+   und `MediaRecorder`.
+4. Es wird Video ohne Audio aufgenommen.
+5. Bevorzugte Formate sind `webm` mit VP9, `webm` mit VP8, `webm`, danach `mp4`,
+   je nach Browser-Support.
+6. Nach `Stop` liefert JavaScript die Videodaten an Blazor zurueck.
+7. `RunningAnalysisService.UploadRecordingAsync` prueft:
+   - Online-Status muss true sein.
+   - Dateiname muss vorhanden sein.
+   - Participant muss zum Analyse-Event gehoeren.
+   - Participant-Ordner muss bereit sein.
+8. Der Service speichert zunaechst eine Aufnahme mit Status `Uploading`.
+9. Der Google-Drive-Provider laedt die Datei in den Participant-Ordner.
+10. Bei Erfolg wird die Aufnahme `Uploaded`, bekommt Drive-ID und Drive-Link und
+    wird als `IsPrimary` markiert.
+11. Bei Fehler wird die Aufnahme `Failed` und nicht primaer.
+
+## Zentrale Regeln
+
+- Eine Aufnahme ist nur online erlaubt.
+- Eine erfolgreiche neue Aufnahme wird primaer.
+- Fehlgeschlagene Uploads ersetzen die primaere Aufnahme nicht.
+- Drive-Provisioning-Fehler blockieren die Kursregistrierung nicht.
+- Teilnehmende bekommen Schreibrechte auf ihren eigenen Ordner.
+- Der Service Account wird nicht im Git-Repository gespeichert.
+
+## Konfiguration
+
+Die Konfiguration liegt im Abschnitt:
+
+```json
+{
+  "RunningAnalysis": {
+    "GoogleDrive": {
+      "ApplicationName": "PaceLetics",
+      "RootFolderId": "",
+      "RootFolderName": "PaceLetics Laufanalysen"
+    }
+  }
+}
+```
+
+Echte Zugangsdaten duerfen nicht in `PaceLetics.Web/appsettings.json`.
+Die getrackte Datei enthaelt nur nicht-geheime Defaults.
+
+### Empfohlene lokale Konfiguration mit User-Secrets
 
 ```powershell
 dotnet user-secrets set "RunningAnalysis:GoogleDrive:RootFolderId" "<central-folder-id>" --project PaceLetics.Web
 dotnet user-secrets set "RunningAnalysis:GoogleDrive:ServiceAccountJsonPath" "C:\secure\paceletics-google-drive-service-account.json" --project PaceLetics.Web
 ```
 
-or environment variables:
+Alternativ kann der komplette JSON-Inhalt gesetzt werden:
+
+```powershell
+dotnet user-secrets set "RunningAnalysis:GoogleDrive:ServiceAccountJson" "<service-account-json>" --project PaceLetics.Web
+```
+
+Das ist praktisch fuer Hosting-Umgebungen, aber fuer lokale Entwicklung ist ein
+Dateipfad meist lesbarer.
+
+### Konfiguration mit Environment-Variablen
 
 ```powershell
 $env:RunningAnalysis__GoogleDrive__RootFolderId = "<central-folder-id>"
 $env:RunningAnalysis__GoogleDrive__ServiceAccountJsonPath = "C:\secure\paceletics-google-drive-service-account.json"
 ```
 
-For local development only, copy `PaceLetics.Web/appsettings.Local.example.json`
-to `PaceLetics.Web/appsettings.Local.json`. The local file is ignored by git.
-Share the central Google Drive folder with the service-account email and set its
-folder id as `RunningAnalysis:GoogleDrive:RootFolderId`.
+oder:
 
-## Next Adapters
+```powershell
+$env:RunningAnalysis__GoogleDrive__ServiceAccountJson = "<service-account-json>"
+```
 
-- Course event adapter: call registration when an athlete registers for a running
-  analysis event.
-- Google Drive adapter: implement central root-folder creation, event folders,
-  participant folders, write permission grants, and video uploads.
-- Component module: trainer roster, browser camera capture, upload handoff, and
-  participant "My analyses" folder-link view.
+### Lokale Datei fuer Entwicklung
+
+Fuer lokale Entwicklung kann
+`PaceLetics.Web/appsettings.Local.example.json` nach
+`PaceLetics.Web/appsettings.Local.json` kopiert werden.
+
+`appsettings.Local.json` ist in `.gitignore` eingetragen und wird in Development
+optional geladen.
+
+### Google-Drive-Vorbereitung
+
+1. Google Cloud Projekt mit Drive API vorbereiten.
+2. Service Account erstellen.
+3. Service-Account-Key als JSON erzeugen.
+4. JSON ausserhalb des Repositories speichern.
+5. Zentralen Drive-Ordner erstellen.
+6. Zentralen Drive-Ordner mit der Service-Account-E-Mail teilen.
+7. Die Folder-ID des zentralen Ordners als
+   `RunningAnalysis:GoogleDrive:RootFolderId` konfigurieren.
+
+Ohne `RootFolderId` versucht der Adapter, einen Root-Ordner ueber
+`RootFolderName` zu finden oder anzulegen. Fuer produktive Nutzung ist eine
+explizite `RootFolderId` robuster.
+
+## Persistenz
+
+Die Web-Integration verwendet `CosmosRunningAnalysisRepository`.
+
+Gespeichert wird im konfigurierten `AthleteDataOptions.CourseContainerName`.
+Die Laufanalyse-Dokumente sind ueber `DocumentType` getrennt:
+
+- `runningAnalysisEvent`
+  Analyse-Event und Status.
+- `runningAnalysisParticipant`
+  Teilnehmender, Folderstatus, Permissionstatus und Drive-Link.
+- `runningAnalysisRecording`
+  Aufnahmeversuch, Uploadstatus, Drive-Datei und Primaerkennzeichnung.
+- `runningAnalysisFolderReference`
+  Wiederverwendbare Ordnerreferenz fuer Kurs, Event und Athlete.
+
+## Wichtige Interfaces
+
+- `IRunningAnalysisService`
+  Hauptservice fuer Event-Vorbereitung, Registrierung, Roster, Athlete-Links,
+  Start, Abschluss und Upload.
+- `IRunningAnalysisRepository`
+  Persistenz fuer Events, Participants und Recordings.
+- `IRunningAnalysisStorageProvider`
+  Abstraktion fuer externe Ablage. Aktuell durch Google Drive implementiert.
+- `IUserDriveFolderRegistry`
+  Sucht und speichert wiederverwendbare Drive-Ordner.
+- `IRunningAnalysisClock`
+  Kapselt Zeit fuer testbare Domainlogik.
+- `ICourseRunningAnalysisRegistrationAdapter`
+  Koppelt Kursregistrierung an Laufanalyse-Provisioning.
+
+## Statuswerte
+
+### Eventstatus
+
+- `Draft`
+  Noch nicht vorbereitet.
+- `Prepared`
+  Event ist im Laufanalyse-Modul angelegt.
+- `InProgress`
+  Trainer hat die Analyse gestartet oder die erste Aufnahme begonnen.
+- `Completed`
+  Trainer hat die Analyse abgeschlossen.
+
+### Folderstatus
+
+- `Missing`
+  Noch kein Ordner bekannt.
+- `Creating`
+  Ordnerbereitstellung laeuft.
+- `Ready`
+  Ordner ist vorhanden.
+- `Failed`
+  Ordnerbereitstellung ist fehlgeschlagen.
+
+### Permissionstatus
+
+- `Missing`
+  Noch keine Freigabe bekannt.
+- `Granting`
+  Freigabe wird gesetzt.
+- `Granted`
+  Schreibrecht wurde vergeben.
+- `Failed`
+  Freigabe ist fehlgeschlagen.
+
+### Uploadstatus
+
+- `Captured`
+  Aufnahme wurde erfasst, aber noch nicht hochgeladen.
+- `Uploading`
+  Upload laeuft.
+- `Uploaded`
+  Upload war erfolgreich.
+- `Failed`
+  Upload ist fehlgeschlagen.
+
+## Browser- und Betriebsanforderungen
+
+- Kameraaufnahme benoetigt einen Browser mit `getUserMedia` und `MediaRecorder`.
+- Kameraaufnahme benoetigt in der Regel HTTPS oder localhost.
+- Der Browser muss online sein.
+- Audio wird nicht aufgenommen.
+- Teilnehmerordner muessen vor Uploads bereit sein.
+- Der Server benoetigt Zugriff auf die Google-Drive-API.
+
+## Troubleshooting
+
+### Trainer sieht nur `Meine Analysen`
+
+Der Account hat vermutlich nicht die Rolle `ApplicationRoles.Trainer`.
+Trainerbereiche erscheinen erst mit dieser Rolle.
+
+### `Laufanalysen` ist leer
+
+Es gibt in den Kursen des Trainers noch kein Event mit Eventtyp
+`RunningAnalysis`. In `Kurse verwalten` ein neues Event vom Typ `Laufanalyse`
+anlegen.
+
+### Drive-Warnung erscheint
+
+Service-Account-Zugangsdaten fehlen. User-Secrets, Environment-Variablen oder
+`appsettings.Local.json` pruefen. Keine echten Keys in getrackte Dateien
+schreiben.
+
+### Athlete sieht keinen Ordnerlink
+
+Moegliche Ursachen:
+
+- Registrierung wurde noch nicht abgeschlossen.
+- Provisioning laeuft noch.
+- Service Account ist nicht konfiguriert.
+- Root-Ordner ist nicht mit dem Service Account geteilt.
+- Athlete-User hat keine E-Mail-Adresse.
+- Google Drive konnte die Berechtigung nicht setzen.
+
+### Aufnahme startet nicht
+
+Moegliche Ursachen:
+
+- Browser blockiert Kamera.
+- Seite laeuft nicht ueber HTTPS oder localhost.
+- Browser unterstuetzt `MediaRecorder` nicht.
+- Browser ist offline.
+
+### Upload schlaegt fehl
+
+Moegliche Ursachen:
+
+- Browser ist offline.
+- Participant-Ordner ist nicht `Ready`.
+- Service Account hat keinen Zugriff auf den Root-Ordner.
+- Drive API ist nicht aktiviert.
+- Service-Account-Key ist falsch oder nicht erreichbar.
+
+## Erweiterungspunkte
+
+- Weitere Storage-Provider koennen ueber `IRunningAnalysisStorageProvider`
+  implementiert werden.
+- Ein Retry-Job kann fehlgeschlagene Folder-Provisionings anhand von
+  `FolderStatus`, `PermissionStatus` und `ProvisioningError` erneut versuchen.
+- Weitere UI-Komponenten koennen auf `IRunningAnalysisService` aufbauen, ohne an
+  die Kursverwaltung gekoppelt zu sein.
+- Zusaetzliche Analyse-Artefakte koennen spaeter im Participant-Ordner abgelegt
+  und ueber neue Recording- oder Result-Modelle referenziert werden.

--- a/PaceLetics.RunningAnalysisModule.CodeBase/README.md
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/README.md
@@ -297,30 +297,32 @@ Die Konfiguration liegt im Abschnitt:
 ```json
 {
   "PaceLeticsUserData": {
-    "ApplicationName": "PaceLetics",
-    "RootFolderId": "",
-    "RootFolderName": "paceletics_user_data"
+    "GoogleDrive": {
+      "ApplicationName": "PaceLetics",
+      "RootFolderId": "",
+      "RootFolderName": "paceletics_user_data"
+    }
   }
 }
 ```
 
 Echte Zugangsdaten duerfen nicht in `PaceLetics.Web/appsettings.json`.
 Die getrackte Datei enthaelt nur nicht-geheime Defaults.
-Die neue primaere Konfiguration heisst `PaceLeticsUserData`. Alte Werte unter
-`RunningAnalysis:GoogleDrive` werden noch als Fallback gelesen, damit bestehende
-Umgebungen nicht sofort brechen.
+Die neue primaere Konfiguration heisst `PaceLeticsUserData:GoogleDrive`. Werte
+unter `PaceLeticsUserData` und `RunningAnalysis:GoogleDrive` werden noch als
+Fallback gelesen, damit bestehende Umgebungen nicht sofort brechen.
 
 ### Empfohlene lokale Konfiguration mit User-Secrets
 
 ```powershell
-dotnet user-secrets set "PaceLeticsUserData:RootFolderId" "<central-folder-id>" --project PaceLetics.Web
-dotnet user-secrets set "PaceLeticsUserData:ServiceAccountJsonPath" "C:\secure\paceletics-google-drive-service-account.json" --project PaceLetics.Web
+dotnet user-secrets set "PaceLeticsUserData:GoogleDrive:RootFolderId" "<central-folder-id>" --project PaceLetics.Web
+dotnet user-secrets set "PaceLeticsUserData:GoogleDrive:ServiceAccountJsonPath" "C:\secure\paceletics-google-drive-service-account.json" --project PaceLetics.Web
 ```
 
 Alternativ kann der komplette JSON-Inhalt gesetzt werden:
 
 ```powershell
-dotnet user-secrets set "PaceLeticsUserData:ServiceAccountJson" "<service-account-json>" --project PaceLetics.Web
+dotnet user-secrets set "PaceLeticsUserData:GoogleDrive:ServiceAccountJson" "<service-account-json>" --project PaceLetics.Web
 ```
 
 Das ist praktisch fuer Hosting-Umgebungen, aber fuer lokale Entwicklung ist ein
@@ -329,14 +331,14 @@ Dateipfad meist lesbarer.
 ### Konfiguration mit Environment-Variablen
 
 ```powershell
-$env:PaceLeticsUserData__RootFolderId = "<central-folder-id>"
-$env:PaceLeticsUserData__ServiceAccountJsonPath = "C:\secure\paceletics-google-drive-service-account.json"
+$env:PaceLeticsUserData__GoogleDrive__RootFolderId = "<central-folder-id>"
+$env:PaceLeticsUserData__GoogleDrive__ServiceAccountJsonPath = "C:\secure\paceletics-google-drive-service-account.json"
 ```
 
 oder:
 
 ```powershell
-$env:PaceLeticsUserData__ServiceAccountJson = "<service-account-json>"
+$env:PaceLeticsUserData__GoogleDrive__ServiceAccountJson = "<service-account-json>"
 ```
 
 ### Lokale Datei fuer Entwicklung
@@ -357,7 +359,7 @@ optional geladen.
 5. Zentralen Drive-Ordner erstellen.
 6. Zentralen Drive-Ordner mit der Service-Account-E-Mail teilen.
 7. Die Folder-ID des zentralen Ordners als
-   `PaceLeticsUserData:RootFolderId` konfigurieren.
+   `PaceLeticsUserData:GoogleDrive:RootFolderId` konfigurieren.
 
 Ohne `RootFolderId` versucht der Adapter, einen Root-Ordner ueber
 `RootFolderName` zu finden oder anzulegen. Fuer produktive Nutzung ist eine

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisOptions.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisOptions.cs
@@ -2,7 +2,8 @@ namespace PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
 
 public sealed class GoogleDriveRunningAnalysisOptions
 {
-    public const string SectionName = "PaceLeticsUserData";
+    public const string SectionName = "PaceLeticsUserData:GoogleDrive";
+    public const string FlatSectionName = "PaceLeticsUserData";
     public const string LegacySectionName = "RunningAnalysis:GoogleDrive";
 
     public string ApplicationName { get; set; } = "PaceLetics";

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisOptions.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisOptions.cs
@@ -2,11 +2,12 @@ namespace PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
 
 public sealed class GoogleDriveRunningAnalysisOptions
 {
-    public const string SectionName = "RunningAnalysis:GoogleDrive";
+    public const string SectionName = "PaceLeticsUserData";
+    public const string LegacySectionName = "RunningAnalysis:GoogleDrive";
 
     public string ApplicationName { get; set; } = "PaceLetics";
     public string RootFolderId { get; set; } = string.Empty;
-    public string RootFolderName { get; set; } = "PaceLetics Laufanalysen";
+    public string RootFolderName { get; set; } = "paceletics_user_data";
     public string ServiceAccountJsonPath { get; set; } = string.Empty;
     public string ServiceAccountJson { get; set; } = string.Empty;
 }

--- a/PaceLetics.Web/Pages/Trainers/RunningAnalyses.razor
+++ b/PaceLetics.Web/Pages/Trainers/RunningAnalyses.razor
@@ -1,0 +1,168 @@
+@page "/Trainers/running-analyses"
+@attribute [Authorize(Roles = ApplicationRoles.Trainer)]
+@using Microsoft.Extensions.Options
+@using PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive
+@using PaceLetics.Web.Services.Courses
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ICourseService CourseService
+@inject NavigationManager Navigation
+@inject LoadingStateService Loading
+@inject IOptions<GoogleDriveRunningAnalysisOptions> DriveOptions
+@inject IStringLocalizer<RunningAnalyses> L
+
+<PageTitle>@L["PageTitle"]</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Medium">
+    <MudStack Spacing="3">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+            <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
+
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Event"
+                       OnClick="@(() => Navigation.NavigateTo("/Trainers/courses"))">
+                @L["ManageCourses"]
+            </MudButton>
+        </MudStack>
+
+        @if (!HasDriveCredentials)
+        {
+            <MudAlert Severity="Severity.Warning" Variant="Variant.Outlined">
+                @L["DriveCredentialsMissing"]
+            </MudAlert>
+        }
+
+        @if (!HasCentralDriveFolder)
+        {
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                @L["DriveRootFolderMissing"]
+            </MudAlert>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(_errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_errorMessage</MudAlert>
+        }
+        else if (_analyses.Count == 0)
+        {
+            <MudPaper Elevation="1" Class="pa-4">
+                <MudStack Spacing="2">
+                    <MudText Typo="Typo.subtitle1">@L["EmptyTitle"]</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["EmptyText"]</MudText>
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Add"
+                               OnClick="@(() => Navigation.NavigateTo("/Trainers/courses"))">
+                        @L["CreateEvent"]
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
+        }
+        else
+        {
+            <MudStack Spacing="2">
+                @foreach (var analysis in _analyses)
+                {
+                    <MudPaper Elevation="1" Class="pa-4">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+                            <MudStack Spacing="1" Style="min-width:0;">
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:8px; flex-wrap:wrap;">
+                                    <MudText Typo="Typo.subtitle1">@analysis.Event.Title</MudText>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">
+                                        @L["RunningAnalysis"]
+                                    </MudChip>
+                                </MudStack>
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">@analysis.Course.Name</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatEventDate(analysis.Event)</MudText>
+                                @if (!string.IsNullOrWhiteSpace(analysis.Event.Location))
+                                {
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@analysis.Event.Location</MudText>
+                                }
+                            </MudStack>
+
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Filled.PlayArrow"
+                                       OnClick="@(() => OpenAnalysis(analysis))">
+                                @L["StartAnalysis"]
+                            </MudButton>
+                        </MudStack>
+                    </MudPaper>
+                }
+            </MudStack>
+        }
+    </MudStack>
+</MudContainer>
+
+@code {
+    private string? _userId;
+    private string? _errorMessage;
+    private IReadOnlyList<RunningAnalysisCourseEvent> _analyses = Array.Empty<RunningAnalysisCourseEvent>();
+
+    private bool HasDriveCredentials =>
+        !string.IsNullOrWhiteSpace(DriveOptions.Value.ServiceAccountJsonPath)
+        || !string.IsNullOrWhiteSpace(DriveOptions.Value.ServiceAccountJson);
+
+    private bool HasCentralDriveFolder =>
+        !string.IsNullOrWhiteSpace(DriveOptions.Value.RootFolderId);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        await Loading.RunAsync(L["Loading"], async () =>
+        {
+            try
+            {
+                _errorMessage = null;
+                var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                _userId = authState.User.FindFirst(claim => claim.Type.Contains("nameidentifier"))?.Value;
+
+                if (string.IsNullOrWhiteSpace(_userId))
+                    throw new InvalidOperationException(L["TrainerNotResolved"]);
+
+                var courses = await CourseService.GetCoursesForTrainerAsync(_userId);
+                var analyses = new List<RunningAnalysisCourseEvent>();
+
+                foreach (var course in courses.OrderBy(course => course.Name))
+                {
+                    var events = await CourseService.GetEventsAsync(course.Id);
+                    analyses.AddRange(events
+                        .Where(IsRunningAnalysisEvent)
+                        .Select(courseEvent => new RunningAnalysisCourseEvent(course, courseEvent)));
+                }
+
+                _analyses = analyses
+                    .OrderBy(analysis => analysis.Event.StartsAt.Date < DateTime.Today ? 1 : 0)
+                    .ThenBy(analysis => analysis.Event.StartsAt)
+                    .ThenBy(analysis => analysis.Event.Title)
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                _analyses = Array.Empty<RunningAnalysisCourseEvent>();
+            }
+        });
+    }
+
+    private static bool IsRunningAnalysisEvent(CourseEventDocument courseEvent)
+    {
+        return string.Equals(courseEvent.EventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void OpenAnalysis(RunningAnalysisCourseEvent analysis)
+    {
+        Navigation.NavigateTo($"/Trainers/courses/{analysis.Course.Id}/events/{analysis.Event.Id}/running-analysis");
+    }
+
+    private string FormatEventDate(CourseEventDocument courseEvent)
+    {
+        return string.Format(L["EventDate"], courseEvent.StartsAt, courseEvent.EndsAt);
+    }
+
+    private sealed record RunningAnalysisCourseEvent(CourseDocument Course, CourseEventDocument Event);
+}

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -35,6 +35,11 @@ using PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
 
 var builder = WebApplication.CreateBuilder(args);
 
+if (builder.Environment.IsDevelopment())
+{
+    builder.Configuration.AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true);
+}
+
 // Add services to the container.
 
 var sqlConnectionString = PaceLeticsConfiguration.GetRequiredEnvironmentVariable("PaceLeticsSqlConnString");

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -112,8 +112,11 @@ builder.Services.Configure<TrainerVerificationOptions>(options =>
 });
 builder.Services.AddTransient<IEmailSender, SmtpEmailSender>();
 builder.Services.AddScoped<ICourseRepository, CosmosCourseRepository>();
-builder.Services.Configure<GoogleDriveRunningAnalysisOptions>(
-    builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.SectionName));
+builder.Services.Configure<GoogleDriveRunningAnalysisOptions>(options =>
+{
+    builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.LegacySectionName).Bind(options);
+    builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.SectionName).Bind(options);
+});
 builder.Services.AddScoped<CosmosRunningAnalysisRepository>();
 builder.Services.AddScoped<IRunningAnalysisRepository>(x => x.GetRequiredService<CosmosRunningAnalysisRepository>());
 builder.Services.AddScoped<IUserDriveFolderRegistry>(x => x.GetRequiredService<CosmosRunningAnalysisRepository>());

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -115,6 +115,7 @@ builder.Services.AddScoped<ICourseRepository, CosmosCourseRepository>();
 builder.Services.Configure<GoogleDriveRunningAnalysisOptions>(options =>
 {
     builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.LegacySectionName).Bind(options);
+    builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.FlatSectionName).Bind(options);
     builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.SectionName).Bind(options);
 });
 builder.Services.AddScoped<CosmosRunningAnalysisRepository>();

--- a/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalyses.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalyses.de.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Laufanalysen</value></data>
+  <data name="Title" xml:space="preserve"><value>Laufanalysen</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Analyse-Events fuer deine Kurse starten und durchfuehren.</value></data>
+  <data name="ManageCourses" xml:space="preserve"><value>Kurse verwalten</value></data>
+  <data name="DriveCredentialsMissing" xml:space="preserve"><value>Google Drive ist noch nicht konfiguriert. Hinterlege die Zugangsdaten ueber User-Secrets, Environment-Variablen oder die ignorierte appsettings.Local.json, bevor Teilnehmende registriert oder Aufnahmen hochgeladen werden.</value></data>
+  <data name="DriveRootFolderMissing" xml:space="preserve"><value>Es ist keine zentrale Google-Drive-Ordner-ID konfiguriert. Der Adapter nutzt stattdessen den konfigurierten Root-Ordnernamen.</value></data>
+  <data name="EmptyTitle" xml:space="preserve"><value>Noch keine Laufanalysen</value></data>
+  <data name="EmptyText" xml:space="preserve"><value>Erstelle in der Kursverwaltung ein Event vom Typ Laufanalyse.</value></data>
+  <data name="CreateEvent" xml:space="preserve"><value>Event erstellen</value></data>
+  <data name="RunningAnalysis" xml:space="preserve"><value>Laufanalyse</value></data>
+  <data name="StartAnalysis" xml:space="preserve"><value>Analyse starten</value></data>
+  <data name="Loading" xml:space="preserve"><value>Laufanalysen werden geladen</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>Trainer:in konnte nicht ermittelt werden.</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} bis {1:HH:mm} Uhr</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalyses.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalyses.en.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Running analyses</value></data>
+  <data name="Title" xml:space="preserve"><value>Running analyses</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Start and run analysis events for your courses.</value></data>
+  <data name="ManageCourses" xml:space="preserve"><value>Manage courses</value></data>
+  <data name="DriveCredentialsMissing" xml:space="preserve"><value>Google Drive credentials are not configured. Add them through user-secrets, environment variables, or the ignored appsettings.Local.json before participants register or recordings are uploaded.</value></data>
+  <data name="DriveRootFolderMissing" xml:space="preserve"><value>No central Google Drive folder id is configured. The adapter will use the configured root folder name instead.</value></data>
+  <data name="EmptyTitle" xml:space="preserve"><value>No running analyses yet</value></data>
+  <data name="EmptyText" xml:space="preserve"><value>Create an event with the running analysis type in course management.</value></data>
+  <data name="CreateEvent" xml:space="preserve"><value>Create event</value></data>
+  <data name="RunningAnalysis" xml:space="preserve"><value>Running analysis</value></data>
+  <data name="StartAnalysis" xml:space="preserve"><value>Start analysis</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading running analyses</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>The coach could not be resolved.</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:MM/dd/yyyy HH:mm} to {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalyses.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/RunningAnalyses.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Running analyses</value></data>
+  <data name="Title" xml:space="preserve"><value>Running analyses</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Start and run analysis events for your courses.</value></data>
+  <data name="ManageCourses" xml:space="preserve"><value>Manage courses</value></data>
+  <data name="DriveCredentialsMissing" xml:space="preserve"><value>Google Drive credentials are not configured. Add them through user-secrets, environment variables, or the ignored appsettings.Local.json before participants register or recordings are uploaded.</value></data>
+  <data name="DriveRootFolderMissing" xml:space="preserve"><value>No central Google Drive folder id is configured. The adapter will use the configured root folder name instead.</value></data>
+  <data name="EmptyTitle" xml:space="preserve"><value>No running analyses yet</value></data>
+  <data name="EmptyText" xml:space="preserve"><value>Create an event with the running analysis type in course management.</value></data>
+  <data name="CreateEvent" xml:space="preserve"><value>Create event</value></data>
+  <data name="RunningAnalysis" xml:space="preserve"><value>Running analysis</value></data>
+  <data name="StartAnalysis" xml:space="preserve"><value>Start analysis</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading running analyses</value></data>
+  <data name="TrainerNotResolved" xml:space="preserve"><value>The coach could not be resolved.</value></data>
+  <data name="EventDate" xml:space="preserve"><value>{0:MM/dd/yyyy HH:mm} to {1:HH:mm}</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -38,6 +38,7 @@
   <data name="Nav_Courses" xml:space="preserve"><value>Meine Kurse</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>Meine Analysen</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Kurse verwalten</value></data>
+  <data name="Nav_TrainerRunningAnalyses" xml:space="preserve"><value>Laufanalysen</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Trainingsplanung</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profile</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -38,6 +38,7 @@
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>
+  <data name="Nav_TrainerRunningAnalyses" xml:space="preserve"><value>Running Analyses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.resx
@@ -38,6 +38,7 @@
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>
+  <data name="Nav_TrainerRunningAnalyses" xml:space="preserve"><value>Running Analyses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>
   <data name="Nav_Workouts" xml:space="preserve"><value>Workouts</value></data>
   <data name="Nav_Profiles" xml:space="preserve"><value>Profiles</value></data>

--- a/PaceLetics.Web/Shared/NavMenu.razor
+++ b/PaceLetics.Web/Shared/NavMenu.razor
@@ -9,6 +9,7 @@
     <AuthorizeView Roles="@ApplicationRoles.Trainer">
         <Authorized>
             <MudNavLink Href="/Trainers/courses" Match="NavLinkMatch.Prefix">@L["Nav_TrainerCourses"]</MudNavLink>
+            <MudNavLink Href="/Trainers/running-analyses" Match="NavLinkMatch.Prefix">@L["Nav_TrainerRunningAnalyses"]</MudNavLink>
         </Authorized>
     </AuthorizeView>
     <MudNavLink Href="/Athletes/trainingplanpage" Match="NavLinkMatch.Prefix">@L["Nav_TrainingPlan"]</MudNavLink>

--- a/PaceLetics.Web/appsettings.Local.example.json
+++ b/PaceLetics.Web/appsettings.Local.example.json
@@ -1,6 +1,8 @@
 {
   "PaceLeticsUserData": {
-    "RootFolderId": "google-drive-folder-id-shared-with-the-service-account",
-    "ServiceAccountJsonPath": "C:\\secure\\paceletics-google-drive-service-account.json"
+    "GoogleDrive": {
+      "RootFolderId": "google-drive-folder-id-shared-with-the-service-account",
+      "ServiceAccountJsonPath": "C:\\secure\\paceletics-google-drive-service-account.json"
+    }
   }
 }

--- a/PaceLetics.Web/appsettings.Local.example.json
+++ b/PaceLetics.Web/appsettings.Local.example.json
@@ -1,8 +1,6 @@
 {
-  "RunningAnalysis": {
-    "GoogleDrive": {
-      "RootFolderId": "google-drive-folder-id-shared-with-the-service-account",
-      "ServiceAccountJsonPath": "C:\\secure\\paceletics-google-drive-service-account.json"
-    }
+  "PaceLeticsUserData": {
+    "RootFolderId": "google-drive-folder-id-shared-with-the-service-account",
+    "ServiceAccountJsonPath": "C:\\secure\\paceletics-google-drive-service-account.json"
   }
 }

--- a/PaceLetics.Web/appsettings.Local.example.json
+++ b/PaceLetics.Web/appsettings.Local.example.json
@@ -1,0 +1,8 @@
+{
+  "RunningAnalysis": {
+    "GoogleDrive": {
+      "RootFolderId": "google-drive-folder-id-shared-with-the-service-account",
+      "ServiceAccountJsonPath": "C:\\secure\\paceletics-google-drive-service-account.json"
+    }
+  }
+}

--- a/PaceLetics.Web/appsettings.json
+++ b/PaceLetics.Web/appsettings.json
@@ -18,9 +18,7 @@
     "GoogleDrive": {
       "ApplicationName": "PaceLetics",
       "RootFolderId": "",
-      "RootFolderName": "PaceLetics Laufanalysen",
-      "ServiceAccountJsonPath": "",
-      "ServiceAccountJson": ""
+      "RootFolderName": "PaceLetics Laufanalysen"
     }
   },
   "Logging": {

--- a/PaceLetics.Web/appsettings.json
+++ b/PaceLetics.Web/appsettings.json
@@ -14,12 +14,10 @@
   "TrainerVerification": {
     "Code": ""
   },
-  "RunningAnalysis": {
-    "GoogleDrive": {
-      "ApplicationName": "PaceLetics",
-      "RootFolderId": "",
-      "RootFolderName": "PaceLetics Laufanalysen"
-    }
+  "PaceLeticsUserData": {
+    "ApplicationName": "PaceLetics",
+    "RootFolderId": "",
+    "RootFolderName": "paceletics_user_data"
   },
   "Logging": {
     "LogLevel": {

--- a/PaceLetics.Web/appsettings.json
+++ b/PaceLetics.Web/appsettings.json
@@ -15,9 +15,11 @@
     "Code": ""
   },
   "PaceLeticsUserData": {
-    "ApplicationName": "PaceLetics",
-    "RootFolderId": "",
-    "RootFolderName": "paceletics_user_data"
+    "GoogleDrive": {
+      "ApplicationName": "PaceLetics",
+      "RootFolderId": "",
+      "RootFolderName": "paceletics_user_data"
+    }
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- add a trainer-only running analyses overview with direct start actions
- keep Google Drive service-account credentials out of tracked appsettings
- add ignored/local configuration support and documented setup paths
- rename Drive settings to `PaceLeticsUserData:GoogleDrive`
- support env vars such as `PaceLeticsUserData__GoogleDrive__RootFolderId`
- keep older config sections as fallback for compatibility
- document trainer and athlete usage plus internal module workflow

## Verification
- dotnet build .\PaceLeticsFramework.sln
- dotnet test .\PaceLeticsFramework.sln --no-build