### PR TITLE
Use personal Drive folder for running analysis uploads

### DIFF
--- a/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/RunningAnalysisService.cs
+++ b/PaceLetics.RunningAnalysisModule.CodeBase/RunningAnalysis/Services/RunningAnalysisService.cs
@@ -10,17 +10,20 @@ public sealed class RunningAnalysisService : IRunningAnalysisService
     private readonly IRunningAnalysisRepository _repository;
     private readonly IRunningAnalysisStorageProvider _storageProvider;
     private readonly IUserDriveFolderRegistry _folderRegistry;
+    private readonly IUserDriveFolderService _userDriveFolderService;
     private readonly IRunningAnalysisClock _clock;
 
     public RunningAnalysisService(
         IRunningAnalysisRepository repository,
         IRunningAnalysisStorageProvider storageProvider,
         IUserDriveFolderRegistry folderRegistry,
+        IUserDriveFolderService userDriveFolderService,
         IRunningAnalysisClock clock)
     {
         _repository = repository;
         _storageProvider = storageProvider;
         _folderRegistry = folderRegistry;
+        _userDriveFolderService = userDriveFolderService;
         _clock = clock;
     }
 
@@ -259,38 +262,23 @@ public sealed class RunningAnalysisService : IRunningAnalysisService
 
         try
         {
-            var reusableFolder = await _folderRegistry.FindReusableFolderAsync(
-                new ReusableDriveFolderRequest(
+            var participantFolder = await _userDriveFolderService.GetFolderAsync(
+                participant.AthleteUserId,
+                cancellationToken);
+
+            participantFolder ??= await _userDriveFolderService.CreateFolderAsync(
+                new UserDriveFolderRequest(participant.AthleteUserId, participant.Email),
+                cancellationToken);
+
+            await _folderRegistry.SaveFolderReferenceAsync(
+                new SaveDriveFolderReferenceRequest(
                     analysisEvent.CourseId,
                     analysisEvent.ExternalEventId,
                     participant.AthleteUserId,
-                    participant.Email),
+                    participant.Email,
+                    participantFolder.FolderId,
+                    participantFolder.Url),
                 cancellationToken);
-
-            var participantFolder = reusableFolder;
-            if (participantFolder is null)
-            {
-                var eventFolder = await _storageProvider.EnsureEventFolderAsync(analysisEvent, cancellationToken);
-                analysisEvent.DriveFolderId = eventFolder.FolderId;
-                analysisEvent.DriveFolderUrl = eventFolder.Url;
-                await _repository.UpsertEventAsync(analysisEvent, cancellationToken);
-
-                participantFolder = await _storageProvider.EnsureParticipantFolderAsync(
-                    analysisEvent,
-                    participant,
-                    eventFolder,
-                    cancellationToken);
-
-                await _folderRegistry.SaveFolderReferenceAsync(
-                    new SaveDriveFolderReferenceRequest(
-                        analysisEvent.CourseId,
-                        analysisEvent.ExternalEventId,
-                        participant.AthleteUserId,
-                        participant.Email,
-                        participantFolder.FolderId,
-                        participantFolder.Url),
-                    cancellationToken);
-            }
 
             participant.DriveFolderId = participantFolder.FolderId;
             participant.DriveFolderUrl = participantFolder.Url;

--- a/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
+++ b/PaceLetics.RunningAnalysisModule.Infrastructure.GoogleDrive/GoogleDriveRunningAnalysisStorageProvider.cs
@@ -55,17 +55,7 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
             throw new InvalidOperationException("A participant email is required to grant Drive access.");
 
         var drive = CreateDriveService();
-        var permission = new Permission
-        {
-            Type = "user",
-            Role = "writer",
-            EmailAddress = participantEmail.Trim()
-        };
-
-        var request = drive.Permissions.Create(permission, participantFolder.FolderId);
-        request.SendNotificationEmail = false;
-        request.SupportsAllDrives = true;
-        await request.ExecuteAsync(cancellationToken);
+        await GrantAccessAsync(drive, participantFolder, participantEmail, role: "writer", cancellationToken);
     }
 
     public async Task<DriveFolderReference> EnsureUserFolderAsync(
@@ -153,17 +143,66 @@ public sealed class GoogleDriveRunningAnalysisStorageProvider :
         string role,
         CancellationToken cancellationToken)
     {
+        var normalizedEmail = email.Trim();
+        var existingPermissions = drive.Permissions.List(folder.FolderId);
+        existingPermissions.Fields = "permissions(id,type,role,emailAddress,deleted)";
+        existingPermissions.SupportsAllDrives = true;
+
+        var permissions = await existingPermissions.ExecuteAsync(cancellationToken);
+        var existingPermission = permissions.Permissions?
+            .FirstOrDefault(permission =>
+                string.Equals(permission.Type, "user", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(permission.EmailAddress, normalizedEmail, StringComparison.OrdinalIgnoreCase)
+                && permission.Deleted != true);
+
+        if (existingPermission is not null)
+        {
+            if (HasAtLeastRole(existingPermission.Role, role))
+                return;
+
+            var update = drive.Permissions.Update(
+                new Permission
+                {
+                    Role = role
+                },
+                folder.FolderId,
+                existingPermission.Id);
+
+            update.SupportsAllDrives = true;
+            await update.ExecuteAsync(cancellationToken);
+            return;
+        }
+
         var permission = new Permission
         {
             Type = "user",
             Role = role,
-            EmailAddress = email.Trim()
+            EmailAddress = normalizedEmail
         };
 
         var request = drive.Permissions.Create(permission, folder.FolderId);
         request.SendNotificationEmail = false;
         request.SupportsAllDrives = true;
         await request.ExecuteAsync(cancellationToken);
+    }
+
+    private static bool HasAtLeastRole(string? existingRole, string requiredRole)
+    {
+        return RoleRank(existingRole) >= RoleRank(requiredRole);
+    }
+
+    private static int RoleRank(string? role)
+    {
+        return role?.ToLowerInvariant() switch
+        {
+            "owner" => 4,
+            "organizer" => 3,
+            "fileorganizer" => 3,
+            "writer" => 2,
+            "commenter" => 1,
+            "reader" => 0,
+            _ => -1
+        };
     }
 
     private DriveService CreateDriveService()

--- a/PaceLetics.Tests/RunningAnalysisServiceTests.cs
+++ b/PaceLetics.Tests/RunningAnalysisServiceTests.cs
@@ -44,34 +44,38 @@ public sealed class RunningAnalysisServiceTests
         var repository = new InMemoryRunningAnalysisRepository();
         var storage = new FakeRunningAnalysisStorageProvider();
         var registry = new FakeUserDriveFolderRegistry();
-        var service = CreateService(repository, storage, registry);
+        var userDrive = new FakeUserDriveFolderService();
+        var service = CreateService(repository, storage, registry, userDrive);
 
         var participant = await service.RegisterParticipantAsync(CreateRegistration());
 
         Assert.Equal(RunningAnalysisFolderStatus.Ready, participant.FolderStatus);
         Assert.Equal(RunningAnalysisPermissionStatus.Granted, participant.PermissionStatus);
         Assert.Equal("runner@example.com", Assert.Single(storage.GrantedEmails));
-        Assert.NotNull(participant.DriveFolderId);
-        Assert.NotNull(participant.DriveFolderUrl);
+        Assert.Equal("user-folder-runner-1", participant.DriveFolderId);
+        Assert.Equal("https://drive.test/user-folder-runner-1", participant.DriveFolderUrl);
+        Assert.Single(userDrive.CreatedFolders);
         Assert.Single(registry.SavedReferences);
     }
 
     [Fact]
-    public async Task RegisterParticipant_ReusesExistingFolderFromRegistry()
+    public async Task RegisterParticipant_ReusesExistingPersonalFolder()
     {
         var repository = new InMemoryRunningAnalysisRepository();
         var storage = new FakeRunningAnalysisStorageProvider();
-        var registry = new FakeUserDriveFolderRegistry
+        var registry = new FakeUserDriveFolderRegistry();
+        var userDrive = new FakeUserDriveFolderService
         {
-            ReusableFolder = new DriveFolderReference("existing-folder", "https://drive.test/existing-folder")
+            ExistingFolder = new DriveFolderReference("existing-folder", "https://drive.test/existing-folder")
         };
-        var service = CreateService(repository, storage, registry);
+        var service = CreateService(repository, storage, registry, userDrive);
 
         var participant = await service.RegisterParticipantAsync(CreateRegistration());
 
         Assert.Equal("existing-folder", participant.DriveFolderId);
         Assert.Equal(0, storage.CreatedParticipantFolderCount);
-        Assert.Empty(registry.SavedReferences);
+        Assert.Empty(userDrive.CreatedFolders);
+        Assert.Single(registry.SavedReferences);
         Assert.Equal(RunningAnalysisPermissionStatus.Granted, participant.PermissionStatus);
     }
 
@@ -79,8 +83,9 @@ public sealed class RunningAnalysisServiceTests
     public async Task RegisterParticipant_KeepsRegistrationWhenProvisioningFails()
     {
         var repository = new InMemoryRunningAnalysisRepository();
-        var storage = new FakeRunningAnalysisStorageProvider { FailFolderCreation = true };
-        var service = CreateService(repository, storage, new FakeUserDriveFolderRegistry());
+        var storage = new FakeRunningAnalysisStorageProvider();
+        var userDrive = new FakeUserDriveFolderService { FailCreate = true };
+        var service = CreateService(repository, storage, new FakeUserDriveFolderRegistry(), userDrive);
 
         var participant = await service.RegisterParticipantAsync(CreateRegistration());
 
@@ -211,12 +216,14 @@ public sealed class RunningAnalysisServiceTests
     private static RunningAnalysisService CreateService(
         InMemoryRunningAnalysisRepository repository,
         FakeRunningAnalysisStorageProvider storage,
-        FakeUserDriveFolderRegistry registry)
+        FakeUserDriveFolderRegistry registry,
+        FakeUserDriveFolderService? userDrive = null)
     {
         return new RunningAnalysisService(
             repository,
             storage,
             registry,
+            userDrive ?? new FakeUserDriveFolderService(),
             new FixedRunningAnalysisClock(new DateTime(2026, 6, 5, 10, 0, 0, DateTimeKind.Utc)));
     }
 
@@ -263,6 +270,43 @@ public sealed class RunningAnalysisServiceTests
             CancellationToken cancellationToken = default)
         {
             SavedReferences.Add(request);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeUserDriveFolderService : IUserDriveFolderService
+    {
+        public bool FailCreate { get; set; }
+        public DriveFolderReference? ExistingFolder { get; set; }
+        public List<UserDriveFolderRequest> CreatedFolders { get; } = new();
+
+        public Task<DriveFolderReference?> GetFolderAsync(
+            string athleteUserId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ExistingFolder);
+        }
+
+        public Task<DriveFolderReference> CreateFolderAsync(
+            UserDriveFolderRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (FailCreate)
+                throw new InvalidOperationException("folder failed");
+
+            CreatedFolders.Add(request);
+            ExistingFolder = new DriveFolderReference(
+                $"user-folder-{request.AthleteUserId}",
+                $"https://drive.test/user-folder-{request.AthleteUserId}");
+
+            return Task.FromResult(ExistingFolder);
+        }
+
+        public Task DeleteFolderAsync(
+            string athleteUserId,
+            CancellationToken cancellationToken = default)
+        {
+            ExistingFolder = null;
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
- Route running analysis participant uploads into the athlete's personal My Drive folder
- Create the personal folder through the existing My Drive flow when missing
- Reuse and upgrade existing Google Drive user permissions instead of creating duplicate permissions

## Tests
- dotnet test .\\PaceLeticsFramework.sln