### PR TITLE
Daten und Analysen in Bottom-Bar bündeln

### DIFF
--- a/PaceLetics.Web/Pages/Athletes/DataAndAnalyses.razor
+++ b/PaceLetics.Web/Pages/Athletes/DataAndAnalyses.razor
@@ -1,0 +1,231 @@
+@page "/Athletes/data-analyses"
+@attribute [Authorize]
+@using System.Security.Claims
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Interfaces
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Models
+@using PaceLetics.RunningAnalysisModule.CodeBase.RunningAnalysis.Storage
+@using PaceLetics.RunningAnalysisModule.Components
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IRunningAnalysisService RunningAnalysisService
+@inject IUserDriveFolderService UserDriveFolderService
+@inject IJSRuntime JS
+@inject ISnackbar Snackbar
+@inject LoadingStateService Loading
+@inject IStringLocalizer<DataAndAnalyses> L
+
+<PageTitle>@L["PageTitle"]</PageTitle>
+
+<MudContainer Class="pt-6 px-6 pb-8" MaxWidth="MaxWidth.Small">
+    <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
+
+    <MudStack Spacing="4" Class="mt-4">
+        <MudPaper Elevation="0" Class="pa-4 pl-course-detail">
+            <MudStack Spacing="3">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="gap:12px;">
+                    <MudIcon Icon="@Icons.Material.Filled.Analytics" Color="Color.Primary" />
+                    <div>
+                        <MudText Typo="Typo.subtitle2">@L["AnalysesTitle"]</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">@L["AnalysesSubtitle"]</MudText>
+                    </div>
+                </MudStack>
+
+                @if (!string.IsNullOrWhiteSpace(_errorMessage))
+                {
+                    <MudAlert Severity="Severity.Error" Variant="Variant.Outlined">@_errorMessage</MudAlert>
+                }
+                else if (_folder is null)
+                {
+                    <MudAlert Severity="Severity.Info"
+                              Variant="Variant.Outlined"
+                              Icon="@Icons.Material.Filled.FolderOff">
+                        @L["DriveRequiredForAnalyses"]
+                    </MudAlert>
+                }
+                else
+                {
+                    <RunningAnalysisLinks Items="_analyses"
+                                          EmptyText="@L["NoAnalyses"]"
+                                          OpenText="@L["OpenFolder"]" />
+                }
+            </MudStack>
+        </MudPaper>
+
+        <MudPaper Elevation="0" Class="pa-4 pl-panel">
+            <MudStack Spacing="3">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Style="gap:12px;">
+                    <MudIcon Icon="@GetDriveIcon()" Color="@GetDriveIconColor()" />
+                    <div style="min-width:0;">
+                        <MudText Typo="Typo.subtitle2">@L["DriveTitle"]</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">@GetDriveDescription()</MudText>
+                    </div>
+                </MudStack>
+
+                @if (_folder is null)
+                {
+                    <MudStack Row="true" Justify="Justify.FlexEnd">
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.CreateNewFolder"
+                                   Disabled="_isBusy || string.IsNullOrWhiteSpace(_userId)"
+                                   OnClick="CreateFolderAsync">
+                            @L["CreateFolder"]
+                        </MudButton>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudLink Href="@_folder.Url" Target="_blank" Typo="Typo.body2">@L["OpenFolder"]</MudLink>
+
+                    <MudStack Row="true" Justify="Justify.FlexEnd" Style="gap:8px; flex-wrap:wrap;">
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.OpenInNew"
+                                   Disabled="_isBusy"
+                                   OnClick="OpenFolderAsync">
+                            @L["OpenFolder"]
+                        </MudButton>
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Error"
+                                   StartIcon="@Icons.Material.Filled.Delete"
+                                   Disabled="_isBusy"
+                                   OnClick="DeleteFolderAsync">
+                            @L["DeleteFolder"]
+                        </MudButton>
+                    </MudStack>
+                }
+            </MudStack>
+        </MudPaper>
+    </MudStack>
+</MudContainer>
+
+@code {
+    private string? _userId;
+    private string? _email;
+    private string? _errorMessage;
+    private DriveFolderReference? _folder;
+    private IReadOnlyList<RunningAnalysisLink> _analyses = Array.Empty<RunningAnalysisLink>();
+    private bool _isBusy;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        await Loading.RunAsync(L["Loading"], async () =>
+        {
+            try
+            {
+                _errorMessage = null;
+                _analyses = Array.Empty<RunningAnalysisLink>();
+
+                var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+                _userId = authState.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                    ?? authState.User.FindFirst(claim => claim.Type.Contains("nameidentifier", StringComparison.OrdinalIgnoreCase))?.Value;
+                _email = authState.User.FindFirst(ClaimTypes.Email)?.Value
+                    ?? authState.User.FindFirst("email")?.Value
+                    ?? authState.User.Identity?.Name;
+
+                if (string.IsNullOrWhiteSpace(_userId))
+                    throw new InvalidOperationException(L["AthleteNotResolved"]);
+
+                _folder = await UserDriveFolderService.GetFolderAsync(_userId);
+                if (_folder is not null)
+                    await LoadAnalysesAsync();
+            }
+            catch (Exception ex)
+            {
+                _errorMessage = ex.Message;
+                _folder = null;
+                _analyses = Array.Empty<RunningAnalysisLink>();
+            }
+        });
+    }
+
+    private async Task LoadAnalysesAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_userId))
+            return;
+
+        _analyses = await RunningAnalysisService.GetAnalysesForAthleteAsync(_userId);
+    }
+
+    private async Task CreateFolderAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_userId))
+            return;
+
+        try
+        {
+            _isBusy = true;
+            _folder = await UserDriveFolderService.CreateFolderAsync(
+                new UserDriveFolderRequest(
+                    _userId,
+                    _email ?? string.Empty));
+            await LoadAnalysesAsync();
+            Snackbar.Add(L["CreateSuccess"], Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private async Task DeleteFolderAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_userId))
+            return;
+
+        try
+        {
+            var confirmed = await JS.InvokeAsync<bool>("confirm", L["DeleteConfirm"].Value);
+            if (!confirmed)
+                return;
+
+            _isBusy = true;
+            await UserDriveFolderService.DeleteFolderAsync(_userId);
+            _folder = null;
+            _analyses = Array.Empty<RunningAnalysisLink>();
+            Snackbar.Add(L["DeleteSuccess"], Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private Task OpenFolderAsync()
+    {
+        return _folder is null
+            ? Task.CompletedTask
+            : JS.InvokeVoidAsync("open", _folder.Url, "_blank").AsTask();
+    }
+
+    private string GetDriveIcon()
+    {
+        return _folder is null
+            ? Icons.Material.Filled.FolderOff
+            : Icons.Material.Filled.FolderOpen;
+    }
+
+    private Color GetDriveIconColor()
+    {
+        return _folder is null ? Color.Secondary : Color.Primary;
+    }
+
+    private string GetDriveDescription()
+    {
+        return _folder is null
+            ? L["NoFolderText"]
+            : L["FolderReadyText"];
+    }
+}

--- a/PaceLetics.Web/Resources/Pages/Athletes/DataAndAnalyses.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/DataAndAnalyses.de.resx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Daten &amp; Analysen</value></data>
+  <data name="Title" xml:space="preserve"><value>Daten &amp; Analysen</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Deine Laufanalysen und dein Drive-Ordner an einem Ort</value></data>
+  <data name="Loading" xml:space="preserve"><value>Daten und Analysen werden geladen</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>Athlet:in konnte nicht ermittelt werden.</value></data>
+  <data name="AnalysesTitle" xml:space="preserve"><value>Analysen</value></data>
+  <data name="AnalysesSubtitle" xml:space="preserve"><value>Deine freigegebenen Laufanalyse-Ordner</value></data>
+  <data name="DriveRequiredForAnalyses" xml:space="preserve"><value>Verlinke zuerst deinen Drive-Ordner, damit hier Analysen angezeigt werden koennen.</value></data>
+  <data name="NoAnalyses" xml:space="preserve"><value>Noch keine Analysen verfuegbar.</value></data>
+  <data name="DriveTitle" xml:space="preserve"><value>Drive-Ordner</value></data>
+  <data name="NoFolderText" xml:space="preserve"><value>Noch kein Drive-Ordner verlinkt.</value></data>
+  <data name="FolderReadyText" xml:space="preserve"><value>Dein Drive-Ordner ist verlinkt und bereit.</value></data>
+  <data name="CreateFolder" xml:space="preserve"><value>Ordner erstellen</value></data>
+  <data name="CreateSuccess" xml:space="preserve"><value>Drive-Ordner wurde erstellt.</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Ordner oeffnen</value></data>
+  <data name="DeleteFolder" xml:space="preserve"><value>Ordner loeschen</value></data>
+  <data name="DeleteConfirm" xml:space="preserve"><value>Deinen PaceLetics-Drive-Ordner loeschen? Dadurch wird der Ordner aus Google Drive entfernt.</value></data>
+  <data name="DeleteSuccess" xml:space="preserve"><value>Drive-Ordner wurde geloescht.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/DataAndAnalyses.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/DataAndAnalyses.en.resx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Data &amp; Analyses</value></data>
+  <data name="Title" xml:space="preserve"><value>Data &amp; Analyses</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Your running analyses and Drive folder in one place</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading data and analyses</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>The athlete could not be resolved.</value></data>
+  <data name="AnalysesTitle" xml:space="preserve"><value>Analyses</value></data>
+  <data name="AnalysesSubtitle" xml:space="preserve"><value>Your shared running analysis folders</value></data>
+  <data name="DriveRequiredForAnalyses" xml:space="preserve"><value>Link your Drive folder before analyses can be shown here.</value></data>
+  <data name="NoAnalyses" xml:space="preserve"><value>No analyses available yet.</value></data>
+  <data name="DriveTitle" xml:space="preserve"><value>Drive folder</value></data>
+  <data name="NoFolderText" xml:space="preserve"><value>No Drive folder is linked yet.</value></data>
+  <data name="FolderReadyText" xml:space="preserve"><value>Your Drive folder is linked and ready.</value></data>
+  <data name="CreateFolder" xml:space="preserve"><value>Create folder</value></data>
+  <data name="CreateSuccess" xml:space="preserve"><value>Drive folder created.</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="DeleteFolder" xml:space="preserve"><value>Delete folder</value></data>
+  <data name="DeleteConfirm" xml:space="preserve"><value>Delete your PaceLetics Drive folder? This removes the folder from Google Drive.</value></data>
+  <data name="DeleteSuccess" xml:space="preserve"><value>Drive folder deleted.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/DataAndAnalyses.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/DataAndAnalyses.resx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Data &amp; Analyses</value></data>
+  <data name="Title" xml:space="preserve"><value>Data &amp; Analyses</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Your running analyses and Drive folder in one place</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading data and analyses</value></data>
+  <data name="AthleteNotResolved" xml:space="preserve"><value>The athlete could not be resolved.</value></data>
+  <data name="AnalysesTitle" xml:space="preserve"><value>Analyses</value></data>
+  <data name="AnalysesSubtitle" xml:space="preserve"><value>Your shared running analysis folders</value></data>
+  <data name="DriveRequiredForAnalyses" xml:space="preserve"><value>Link your Drive folder before analyses can be shown here.</value></data>
+  <data name="NoAnalyses" xml:space="preserve"><value>No analyses available yet.</value></data>
+  <data name="DriveTitle" xml:space="preserve"><value>Drive folder</value></data>
+  <data name="NoFolderText" xml:space="preserve"><value>No Drive folder is linked yet.</value></data>
+  <data name="FolderReadyText" xml:space="preserve"><value>Your Drive folder is linked and ready.</value></data>
+  <data name="CreateFolder" xml:space="preserve"><value>Create folder</value></data>
+  <data name="CreateSuccess" xml:space="preserve"><value>Drive folder created.</value></data>
+  <data name="OpenFolder" xml:space="preserve"><value>Open folder</value></data>
+  <data name="DeleteFolder" xml:space="preserve"><value>Delete folder</value></data>
+  <data name="DeleteConfirm" xml:space="preserve"><value>Delete your PaceLetics Drive folder? This removes the folder from Google Drive.</value></data>
+  <data name="DeleteSuccess" xml:space="preserve"><value>Drive folder deleted.</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Laufdaten</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pacebereiche</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>Meine Kurse</value></data>
+  <data name="Nav_DataAnalyses" xml:space="preserve"><value>Daten &amp; Analysen</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>Meine Analysen</value></data>
   <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Kurse verwalten</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
+  <data name="Nav_DataAnalyses" xml:space="preserve"><value>Data &amp; Analyses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.resx
@@ -36,6 +36,7 @@
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
+  <data name="Nav_DataAnalyses" xml:space="preserve"><value>Data &amp; Analyses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>
   <data name="Nav_TrainerCourses" xml:space="preserve"><value>Manage Courses</value></data>

--- a/PaceLetics.Web/Shared/BottomNavBar.razor
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor
@@ -39,4 +39,17 @@
             <span class="pl-bottom-nav__label">@L["Nav_Courses"]</span>
         </span>
     </NavLink>
+
+    <NavLink href="/Athletes/data-analyses"
+             class="pl-bottom-nav__item"
+             ActiveClass="pl-bottom-nav__item--active"
+             Match="NavLinkMatch.Prefix"
+             title="@L["Nav_DataAnalyses"]">
+        <span class="pl-bottom-nav__content">
+            <span class="pl-bottom-nav__icon" aria-hidden="true">
+                <MudIcon Icon="@Icons.Material.Filled.Analytics" Size="Size.Medium" />
+            </span>
+            <span class="pl-bottom-nav__label">@L["Nav_DataAnalyses"]</span>
+        </span>
+    </NavLink>
 </nav>

--- a/PaceLetics.Web/Shared/BottomNavBar.razor.css
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor.css
@@ -6,8 +6,8 @@
     z-index: 1200;
     display: flex;
     justify-content: center;
-    gap: 0.75rem;
-    padding: 0.55rem 1rem calc(0.55rem + env(safe-area-inset-bottom));
+    gap: 0.25rem;
+    padding: 0.5rem 0.45rem calc(0.5rem + env(safe-area-inset-bottom));
     background: color-mix(in srgb, var(--mud-palette-surface) 94%, black);
     border-top: 1px solid var(--mud-palette-lines-default);
     box-shadow: 0 -8px 24px color-mix(in srgb, var(--mud-palette-black) 20%, transparent);
@@ -17,9 +17,11 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 5.5rem;
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: 6.25rem;
     min-height: 3.75rem;
-    padding: 0.4rem 0.85rem;
+    padding: 0.4rem 0.45rem;
     color: var(--mud-palette-text-secondary);
     text-decoration: none;
     border-radius: 999px;
@@ -57,14 +59,16 @@
 }
 
 .pl-bottom-nav__label {
-    max-width: 5rem;
+    display: -webkit-box;
+    max-width: 5.4rem;
     overflow: hidden;
     font-size: 0.68rem;
     font-weight: 600;
     line-height: 1.15;
     text-align: center;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow-wrap: anywhere;
 }
 
 @media (min-width: 641px) {

--- a/PaceLetics.Web/Shared/NavMenu.razor
+++ b/PaceLetics.Web/Shared/NavMenu.razor
@@ -4,8 +4,7 @@
     <MudNavLink Href="/Athletes/dashboard" Match="NavLinkMatch.All">@L["Nav_Dashboard"]</MudNavLink>
     <MudNavLink Href="/Athletes/racepaces" Match="NavLinkMatch.Prefix">@L["Nav_RaceData"]</MudNavLink>
     <MudNavLink Href="/Athletes/courses" Match="NavLinkMatch.Prefix">@L["Nav_Courses"]</MudNavLink>
-    <MudNavLink Href="/Athletes/analyses" Match="NavLinkMatch.Prefix">@L["Nav_Analyses"]</MudNavLink>
-    <MudNavLink Href="/Athletes/drive" Match="NavLinkMatch.Prefix">@L["Nav_MyDrive"]</MudNavLink>
+    <MudNavLink Href="/Athletes/data-analyses" Match="NavLinkMatch.Prefix">@L["Nav_DataAnalyses"]</MudNavLink>
     <AuthorizeView Roles="@ApplicationRoles.Trainer">
         <Authorized>
             <MudNavLink Href="/Trainers/courses" Match="NavLinkMatch.Prefix">@L["Nav_TrainerCourses"]</MudNavLink>


### PR DESCRIPTION
## Summary
- add a combined athlete page for data and analyses
- gate the analyses list behind a linked Drive folder notice
- move the mobile bottom-bar and side-nav entry to the combined Data & Analyses route

## Verification
- dotnet build PaceLetics.Web\\PaceLetics.Web.csproj --no-dependencies -o artifacts\\verify-web-build-pr

Note: build succeeds with existing NU1902 warnings for OpenMcdf and SharpCompress.