### PR TITLE
Mobile Navigation auf Md-Breakpoint ausrichten

### DIFF
--- a/PaceLetics.Web/Shared/BottomNavBar.razor.css
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor.css
@@ -71,7 +71,7 @@
     overflow-wrap: anywhere;
 }
 
-@media (min-width: 641px) {
+@media (min-width: 960px) {
     .pl-bottom-nav {
         display: none;
     }

--- a/PaceLetics.Web/Shared/MainLayout.razor
+++ b/PaceLetics.Web/Shared/MainLayout.razor
@@ -77,7 +77,7 @@
 
     <MudDrawer @bind-Open="@_drawerOpen"
                ClipMode="DrawerClipMode.Always"
-               Breakpoint="Breakpoint.Sm"
+               Breakpoint="Breakpoint.Md"
                Elevation="2"
                Class="pl-desktop-drawer">
         <NavMenu />

--- a/PaceLetics.Web/Shared/MainLayout.razor.css
+++ b/PaceLetics.Web/Shared/MainLayout.razor.css
@@ -39,7 +39,7 @@ main {
         text-overflow: ellipsis;
     }
 
-@media (max-width: 640.98px) {
+@media (max-width: 959.98px) {
     ::deep .pl-desktop-only,
     ::deep .pl-desktop-drawer {
         display: none !important;
@@ -66,7 +66,7 @@ main {
     }
 }
 
-@media (min-width: 641px) {
+@media (min-width: 960px) {
     .pl-main-content {
         padding-bottom: 0;
     }


### PR DESCRIPTION
## Summary
- align drawer, mobile topbar, and bottom bar visibility on the Md breakpoint
- keep the side navigation hidden below 960px and show the bottom bar until desktop width

## Verification
- dotnet build PaceLetics.Web\\PaceLetics.Web.csproj --no-dependencies -o artifacts\\verify-mobile-nav-md-breakpoint-build

Note: build succeeds with existing NU1902 warnings for OpenMcdf and SharpCompress.