### PR TITLE
Mobile Hamburger-Navigation global ausblenden

### DIFF
--- a/PaceLetics.Web/wwwroot/css/app-theme.css
+++ b/PaceLetics.Web/wwwroot/css/app-theme.css
@@ -831,3 +831,24 @@
 .pl-identity-success {
     color: var(--mud-palette-success) !important;
 }
+
+.pl-mobile-more-menu {
+    display: none !important;
+}
+
+@media (max-width: 959.98px) {
+    .pl-desktop-only,
+    .pl-desktop-drawer,
+    .mud-drawer.pl-desktop-drawer {
+        display: none !important;
+        visibility: hidden !important;
+    }
+
+    .mud-main-content {
+        margin-left: 0 !important;
+    }
+
+    .pl-mobile-more-menu {
+        display: inline-flex !important;
+    }
+}


### PR DESCRIPTION
## Summary
- add global mobile CSS rules to hide the desktop hamburger button and drawer below 960px
- keep mobile More menu visible and clear drawer left margin globally

## Verification
- dotnet build PaceLetics.Web\\PaceLetics.Web.csproj --no-dependencies -o artifacts\\verify-hide-mobile-hamburger-build
- dotnet build PaceLetics.Web\\PaceLetics.Web.csproj --no-dependencies -o artifacts\\verify-sdk-workload-repair

Note: builds succeed with existing NU1902 warnings for OpenMcdf and SharpCompress.