### PR TITLE
Codex/user drive folder

### DIFF
--- a/PR_REPORT.md
+++ b/PR_REPORT.md
@@ -1,53 +1,66 @@
-# PR Report: Theme-Aware Loading State Service
+# PR Report: User-Owned Google Drive Folder Management
 
 ## Summary
-- Replaced the improvised text-based loading bar with a dedicated MudBlazor loading indicator.
-- Added a scoped loading state service for page and operation loading states.
-- Added a global loading host to the main layout so pages can report loading work centrally.
-- Migrated existing page-level loading flags to the new service.
-- Kept loader styling consistent with the existing app theme tokens.
+- Added a new authenticated **My Drive** area where users can manage their personal PaceLetics Google Drive folder.
+- Added a navigation entry for **My Drive**.
+- Added create, view, and delete flows for per-user Drive folders.
+- Kept folder names anonymous by excluding email addresses and display names.
+- Hardened Google Drive service account credential loading for local and hosted environments.
+
+## User Experience
+- Users can open `/Athletes/drive` from the navigation menu.
+- If no folder exists, the page shows a **Create folder** action.
+- If a folder exists, the page shows an **Open folder** link and a **Delete folder** action.
+- Folder deletion remains controlled through the app button and service account flow.
+- The folder link is not public. It works for the Google account that was explicitly granted access.
+
+## Google Drive Behavior
+- User folders are created below the configured PaceLetics Drive root.
+- User folder names use the format:
+  - `PaceLetics - User - {last 6 chars of AthleteUserId}`
+- The user's email address is used only for permission assignment, not for folder naming.
+- Users receive `reader` access to their folder.
+- The service account remains responsible for folder lifecycle operations, including deletion.
+
+## Credential Handling
+- `ServiceAccountJsonPath` is preferred when it points to an existing credential file.
+- `ServiceAccountJson` supports:
+  - raw service account JSON
+  - quoted or escaped JSON strings
+  - base64-encoded service account JSON
+  - a file path accidentally supplied in the JSON setting
+- Invalid credential JSON now produces a clearer configuration error.
 
 ## Implementation Details
-- Added `LoadingStateService` with:
-  - `Show(string label)`
-  - `RunAsync(string label, Func<Task> operation)`
-  - `RunAsync<T>(string label, Func<Task<T>> operation)`
-  - nested loading scope support
-- Registered `LoadingStateService` as scoped in the web app dependency injection container.
-- Added `LoadingHost` to `MainLayout` so active loading operations render through a single global host.
-- Reworked `LoadingScreen` to render `MudProgressCircular` instead of the previous `|||||` gradient text placeholder.
-- Added theme-aware loader CSS classes in `app-theme.css` using existing MudBlazor and PaceLetics CSS variables.
-- Updated `DataGridView` to reuse `LoadingScreen` instead of rendering raw emphasized loading text.
-
-## Migrated Pages
-- `Dashboard`
-- `Profiles`
-- `WorkoutArea`
-- `CourseManagement`
-- `MyCourses`
-- `RacePaces`
-- `TrainingPaces`
-- `TrainingIntervalls`
-
-## ViewModel Changes
-- Removed UI loading responsibility from `WorkoutAreaViewModel`.
-- Updated the related test to assert loaded workout preview data instead of checking a UI loading flag.
+- Added user Drive folder contracts:
+  - `IUserDriveFolderService`
+  - `IUserDriveFolderRepository`
+  - `IUserDriveFolderStorageProvider`
+- Added request models:
+  - `UserDriveFolderRequest`
+  - `SaveUserDriveFolderRequest`
+- Added `UserDriveFolderService` to coordinate repository and Google Drive operations.
+- Extended the Google Drive storage provider with:
+  - user folder creation
+  - user read access grants
+  - Drive folder deletion
+  - robust credential normalization
+- Extended the Cosmos running analysis repository with user folder references.
+- Registered the new services in web dependency injection.
+- Added localized My Drive page resources for English, German, and fallback resources.
 
 ## Tests
-- Added unit tests for `LoadingStateService`:
-  - verifies `RunAsync` activates and clears loading state
-  - verifies nested loading scopes restore the previous label
-- Updated `WorkoutViewModelTests` for the new separation between view model data and page loading state.
+- Added `UserDriveFolderServiceTests` covering:
+  - reusing an existing folder reference
+  - creating, sharing, and saving a new folder reference
+  - deleting the Drive folder and stored reference
 
 ## Verification
-- `dotnet build PaceLeticsFramework.sln` passed.
-- `dotnet test PaceLeticsFramework.sln` passed with 106 tests.
-- Browser smoke check passed at `http://127.0.0.1:5127`.
-- Login page rendered successfully with no browser console errors.
-- Protected routes redirected to login as expected.
-- Repository search confirmed no remaining `MudExGradientText`, text-bar placeholder, or web `_isLoading` usage.
+- `dotnet test PaceLeticsFramework.sln` passed.
+- Test result: 111 passed, 0 failed, 0 skipped.
+- Existing NuGet advisory warnings for `OpenMcdf` and `SharpCompress` still appear and are unrelated to this PR.
 
-## Notes
-- Existing NuGet advisory warnings for `OpenMcdf` and `SharpCompress` still appear during build/test and are unrelated to this PR.
-- Initial local browser navigation to `localhost` was blocked by the browser client, but `127.0.0.1` worked.
-- The Azure SQL firewall warning appeared during local app startup in role seeding and is unrelated to the loader changes.
+## PR
+- Branch: `codex/user-drive-folder`
+- Base: `main`
+- Suggested title: `Add user-owned Google Drive folder management`

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderRepository.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderRepository.cs
@@ -1,0 +1,18 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IUserDriveFolderRepository
+{
+    Task<DriveFolderReference?> FindUserFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveUserFolderAsync(
+        SaveUserDriveFolderRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteUserFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderService.cs
@@ -1,0 +1,18 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IUserDriveFolderService
+{
+    Task<DriveFolderReference?> GetFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default);
+
+    Task<DriveFolderReference> CreateFolderAsync(
+        UserDriveFolderRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderStorageProvider.cs
@@ -8,7 +8,7 @@ public interface IUserDriveFolderStorageProvider
         UserDriveFolderRequest request,
         CancellationToken cancellationToken = default);
 
-    Task GrantUserWriteAccessAsync(
+    Task GrantUserReadAccessAsync(
         DriveFolderReference userFolder,
         string userEmail,
         CancellationToken cancellationToken = default);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Interfaces/IUserDriveFolderStorageProvider.cs
@@ -1,0 +1,19 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+
+public interface IUserDriveFolderStorageProvider
+{
+    Task<DriveFolderReference> EnsureUserFolderAsync(
+        UserDriveFolderRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task GrantUserWriteAccessAsync(
+        DriveFolderReference userFolder,
+        string userEmail,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteFolderAsync(
+        DriveFolderReference userFolder,
+        CancellationToken cancellationToken = default);
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/UserDriveFolderService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/UserDriveFolderService.cs
@@ -1,0 +1,75 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Services;
+
+public sealed class UserDriveFolderService : IUserDriveFolderService
+{
+    private readonly IUserDriveFolderRepository _repository;
+    private readonly IUserDriveFolderStorageProvider _storageProvider;
+
+    public UserDriveFolderService(
+        IUserDriveFolderRepository repository,
+        IUserDriveFolderStorageProvider storageProvider)
+    {
+        _repository = repository;
+        _storageProvider = storageProvider;
+    }
+
+    public Task<DriveFolderReference?> GetFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return Task.FromResult<DriveFolderReference?>(null);
+
+        return _repository.FindUserFolderAsync(athleteUserId.Trim(), cancellationToken);
+    }
+
+    public async Task<DriveFolderReference> CreateFolderAsync(
+        UserDriveFolderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequest(request);
+
+        var existing = await _repository.FindUserFolderAsync(request.AthleteUserId.Trim(), cancellationToken);
+        if (existing is not null)
+            return existing;
+
+        var userFolder = await _storageProvider.EnsureUserFolderAsync(request, cancellationToken);
+        await _storageProvider.GrantUserWriteAccessAsync(userFolder, request.Email, cancellationToken);
+        await _repository.SaveUserFolderAsync(
+            new SaveUserDriveFolderRequest(
+                request.AthleteUserId.Trim(),
+                request.Email.Trim(),
+                userFolder.FolderId,
+                userFolder.Url),
+            cancellationToken);
+
+        return userFolder;
+    }
+
+    public async Task DeleteFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            throw new InvalidOperationException("An athlete user id is required.");
+
+        var existing = await _repository.FindUserFolderAsync(athleteUserId.Trim(), cancellationToken);
+        if (existing is null)
+            return;
+
+        await _storageProvider.DeleteFolderAsync(existing, cancellationToken);
+        await _repository.DeleteUserFolderAsync(athleteUserId.Trim(), cancellationToken);
+    }
+
+    private static void ValidateRequest(UserDriveFolderRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.AthleteUserId))
+            throw new InvalidOperationException("An athlete user id is required.");
+
+        if (string.IsNullOrWhiteSpace(request.Email))
+            throw new InvalidOperationException("A user email is required to share the Drive folder.");
+    }
+}

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/UserDriveFolderService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/UserDriveFolderService.cs
@@ -37,7 +37,7 @@ public sealed class UserDriveFolderService : IUserDriveFolderService
             return existing;
 
         var userFolder = await _storageProvider.EnsureUserFolderAsync(request, cancellationToken);
-        await _storageProvider.GrantUserWriteAccessAsync(userFolder, request.Email, cancellationToken);
+        await _storageProvider.GrantUserReadAccessAsync(userFolder, request.Email, cancellationToken);
         await _repository.SaveUserFolderAsync(
             new SaveUserDriveFolderRequest(
                 request.AthleteUserId.Trim(),

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/SaveUserDriveFolderRequest.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/SaveUserDriveFolderRequest.cs
@@ -1,0 +1,7 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+public sealed record SaveUserDriveFolderRequest(
+    string AthleteUserId,
+    string Email,
+    string FolderId,
+    string FolderUrl);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/UserDriveFolderRequest.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/UserDriveFolderRequest.cs
@@ -2,5 +2,4 @@ namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
 
 public sealed record UserDriveFolderRequest(
     string AthleteUserId,
-    string Email,
-    string DisplayName);
+    string Email);

--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/UserDriveFolderRequest.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Storage/UserDriveFolderRequest.cs
@@ -1,0 +1,6 @@
+namespace PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+public sealed record UserDriveFolderRequest(
+    string AthleteUserId,
+    string Email,
+    string DisplayName);

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
@@ -7,6 +7,7 @@ using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
 using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models;
 using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
 using System.Text;
+using System.Text.Json;
 
 namespace PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
 
@@ -156,15 +157,24 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
     {
         GoogleCredential credential;
 
-        if (!string.IsNullOrWhiteSpace(_options.ServiceAccountJson))
+        var serviceAccountJsonPath = _options.ServiceAccountJsonPath?.Trim();
+        var serviceAccountJson = _options.ServiceAccountJson?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(serviceAccountJsonPath) && System.IO.File.Exists(serviceAccountJsonPath))
         {
-            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(_options.ServiceAccountJson));
+            using var stream = System.IO.File.OpenRead(serviceAccountJsonPath);
             credential = ServiceAccountCredential.FromServiceAccountData(stream).ToGoogleCredential();
         }
-        else if (!string.IsNullOrWhiteSpace(_options.ServiceAccountJsonPath))
+        else if (!string.IsNullOrWhiteSpace(serviceAccountJson))
         {
-            using var stream = System.IO.File.OpenRead(_options.ServiceAccountJsonPath);
+            var normalizedJson = NormalizeServiceAccountJson(serviceAccountJson);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(normalizedJson));
             credential = ServiceAccountCredential.FromServiceAccountData(stream).ToGoogleCredential();
+        }
+        else if (!string.IsNullOrWhiteSpace(serviceAccountJsonPath))
+        {
+            throw new InvalidOperationException(
+                $"Google Drive service account credential file was not found: {serviceAccountJsonPath}");
         }
         else
         {
@@ -181,6 +191,64 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
                 ? "PaceLetics"
                 : _options.ApplicationName
         });
+    }
+
+    private static string NormalizeServiceAccountJson(string value)
+    {
+        var trimmed = value.Trim();
+
+        if (System.IO.File.Exists(trimmed))
+            return System.IO.File.ReadAllText(trimmed);
+
+        var unescaped = TryUnescapeJsonString(trimmed);
+        if (!string.Equals(unescaped, trimmed, StringComparison.Ordinal))
+            trimmed = unescaped.Trim();
+
+        if (!trimmed.StartsWith('{'))
+            trimmed = TryDecodeBase64(trimmed) ?? trimmed;
+
+        try
+        {
+            using var document = JsonDocument.Parse(trimmed);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                throw new InvalidOperationException("Google Drive service account credentials must be a JSON object.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                "Google Drive service account credentials are not valid JSON. Configure PaceLeticsUserData:GoogleDrive:ServiceAccountJsonPath with a readable credential file, or PaceLeticsUserData:GoogleDrive:ServiceAccountJson with raw or base64-encoded service account JSON.",
+                ex);
+        }
+
+        return trimmed;
+    }
+
+    private static string TryUnescapeJsonString(string value)
+    {
+        if (!value.StartsWith('"') || !value.EndsWith('"'))
+            return value;
+
+        try
+        {
+            return JsonSerializer.Deserialize<string>(value) ?? value;
+        }
+        catch (JsonException)
+        {
+            return value;
+        }
+    }
+
+    private static string? TryDecodeBase64(string value)
+    {
+        try
+        {
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(value));
+            return decoded.TrimStart().StartsWith('{') ? decoded : null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
     }
 
     private async Task<DriveFolderReference> EnsureRootFolderAsync(

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
@@ -10,7 +10,9 @@ using System.Text;
 
 namespace PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive;
 
-public sealed class GoogleDriveRunningAnalysisStorageProvider : IRunningAnalysisStorageProvider
+public sealed class GoogleDriveRunningAnalysisStorageProvider :
+    IRunningAnalysisStorageProvider,
+    IUserDriveFolderStorageProvider
 {
     private const string FolderMimeType = "application/vnd.google-apps.folder";
     private readonly GoogleDriveRunningAnalysisOptions _options;
@@ -65,6 +67,38 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider : IRunningAnalysis
         await request.ExecuteAsync(cancellationToken);
     }
 
+    public async Task<DriveFolderReference> EnsureUserFolderAsync(
+        UserDriveFolderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var drive = CreateDriveService();
+        var rootFolder = await EnsureRootFolderAsync(drive, cancellationToken);
+        var folderName = BuildUserFolderName(request);
+
+        return await EnsureFolderAsync(drive, folderName, rootFolder.FolderId, cancellationToken);
+    }
+
+    public Task GrantUserWriteAccessAsync(
+        DriveFolderReference userFolder,
+        string userEmail,
+        CancellationToken cancellationToken = default)
+    {
+        return GrantWriteAccessAsync(userFolder, userEmail, cancellationToken);
+    }
+
+    public async Task DeleteFolderAsync(
+        DriveFolderReference userFolder,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(userFolder.FolderId))
+            throw new InvalidOperationException("The Drive folder id is required.");
+
+        var drive = CreateDriveService();
+        var request = drive.Files.Delete(userFolder.FolderId);
+        request.SupportsAllDrives = true;
+        await request.ExecuteAsync(cancellationToken);
+    }
+
     public async Task<DriveFileReference> UploadRecordingAsync(
         UploadRecordingRequest request,
         CancellationToken cancellationToken = default)
@@ -94,6 +128,28 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider : IRunningAnalysis
             throw result.Exception ?? new InvalidOperationException("Google Drive upload failed.");
 
         return new DriveFileReference(upload.ResponseBody.Id, upload.ResponseBody.WebViewLink);
+    }
+
+    private async Task GrantWriteAccessAsync(
+        DriveFolderReference folder,
+        string email,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new InvalidOperationException("A user email is required to grant Drive access.");
+
+        var drive = CreateDriveService();
+        var permission = new Permission
+        {
+            Type = "user",
+            Role = "writer",
+            EmailAddress = email.Trim()
+        };
+
+        var request = drive.Permissions.Create(permission, folder.FolderId);
+        request.SendNotificationEmail = false;
+        request.SupportsAllDrives = true;
+        await request.ExecuteAsync(cancellationToken);
     }
 
     private DriveService CreateDriveService()
@@ -214,6 +270,18 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider : IRunningAnalysis
             : participant.AthleteUserId[^6..];
 
         return $"{SanitizeName(participant.DisplayName)} - {suffix}";
+    }
+
+    private static string BuildUserFolderName(UserDriveFolderRequest request)
+    {
+        var displayName = string.IsNullOrWhiteSpace(request.DisplayName)
+            ? request.Email
+            : request.DisplayName;
+        var suffix = request.AthleteUserId.Length <= 6
+            ? request.AthleteUserId
+            : request.AthleteUserId[^6..];
+
+        return $"PaceLetics - {SanitizeName(displayName)} - {suffix}";
     }
 
     private static string SanitizeName(string value)

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
@@ -79,12 +79,12 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
         return await EnsureFolderAsync(drive, folderName, rootFolder.FolderId, cancellationToken);
     }
 
-    public Task GrantUserWriteAccessAsync(
+    public Task GrantUserReadAccessAsync(
         DriveFolderReference userFolder,
         string userEmail,
         CancellationToken cancellationToken = default)
     {
-        return GrantWriteAccessAsync(userFolder, userEmail, cancellationToken);
+        return GrantAccessAsync(userFolder, userEmail, role: "reader", cancellationToken);
     }
 
     public async Task DeleteFolderAsync(
@@ -131,9 +131,10 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
         return new DriveFileReference(upload.ResponseBody.Id, upload.ResponseBody.WebViewLink);
     }
 
-    private async Task GrantWriteAccessAsync(
+    private async Task GrantAccessAsync(
         DriveFolderReference folder,
         string email,
+        string role,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(email))
@@ -143,7 +144,7 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
         var permission = new Permission
         {
             Type = "user",
-            Role = "writer",
+            Role = role,
             EmailAddress = email.Trim()
         };
 
@@ -342,14 +343,11 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
 
     private static string BuildUserFolderName(UserDriveFolderRequest request)
     {
-        var displayName = string.IsNullOrWhiteSpace(request.DisplayName)
-            ? request.Email
-            : request.DisplayName;
         var suffix = request.AthleteUserId.Length <= 6
             ? request.AthleteUserId
             : request.AthleteUserId[^6..];
 
-        return $"PaceLetics - {SanitizeName(displayName)} - {suffix}";
+        return $"PaceLetics - User - {SanitizeName(suffix)}";
     }
 
     private static string SanitizeName(string value)

--- a/PaceLetics.Tests/UserDriveFolderServiceTests.cs
+++ b/PaceLetics.Tests/UserDriveFolderServiceTests.cs
@@ -18,8 +18,7 @@ public sealed class UserDriveFolderServiceTests
 
         var folder = await service.CreateFolderAsync(new UserDriveFolderRequest(
             "athlete-1",
-            "athlete@example.com",
-            "Athlete One"));
+            "athlete@example.com"));
 
         Assert.Equal("existing-folder", folder.FolderId);
         Assert.Empty(storage.CreatedFolders);
@@ -35,12 +34,11 @@ public sealed class UserDriveFolderServiceTests
 
         var folder = await service.CreateFolderAsync(new UserDriveFolderRequest(
             "athlete-1",
-            "athlete@example.com",
-            "Athlete One"));
+            "athlete@example.com"));
 
         Assert.Equal("user-folder-athlete-1", folder.FolderId);
         Assert.Single(storage.CreatedFolders);
-        Assert.Single(storage.SharedFolders);
+        Assert.Single(storage.ReadableFolders);
         Assert.Single(repository.SavedFolders);
         Assert.Equal("athlete@example.com", repository.SavedFolders[0].Email);
     }
@@ -97,7 +95,7 @@ public sealed class UserDriveFolderServiceTests
     private sealed class FakeUserDriveFolderStorageProvider : IUserDriveFolderStorageProvider
     {
         public List<UserDriveFolderRequest> CreatedFolders { get; } = new();
-        public List<(DriveFolderReference Folder, string Email)> SharedFolders { get; } = new();
+        public List<(DriveFolderReference Folder, string Email)> ReadableFolders { get; } = new();
         public List<DriveFolderReference> DeletedFolders { get; } = new();
 
         public Task<DriveFolderReference> EnsureUserFolderAsync(
@@ -110,12 +108,12 @@ public sealed class UserDriveFolderServiceTests
                 $"https://drive.test/user-folder-{request.AthleteUserId}"));
         }
 
-        public Task GrantUserWriteAccessAsync(
+        public Task GrantUserReadAccessAsync(
             DriveFolderReference userFolder,
             string userEmail,
             CancellationToken cancellationToken = default)
         {
-            SharedFolders.Add((userFolder, userEmail));
+            ReadableFolders.Add((userFolder, userEmail));
             return Task.CompletedTask;
         }
 

--- a/PaceLetics.Tests/UserDriveFolderServiceTests.cs
+++ b/PaceLetics.Tests/UserDriveFolderServiceTests.cs
@@ -1,0 +1,130 @@
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Services;
+using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
+
+namespace PaceLetics.Tests;
+
+public sealed class UserDriveFolderServiceTests
+{
+    [Fact]
+    public async Task CreateFolderAsync_ReturnsExistingFolderWithoutCreatingANewOne()
+    {
+        var repository = new FakeUserDriveFolderRepository
+        {
+            ExistingFolder = new DriveFolderReference("existing-folder", "https://drive.test/existing-folder")
+        };
+        var storage = new FakeUserDriveFolderStorageProvider();
+        var service = new UserDriveFolderService(repository, storage);
+
+        var folder = await service.CreateFolderAsync(new UserDriveFolderRequest(
+            "athlete-1",
+            "athlete@example.com",
+            "Athlete One"));
+
+        Assert.Equal("existing-folder", folder.FolderId);
+        Assert.Empty(storage.CreatedFolders);
+        Assert.Empty(repository.SavedFolders);
+    }
+
+    [Fact]
+    public async Task CreateFolderAsync_CreatesSharesAndSavesFolder()
+    {
+        var repository = new FakeUserDriveFolderRepository();
+        var storage = new FakeUserDriveFolderStorageProvider();
+        var service = new UserDriveFolderService(repository, storage);
+
+        var folder = await service.CreateFolderAsync(new UserDriveFolderRequest(
+            "athlete-1",
+            "athlete@example.com",
+            "Athlete One"));
+
+        Assert.Equal("user-folder-athlete-1", folder.FolderId);
+        Assert.Single(storage.CreatedFolders);
+        Assert.Single(storage.SharedFolders);
+        Assert.Single(repository.SavedFolders);
+        Assert.Equal("athlete@example.com", repository.SavedFolders[0].Email);
+    }
+
+    [Fact]
+    public async Task DeleteFolderAsync_DeletesDriveFolderAndReference()
+    {
+        var repository = new FakeUserDriveFolderRepository
+        {
+            ExistingFolder = new DriveFolderReference("existing-folder", "https://drive.test/existing-folder")
+        };
+        var storage = new FakeUserDriveFolderStorageProvider();
+        var service = new UserDriveFolderService(repository, storage);
+
+        await service.DeleteFolderAsync("athlete-1");
+
+        Assert.Single(storage.DeletedFolders);
+        Assert.Equal("existing-folder", storage.DeletedFolders[0].FolderId);
+        Assert.Equal("athlete-1", repository.DeletedAthleteUserIds.Single());
+    }
+
+    private sealed class FakeUserDriveFolderRepository : IUserDriveFolderRepository
+    {
+        public DriveFolderReference? ExistingFolder { get; set; }
+        public List<SaveUserDriveFolderRequest> SavedFolders { get; } = new();
+        public List<string> DeletedAthleteUserIds { get; } = new();
+
+        public Task<DriveFolderReference?> FindUserFolderAsync(
+            string athleteUserId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ExistingFolder);
+        }
+
+        public Task SaveUserFolderAsync(
+            SaveUserDriveFolderRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            SavedFolders.Add(request);
+            ExistingFolder = new DriveFolderReference(request.FolderId, request.FolderUrl);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteUserFolderAsync(
+            string athleteUserId,
+            CancellationToken cancellationToken = default)
+        {
+            DeletedAthleteUserIds.Add(athleteUserId);
+            ExistingFolder = null;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeUserDriveFolderStorageProvider : IUserDriveFolderStorageProvider
+    {
+        public List<UserDriveFolderRequest> CreatedFolders { get; } = new();
+        public List<(DriveFolderReference Folder, string Email)> SharedFolders { get; } = new();
+        public List<DriveFolderReference> DeletedFolders { get; } = new();
+
+        public Task<DriveFolderReference> EnsureUserFolderAsync(
+            UserDriveFolderRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            CreatedFolders.Add(request);
+            return Task.FromResult(new DriveFolderReference(
+                $"user-folder-{request.AthleteUserId}",
+                $"https://drive.test/user-folder-{request.AthleteUserId}"));
+        }
+
+        public Task GrantUserWriteAccessAsync(
+            DriveFolderReference userFolder,
+            string userEmail,
+            CancellationToken cancellationToken = default)
+        {
+            SharedFolders.Add((userFolder, userEmail));
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteFolderAsync(
+            DriveFolderReference userFolder,
+            CancellationToken cancellationToken = default)
+        {
+            DeletedFolders.Add(userFolder);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/PaceLetics.Web/Pages/Athletes/MyDrive.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyDrive.razor
@@ -1,0 +1,177 @@
+@page "/Athletes/drive"
+@attribute [Authorize]
+@using System.Security.Claims
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IUserDriveFolderService UserDriveFolderService
+@inject IJSRuntime JS
+@inject ISnackbar Snackbar
+@inject LoadingStateService Loading
+@inject IStringLocalizer<MyDrive> L
+
+<PageTitle>@L["PageTitle"]</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
+    <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
+
+    <MudDivider Class="my-4" />
+
+    @if (!string.IsNullOrWhiteSpace(_errorMessage))
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4">@_errorMessage</MudAlert>
+    }
+
+    <MudPaper Elevation="0" Class="pa-4 pl-course-detail">
+        @if (_folder is null)
+        {
+            <MudStack Spacing="3">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="gap:12px;">
+                    <MudIcon Icon="@Icons.Material.Filled.FolderOff" Color="Color.Secondary" />
+                    <div>
+                        <MudText Typo="Typo.subtitle2">@L["NoFolderTitle"]</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoFolderText"]</MudText>
+                    </div>
+                </MudStack>
+
+                <MudStack Row="true" Justify="Justify.FlexEnd">
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.CreateNewFolder"
+                               Disabled="_isBusy"
+                               OnClick="CreateFolderAsync">
+                        @L["CreateFolder"]
+                    </MudButton>
+                </MudStack>
+            </MudStack>
+        }
+        else
+        {
+            <MudStack Spacing="3">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="gap:12px;">
+                    <MudIcon Icon="@Icons.Material.Filled.FolderOpen" Color="Color.Primary" />
+                    <div style="min-width:0;">
+                        <MudText Typo="Typo.subtitle2">@L["FolderReadyTitle"]</MudText>
+                        <MudLink Href="@_folder.Url" Target="_blank" Typo="Typo.body2">@L["OpenFolder"]</MudLink>
+                    </div>
+                </MudStack>
+
+                <MudStack Row="true" Justify="Justify.FlexEnd" Style="gap:8px;">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.OpenInNew"
+                               Disabled="_isBusy"
+                               OnClick="OpenFolderAsync">
+                        @L["OpenFolder"]
+                    </MudButton>
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Error"
+                               StartIcon="@Icons.Material.Filled.Delete"
+                               Disabled="_isBusy"
+                               OnClick="DeleteFolderAsync">
+                        @L["DeleteFolder"]
+                    </MudButton>
+                </MudStack>
+            </MudStack>
+        }
+    </MudPaper>
+</MudContainer>
+
+@code {
+    private string? _userId;
+    private string? _email;
+    private string? _displayName;
+    private string? _errorMessage;
+    private DriveFolderReference? _folder;
+    private bool _isBusy;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        await Loading.RunAsync(L["Loading"], async () =>
+        {
+            try
+            {
+                _errorMessage = null;
+                var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                _userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                _email = authState.User.FindFirst(ClaimTypes.Email)?.Value
+                    ?? authState.User.FindFirst("email")?.Value
+                    ?? authState.User.Identity?.Name;
+                _displayName = authState.User.Identity?.Name ?? _email ?? _userId;
+
+                if (string.IsNullOrWhiteSpace(_userId))
+                    throw new InvalidOperationException(L["AthleteNotResolved"]);
+
+                _folder = await UserDriveFolderService.GetFolderAsync(_userId);
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                _folder = null;
+            }
+        });
+    }
+
+    private async Task CreateFolderAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_userId))
+            return;
+
+        try
+        {
+            _isBusy = true;
+            _folder = await UserDriveFolderService.CreateFolderAsync(
+                new UserDriveFolderRequest(
+                    _userId,
+                    _email ?? string.Empty,
+                    _displayName ?? string.Empty));
+            Snackbar.Add(L["CreateSuccess"], Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private async Task DeleteFolderAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_userId))
+            return;
+
+        try
+        {
+            var confirmed = await JS.InvokeAsync<bool>("confirm", L["DeleteConfirm"].Value);
+            if (!confirmed)
+                return;
+
+            _isBusy = true;
+            await UserDriveFolderService.DeleteFolderAsync(_userId);
+            _folder = null;
+            Snackbar.Add(L["DeleteSuccess"], Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private Task OpenFolderAsync()
+    {
+        return _folder is null
+            ? Task.CompletedTask
+            : JS.InvokeVoidAsync("open", _folder.Url, "_blank").AsTask();
+    }
+}

--- a/PaceLetics.Web/Pages/Athletes/MyDrive.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyDrive.razor
@@ -80,7 +80,6 @@
 @code {
     private string? _userId;
     private string? _email;
-    private string? _displayName;
     private string? _errorMessage;
     private DriveFolderReference? _folder;
     private bool _isBusy;
@@ -102,7 +101,6 @@
                 _email = authState.User.FindFirst(ClaimTypes.Email)?.Value
                     ?? authState.User.FindFirst("email")?.Value
                     ?? authState.User.Identity?.Name;
-                _displayName = authState.User.Identity?.Name ?? _email ?? _userId;
 
                 if (string.IsNullOrWhiteSpace(_userId))
                     throw new InvalidOperationException(L["AthleteNotResolved"]);
@@ -128,8 +126,7 @@
             _folder = await UserDriveFolderService.CreateFolderAsync(
                 new UserDriveFolderRequest(
                     _userId,
-                    _email ?? string.Empty,
-                    _displayName ?? string.Empty));
+                    _email ?? string.Empty));
             Snackbar.Add(L["CreateSuccess"], Severity.Success);
         }
         catch (Exception ex)

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -121,11 +121,16 @@ builder.Services.Configure<GoogleDriveRunningAnalysisOptions>(options =>
 builder.Services.AddScoped<CosmosRunningAnalysisRepository>();
 builder.Services.AddScoped<IRunningAnalysisRepository>(x => x.GetRequiredService<CosmosRunningAnalysisRepository>());
 builder.Services.AddScoped<IUserDriveFolderRegistry>(x => x.GetRequiredService<CosmosRunningAnalysisRepository>());
+builder.Services.AddScoped<IUserDriveFolderRepository>(x => x.GetRequiredService<CosmosRunningAnalysisRepository>());
 builder.Services.AddSingleton<IRunningAnalysisClock, SystemRunningAnalysisClock>();
 builder.Services.AddScoped<IRunningAnalysisStorageProvider>(x =>
     new GoogleDriveRunningAnalysisStorageProvider(
         x.GetRequiredService<IOptions<GoogleDriveRunningAnalysisOptions>>().Value));
+builder.Services.AddScoped<IUserDriveFolderStorageProvider>(x =>
+    new GoogleDriveRunningAnalysisStorageProvider(
+        x.GetRequiredService<IOptions<GoogleDriveRunningAnalysisOptions>>().Value));
 builder.Services.AddScoped<IRunningAnalysisService, RunningAnalysisService>();
+builder.Services.AddScoped<IUserDriveFolderService, UserDriveFolderService>();
 builder.Services.AddScoped<ICourseRunningAnalysisRegistrationAdapter, CourseRunningAnalysisRegistrationAdapter>();
 builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddScoped<ITrainingPlanService, TrainingPlanService>();

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyDrive.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyDrive.de.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>My Drive</value></data>
+  <data name="Title" xml:space="preserve"><value>My Drive</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Dein persoenlicher PaceLetics-Ordner in Google Drive</value></data>
+  <data name="Loading" xml:space="preserve"><value>Drive-Ordner wird geladen</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>Athlet:in konnte nicht ermittelt werden.</value></data>
+  <data name="NoFolderTitle" xml:space="preserve"><value>Noch kein Drive-Ordner</value></data>
+  <data name="NoFolderText" xml:space="preserve"><value>Erstelle deinen Ordner, um PaceLetics-Dateien in Google Drive zu speichern.</value></data>
+  <data name="CreateFolder" xml:space="preserve"><value>Ordner erstellen</value></data>
+  <data name="CreateSuccess" xml:space="preserve"><value>Drive-Ordner wurde erstellt.</value></data>
+  <data name="FolderReadyTitle" xml:space="preserve"><value>Dein Drive-Ordner ist bereit</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Ordner oeffnen</value></data>
+  <data name="DeleteFolder" xml:space="preserve"><value>Ordner loeschen</value></data>
+  <data name="DeleteConfirm" xml:space="preserve"><value>Deinen PaceLetics-Drive-Ordner loeschen? Dadurch wird der Ordner aus Google Drive entfernt.</value></data>
+  <data name="DeleteSuccess" xml:space="preserve"><value>Drive-Ordner wurde geloescht.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyDrive.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyDrive.en.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>My Drive</value></data>
+  <data name="Title" xml:space="preserve"><value>My Drive</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Your personal PaceLetics Google Drive folder</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading Drive folder</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>The athlete could not be resolved.</value></data>
+  <data name="NoFolderTitle" xml:space="preserve"><value>No Drive folder yet</value></data>
+  <data name="NoFolderText" xml:space="preserve"><value>Create your folder to store PaceLetics files in Google Drive.</value></data>
+  <data name="CreateFolder" xml:space="preserve"><value>Create folder</value></data>
+  <data name="CreateSuccess" xml:space="preserve"><value>Drive folder created.</value></data>
+  <data name="FolderReadyTitle" xml:space="preserve"><value>Your Drive folder is ready</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="DeleteFolder" xml:space="preserve"><value>Delete folder</value></data>
+  <data name="DeleteConfirm" xml:space="preserve"><value>Delete your PaceLetics Drive folder? This removes the folder from Google Drive.</value></data>
+  <data name="DeleteSuccess" xml:space="preserve"><value>Drive folder deleted.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyDrive.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyDrive.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>My Drive</value></data>
+  <data name="Title" xml:space="preserve"><value>My Drive</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Your personal PaceLetics Google Drive folder</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading Drive folder</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>The athlete could not be resolved.</value></data>
+  <data name="NoFolderTitle" xml:space="preserve"><value>No Drive folder yet</value></data>
+  <data name="NoFolderText" xml:space="preserve"><value>Create your folder to store PaceLetics files in Google Drive.</value></data>
+  <data name="CreateFolder" xml:space="preserve"><value>Create folder</value></data>
+  <data name="CreateSuccess" xml:space="preserve"><value>Drive folder created.</value></data>
+  <data name="FolderReadyTitle" xml:space="preserve"><value>Your Drive folder is ready</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="DeleteFolder" xml:space="preserve"><value>Delete folder</value></data>
+  <data name="DeleteConfirm" xml:space="preserve"><value>Delete your PaceLetics Drive folder? This removes the folder from Google Drive.</value></data>
+  <data name="DeleteSuccess" xml:space="preserve"><value>Drive folder deleted.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -37,6 +37,7 @@
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pacebereiche</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>Meine Kurse</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>Meine Analysen</value></data>
+  <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Kurse verwalten</value></data>
   <data name="Nav_TrainerRunningAnalyses" xml:space="preserve"><value>Laufanalysen</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Trainingsplanung</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -37,6 +37,7 @@
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
+  <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>
   <data name="Nav_TrainerRunningAnalyses" xml:space="preserve"><value>Running Analyses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.resx
@@ -37,6 +37,7 @@
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
+  <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>
   <data name="Nav_TrainerRunningAnalyses" xml:space="preserve"><value>Running Analyses</value></data>
   <data name="Nav_TrainingPlan" xml:space="preserve"><value>Training Plan</value></data>

--- a/PaceLetics.Web/Services/RunningAnalysis/CosmosRunningAnalysisRepository.cs
+++ b/PaceLetics.Web/Services/RunningAnalysis/CosmosRunningAnalysisRepository.cs
@@ -6,7 +6,10 @@ using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage;
 
 namespace PaceLetics.Web.Services.RunningAnalysis;
 
-public sealed class CosmosRunningAnalysisRepository : IRunningAnalysisRepository, IUserDriveFolderRegistry
+public sealed class CosmosRunningAnalysisRepository :
+    IRunningAnalysisRepository,
+    IUserDriveFolderRegistry,
+    IUserDriveFolderRepository
 {
     private readonly IDataAccess _db;
     private readonly AthleteDataOptions _options;
@@ -136,6 +139,56 @@ public sealed class CosmosRunningAnalysisRepository : IRunningAnalysisRepository
             document.CourseId);
     }
 
+    public async Task<DriveFolderReference?> FindUserFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return null;
+
+        var reference = await _db.LoadItem<UserDriveFolderReferenceDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            UserFolderReferenceId(athleteUserId.Trim()),
+            UserDriveFolderReferenceDocument.PartitionKeyValue);
+
+        return reference is null
+            ? null
+            : new DriveFolderReference(reference.FolderId, reference.FolderUrl);
+    }
+
+    public Task SaveUserFolderAsync(
+        SaveUserDriveFolderRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var document = new UserDriveFolderReferenceDocument
+        {
+            Id = UserFolderReferenceId(request.AthleteUserId),
+            AthleteUserId = request.AthleteUserId,
+            Email = request.Email,
+            FolderId = request.FolderId,
+            FolderUrl = request.FolderUrl,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            document,
+            UserDriveFolderReferenceDocument.PartitionKeyValue);
+    }
+
+    public Task DeleteUserFolderAsync(
+        string athleteUserId,
+        CancellationToken cancellationToken = default)
+    {
+        return _db.DeleteItem<UserDriveFolderReferenceDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            UserFolderReferenceId(athleteUserId),
+            UserDriveFolderReferenceDocument.PartitionKeyValue);
+    }
+
     private Task<List<T>> LoadAllAsync<T>(string documentType)
     {
         return _db.LoadData<T>(_options.DatabaseName, _options.CourseContainerName, documentType);
@@ -151,5 +204,10 @@ public sealed class CosmosRunningAnalysisRepository : IRunningAnalysisRepository
     private static string FolderReferenceId(string courseId, string externalEventId, string athleteUserId)
     {
         return $"running-analysis-folder:{courseId}:{externalEventId}:{athleteUserId}";
+    }
+
+    private static string UserFolderReferenceId(string athleteUserId)
+    {
+        return $"user-drive-folder:{athleteUserId.Trim()}";
     }
 }

--- a/PaceLetics.Web/Services/RunningAnalysis/RunningAnalysisDocumentTypes.cs
+++ b/PaceLetics.Web/Services/RunningAnalysis/RunningAnalysisDocumentTypes.cs
@@ -6,4 +6,5 @@ public static class RunningAnalysisDocumentTypes
     public const string Participant = "runningAnalysisParticipant";
     public const string Recording = "runningAnalysisRecording";
     public const string FolderReference = "runningAnalysisFolderReference";
+    public const string UserFolderReference = "userDriveFolderReference";
 }

--- a/PaceLetics.Web/Services/RunningAnalysis/UserDriveFolderReferenceDocument.cs
+++ b/PaceLetics.Web/Services/RunningAnalysis/UserDriveFolderReferenceDocument.cs
@@ -1,0 +1,17 @@
+using PaceLetics.CoreModule.Infrastructure.Interfaces;
+
+namespace PaceLetics.Web.Services.RunningAnalysis;
+
+public sealed class UserDriveFolderReferenceDocument : IQueryItem
+{
+    public const string PartitionKeyValue = "user-drive-folders";
+
+    public string Id { get; set; } = string.Empty;
+    public string CourseId { get; set; } = PartitionKeyValue;
+    public string AthleteUserId { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string FolderId { get; set; } = string.Empty;
+    public string FolderUrl { get; set; } = string.Empty;
+    public string DocumentType { get; set; } = RunningAnalysisDocumentTypes.UserFolderReference;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/PaceLetics.Web/Shared/NavMenu.razor
+++ b/PaceLetics.Web/Shared/NavMenu.razor
@@ -6,6 +6,7 @@
     <MudNavLink Href="/Athletes/trainingpaces" Match="NavLinkMatch.Prefix">@L["Nav_PaceZones"]</MudNavLink>
     <MudNavLink Href="/Athletes/courses" Match="NavLinkMatch.Prefix">@L["Nav_Courses"]</MudNavLink>
     <MudNavLink Href="/Athletes/analyses" Match="NavLinkMatch.Prefix">@L["Nav_Analyses"]</MudNavLink>
+    <MudNavLink Href="/Athletes/drive" Match="NavLinkMatch.Prefix">@L["Nav_MyDrive"]</MudNavLink>
     <AuthorizeView Roles="@ApplicationRoles.Trainer">
         <Authorized>
             <MudNavLink Href="/Trainers/courses" Match="NavLinkMatch.Prefix">@L["Nav_TrainerCourses"]</MudNavLink>


### PR DESCRIPTION
Summary
Added a new authenticated My Drive area where users can manage their personal PaceLetics Google Drive folder.
Added a navigation entry for My Drive.
Added create, view, and delete flows for per-user Drive folders.
Kept folder names anonymous by excluding email addresses and display names.
Hardened Google Drive service account credential loading for local and hosted environments.
User Experience
Users can open /Athletes/drive from the navigation menu.
If no folder exists, the page shows a Create folder action.
If a folder exists, the page shows an Open folder link and a Delete folder action.
Folder deletion remains controlled through the app button and service account flow.
The folder link is not public. It works for the Google account that was explicitly granted access.
Google Drive Behavior
User folders are created below the configured PaceLetics Drive root.
User folder names use the format:
PaceLetics - User - {last 6 chars of AthleteUserId}
The user's email address is used only for permission assignment, not for folder naming.
Users receive reader access to their folder.
The service account remains responsible for folder lifecycle operations, including deletion.
Credential Handling
ServiceAccountJsonPath is preferred when it points to an existing credential file.
ServiceAccountJson supports:
raw service account JSON
quoted or escaped JSON strings
base64-encoded service account JSON
a file path accidentally supplied in the JSON setting
Invalid credential JSON now produces a clearer configuration error.
Implementation Details
Added user Drive folder contracts:
IUserDriveFolderService
IUserDriveFolderRepository
IUserDriveFolderStorageProvider
Added request models:
UserDriveFolderRequest
SaveUserDriveFolderRequest
Added UserDriveFolderService to coordinate repository and Google Drive operations.
Extended the Google Drive storage provider with:
user folder creation
user read access grants
Drive folder deletion
robust credential normalization
Extended the Cosmos running analysis repository with user folder references.
Registered the new services in web dependency injection.
Added localized My Drive page resources for English, German, and fallback resources.
Tests
Added UserDriveFolderServiceTests covering:
reusing an existing folder reference
creating, sharing, and saving a new folder reference
deleting the Drive folder and stored reference
Verification
dotnet test PaceLeticsFramework.sln passed.
Test result: 111 passed, 0 failed, 0 skipped.
Existing NuGet advisory warnings for OpenMcdf and SharpCompress still appear and are unrelated to this PR.