### PR TITLE
Mobile Seitennavigation ausblenden

### DIFF
--- a/PaceLetics.Web/Shared/MainLayout.razor
+++ b/PaceLetics.Web/Shared/MainLayout.razor
@@ -77,6 +77,7 @@
 
     <MudDrawer @bind-Open="@_drawerOpen"
                ClipMode="DrawerClipMode.Always"
+               Breakpoint="Breakpoint.Sm"
                Elevation="2"
                Class="pl-desktop-drawer">
         <NavMenu />

--- a/PaceLetics.Web/Shared/MainLayout.razor.css
+++ b/PaceLetics.Web/Shared/MainLayout.razor.css
@@ -45,6 +45,10 @@ main {
         display: none !important;
     }
 
+    ::deep .mud-main-content {
+        margin-left: 0 !important;
+    }
+
     ::deep .pl-mobile-more-menu {
         display: inline-flex;
     }


### PR DESCRIPTION
## Summary
- set the MudDrawer breakpoint so the side navigation closes on mobile
- clear mobile main-content left margin to avoid leftover drawer spacing

## Verification
- dotnet build PaceLetics.Web\\PaceLetics.Web.csproj --no-dependencies -o artifacts\\verify-hide-mobile-side-nav-build

Note: build succeeds with existing NU1902 warnings for OpenMcdf and SharpCompress.