### PR TITLE
Mobile Navigation ohne Seitendrawer verfeinern

### DIFF
--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -35,7 +35,7 @@
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Laufdaten</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pacebereiche</value></data>
-  <data name="Nav_Courses" xml:space="preserve"><value>Meine Kurse</value></data>
+  <data name="Nav_Courses" xml:space="preserve"><value>Kurse &amp; Plaene</value></data>
   <data name="Nav_DataAnalyses" xml:space="preserve"><value>Daten &amp; Analysen</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>Meine Analysen</value></data>
   <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -35,7 +35,7 @@
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
-  <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
+  <data name="Nav_Courses" xml:space="preserve"><value>Courses &amp; Plans</value></data>
   <data name="Nav_DataAnalyses" xml:space="preserve"><value>Data &amp; Analyses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.resx
@@ -35,7 +35,7 @@
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
-  <data name="Nav_Courses" xml:space="preserve"><value>My Courses</value></data>
+  <data name="Nav_Courses" xml:space="preserve"><value>Courses &amp; Plans</value></data>
   <data name="Nav_DataAnalyses" xml:space="preserve"><value>Data &amp; Analyses</value></data>
   <data name="Nav_Analyses" xml:space="preserve"><value>My Analyses</value></data>
   <data name="Nav_MyDrive" xml:space="preserve"><value>My Drive</value></data>

--- a/PaceLetics.Web/Shared/BottomNavBar.razor
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor
@@ -52,4 +52,17 @@
             <span class="pl-bottom-nav__label">@L["Nav_DataAnalyses"]</span>
         </span>
     </NavLink>
+
+    <NavLink href="/Workouts/WorkoutArea"
+             class="pl-bottom-nav__item"
+             ActiveClass="pl-bottom-nav__item--active"
+             Match="NavLinkMatch.Prefix"
+             title="@L["Nav_Workouts"]">
+        <span class="pl-bottom-nav__content">
+            <span class="pl-bottom-nav__icon" aria-hidden="true">
+                <MudIcon Icon="@Icons.Material.Filled.FitnessCenter" Size="Size.Medium" />
+            </span>
+            <span class="pl-bottom-nav__label">@L["Nav_Workouts"]</span>
+        </span>
+    </NavLink>
 </nav>

--- a/PaceLetics.Web/Shared/BottomNavBar.razor.css
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor.css
@@ -6,8 +6,8 @@
     z-index: 1200;
     display: flex;
     justify-content: center;
-    gap: 0.25rem;
-    padding: 0.5rem 0.45rem calc(0.5rem + env(safe-area-inset-bottom));
+    gap: 0.15rem;
+    padding: 0.45rem 0.35rem calc(0.45rem + env(safe-area-inset-bottom));
     background: color-mix(in srgb, var(--mud-palette-surface) 94%, black);
     border-top: 1px solid var(--mud-palette-lines-default);
     box-shadow: 0 -8px 24px color-mix(in srgb, var(--mud-palette-black) 20%, transparent);
@@ -19,9 +19,9 @@
     justify-content: center;
     flex: 1 1 0;
     min-width: 0;
-    max-width: 6.25rem;
+    max-width: 5.4rem;
     min-height: 3.75rem;
-    padding: 0.4rem 0.45rem;
+    padding: 0.35rem 0.25rem;
     color: var(--mud-palette-text-secondary);
     text-decoration: none;
     border-radius: 999px;
@@ -60,7 +60,7 @@
 
 .pl-bottom-nav__label {
     display: -webkit-box;
-    max-width: 5.4rem;
+    max-width: 4.9rem;
     overflow: hidden;
     font-size: 0.68rem;
     font-weight: 600;

--- a/PaceLetics.Web/Shared/LoginDisplay.razor
+++ b/PaceLetics.Web/Shared/LoginDisplay.razor
@@ -33,10 +33,11 @@
                     </MudStack>
                 </MudMenuItem>
             }
+            <MudDivider />
+            <MudMenuItem OnClick="LogOutAsync" Icon="@Icons.Material.Outlined.Logout">
+                @L["LogOut"]
+            </MudMenuItem>
         </MudMenu>
-        <form method="post" action="Identity/Account/Logout">
-            <MudIconButton Icon="@Icons.Material.Outlined.Logout" ButtonType="ButtonType.Submit" Class="nav-link btn btn-link">@L["LogOut"]</MudIconButton>
-        </form>
     </Authorized>
     <NotAuthorized>
         <a href="Identity/Account/Register">@L["Register"]</a>
@@ -54,5 +55,18 @@
         await JS.InvokeVoidAsync("eval",
             $"document.cookie='.AspNetCore.Culture={cookieValue};path=/;max-age=31536000;samesite=lax'");
         NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
+    }
+
+    private async Task LogOutAsync()
+    {
+        await JS.InvokeVoidAsync("eval", """
+            (() => {
+                const form = document.createElement('form');
+                form.method = 'post';
+                form.action = '/Identity/Account/Logout';
+                document.body.appendChild(form);
+                form.submit();
+            })()
+            """);
     }
 }

--- a/PaceLetics.Web/Shared/MainLayout.razor
+++ b/PaceLetics.Web/Shared/MainLayout.razor
@@ -3,6 +3,7 @@
 @using MudBlazor
 @inject ThemePreferenceService ThemePreferences
 @inject IStringLocalizer<MainLayout> L
+@inject IStringLocalizer<NavMenu> NavL
 
 <MudThemeProvider @ref="_themeProvider"
                   Theme="@ThemePreferences.CurrentTheme"
@@ -20,10 +21,34 @@
         <MudIconButton Icon="@Icons.Material.Filled.Menu"
                        Color="Color.Inherit"
                        Edge="Edge.Start"
+                       Class="pl-desktop-only"
                        OnClick="@((e) => DrawerToggle())" />
         <MudText Align="Align.Start">PaceLetics - Team Running</MudText>
         <MudSpacer />
         <AthleteMessageFeedButton />
+        <MudMenu Icon="@Icons.Material.Filled.MoreVert"
+                 Color="Color.Inherit"
+                 Class="pl-mobile-more-menu"
+                 AnchorOrigin="Origin.BottomRight"
+                 TransformOrigin="Origin.TopRight">
+            <MudMenuItem Href="/profiles" Icon="@Icons.Material.Filled.AccountCircle">
+                @NavL["Nav_Profiles"]
+            </MudMenuItem>
+            <MudMenuItem Href="/impressum" Icon="@Icons.Material.Filled.Info">
+                @NavL["Nav_About"]
+            </MudMenuItem>
+            <AuthorizeView Roles="@ApplicationRoles.Trainer">
+                <Authorized>
+                    <MudDivider />
+                    <MudMenuItem Href="/Trainers/courses" Icon="@Icons.Material.Filled.School">
+                        @NavL["Nav_TrainerCourses"]
+                    </MudMenuItem>
+                    <MudMenuItem Href="/Trainers/running-analyses" Icon="@Icons.Material.Filled.Analytics">
+                        @NavL["Nav_TrainerRunningAnalyses"]
+                    </MudMenuItem>
+                </Authorized>
+            </AuthorizeView>
+        </MudMenu>
         <MudMenu Icon="@GetThemeMenuIcon()"
                  Color="Color.Inherit"
                  AnchorOrigin="Origin.BottomRight"
@@ -52,7 +77,8 @@
 
     <MudDrawer @bind-Open="@_drawerOpen"
                ClipMode="DrawerClipMode.Always"
-               Elevation="2">
+               Elevation="2"
+               Class="pl-desktop-drawer">
         <NavMenu />
     </MudDrawer>
 

--- a/PaceLetics.Web/Shared/MainLayout.razor.css
+++ b/PaceLetics.Web/Shared/MainLayout.razor.css
@@ -12,6 +12,10 @@ main {
     padding-bottom: calc(5.25rem + env(safe-area-inset-bottom));
 }
 
+::deep .pl-mobile-more-menu {
+    display: none;
+}
+
 .sidebar {
     background: var(--mud-palette-drawer-background);
 }
@@ -36,6 +40,15 @@ main {
     }
 
 @media (max-width: 640.98px) {
+    ::deep .pl-desktop-only,
+    ::deep .pl-desktop-drawer {
+        display: none !important;
+    }
+
+    ::deep .pl-mobile-more-menu {
+        display: inline-flex;
+    }
+
     .top-row:not(.auth) {
         display: none;
     }


### PR DESCRIPTION
## Summary
- hide the side drawer controls on mobile while keeping desktop side navigation intact
- add Workouts to the mobile bottom bar and compact it for five items
- add a mobile More menu for Profile, About, and trainer-only links
- move logout into the account dropdown below language selection
- rename courses navigation to Courses & Plans / Kurse & Plaene

## Verification
- dotnet build PaceLetics.Web\\PaceLetics.Web.csproj --no-dependencies -o artifacts\\verify-mobile-nav-build
- dotnet publish PaceLetics.Web\\PaceLetics.Web.csproj -o artifacts\\verify-mobile-nav-publish

Note: both commands succeed with existing NU1902 warnings for OpenMcdf and SharpCompress.