### PR TITLE
Add team challenge foundation

### DIFF
--- a/PaceLetics.Tests/CourseServiceTests.cs
+++ b/PaceLetics.Tests/CourseServiceTests.cs
@@ -47,6 +47,25 @@ public sealed class CourseServiceTests
         Assert.Equal("Level 3", course.Level);
     }
 
+    [Fact]
+    public async Task CreateCourse_AssignsCourseAsTeamByDefault()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Sprintgruppe",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        Assert.Equal(course.Id, course.TeamId);
+    }
+
     [Theory]
     [InlineData("1", "Level 1")]
     [InlineData("Level 2", "Level 2")]
@@ -375,6 +394,104 @@ public sealed class CourseServiceTests
     }
 
     [Fact]
+    public async Task CreateChallenge_AddsChallengeForAssignedTrainer()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        var challenge = await service.CreateChallengeAsync(
+            course.Id,
+            new CourseChallengeCreateRequest
+            {
+                Title = "Juni-Kilometer",
+                ChallengeType = "DISTANCE",
+                StartsAt = DateTime.UtcNow.Date,
+                EndsAt = DateTime.UtcNow.Date.AddDays(14),
+                TargetValue = 40,
+                Unit = "km"
+            },
+            "trainer-1");
+        var updatedCourse = await repository.GetCourseAsync(course.Id);
+
+        Assert.NotNull(updatedCourse);
+        var storedChallenge = Assert.Single(updatedCourse.Challenges);
+        Assert.Equal(challenge.Id, storedChallenge.Id);
+        Assert.Equal(CourseChallengeTypes.Distance, storedChallenge.ChallengeType);
+        Assert.Equal(40m, storedChallenge.TargetValue);
+        Assert.Equal("km", storedChallenge.Unit);
+    }
+
+    [Fact]
+    public async Task CreateChallenge_RequiresTrainerWithEventPermissions()
+    {
+        var repository = new InMemoryCourseRepository();
+        var service = new CourseService(repository);
+        var course = await service.CreateCourseAsync(
+            new CourseCreateRequest
+            {
+                Name = "Laufschule",
+                StartDate = DateTime.UtcNow.Date,
+                EndDate = DateTime.UtcNow.Date.AddDays(14)
+            },
+            "trainer-1",
+            "Coach");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CreateChallengeAsync(
+                course.Id,
+                new CourseChallengeCreateRequest
+                {
+                    Title = "Juni-Kilometer",
+                    StartsAt = DateTime.UtcNow.Date,
+                    EndsAt = DateTime.UtcNow.Date.AddDays(14)
+                },
+                "trainer-2"));
+    }
+
+    [Fact]
+    public async Task RemoveChallenge_RemovesChallengeForAssignedTrainer()
+    {
+        var course = CreateCourse("course-1", "plan-1");
+        course.Challenges.Add(CreateChallenge("challenge-1", "Juni-Kilometer"));
+        var repository = new InMemoryCourseRepository(course);
+        var service = new CourseService(repository);
+
+        await service.RemoveChallengeAsync("course-1", "challenge-1", "trainer-1");
+        var updatedCourse = await repository.GetCourseAsync("course-1");
+
+        Assert.NotNull(updatedCourse);
+        Assert.Empty(updatedCourse.Challenges);
+    }
+
+    [Fact]
+    public async Task GetChallengesForAthlete_ReturnsCurrentPublishedChallengesFromJoinedCourses()
+    {
+        var hiddenCourse = CreateCourse("course-1", "plan-1");
+        hiddenCourse.Challenges.Add(CreateChallenge("hidden", "Hidden"));
+        var joinedCourse = CreateCourse("course-2", "plan-2");
+        joinedCourse.Challenges.Add(CreateChallenge("active", "Active"));
+        joinedCourse.Challenges.Add(CreateChallenge("unpublished", "Unpublished", isPublished: false));
+        joinedCourse.Challenges.Add(CreateChallenge("past", "Past", startsAt: DateTime.UtcNow.AddDays(-20), endsAt: DateTime.UtcNow.AddDays(-1)));
+        var repository = new InMemoryCourseRepository(hiddenCourse, joinedCourse);
+        var service = new CourseService(repository);
+        await service.JoinCourseAsync("course-2", "athlete-1");
+
+        var challenges = await service.GetChallengesForAthleteAsync("athlete-1");
+
+        var challenge = Assert.Single(challenges);
+        Assert.Equal("Active", challenge.Title);
+    }
+
+    [Fact]
     public async Task JoinCourse_CreatesActiveEnrollment()
     {
         var repository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"));
@@ -603,6 +720,24 @@ public sealed class CourseServiceTests
                     PublishedAt = DateTime.UtcNow.AddDays(-1)
                 }
             }
+        };
+    }
+
+    private static CourseChallengeDocument CreateChallenge(
+        string challengeId,
+        string title,
+        DateTime? startsAt = null,
+        DateTime? endsAt = null,
+        bool isPublished = true)
+    {
+        return new CourseChallengeDocument
+        {
+            Id = challengeId,
+            Title = title,
+            StartsAt = startsAt?.Date ?? DateTime.UtcNow.Date,
+            EndsAt = endsAt?.Date ?? DateTime.UtcNow.Date.AddDays(14),
+            IsPublished = isPublished,
+            ChallengeType = CourseChallengeTypes.General
         };
     }
 

--- a/PaceLetics.Web/Pages/Athletes/MyCourses.razor
+++ b/PaceLetics.Web/Pages/Athletes/MyCourses.razor
@@ -167,6 +167,7 @@
                     var course = selected.Course;
                     var upcomingDates = GetUpcomingDates(course).Take(6).ToList();
                     var courseEvents = GetEvents(course.Id).ToList();
+                    var courseChallenges = GetCourseChallenges(course).ToList();
                     var trainingPlanPublications = course.TrainingPlanPublications
                         .OrderBy(publication => publication.TrainingPlanId)
                         .ToList();
@@ -304,6 +305,52 @@
 
                             <section>
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
+                                    <MudText Typo="Typo.subtitle2">@L["Challenges"]</MudText>
+                                    @if (courseChallenges.Count > 2)
+                                    {
+                                        <MudTooltip Text="@(_showAllChallenges ? L["ShowLess"] : L["ShowAll"])">
+                                            <MudIconButton Size="Size.Small"
+                                                           Color="Color.Primary"
+                                                           Icon="@(_showAllChallenges ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                                                           OnClick="@(() => _showAllChallenges = !_showAllChallenges)"
+                                                           aria-label="@(_showAllChallenges ? L["ShowLess"] : L["ShowAll"])" />
+                                        </MudTooltip>
+                                    }
+                                </MudStack>
+
+                                @if (courseChallenges.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoChallenges"]</MudText>
+                                }
+                                else
+                                {
+                                    <MudStack Spacing="1">
+                                        @foreach (var challenge in GetVisibleChallenges(courseChallenges))
+                                        {
+                                            <div class="pl-list-row">
+                                                <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:6px; flex-wrap:wrap;">
+                                                    <MudText Typo="Typo.body2">@challenge.Title</MudText>
+                                                    <MudChip T="string" Size="Size.Small" Color="Color.Primary" Variant="Variant.Outlined">
+                                                        @FormatChallengeType(challenge.ChallengeType)
+                                                    </MudChip>
+                                                </MudStack>
+                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatChallengePeriod(challenge)</MudText>
+                                                @if (!string.IsNullOrWhiteSpace(challenge.Description))
+                                                {
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@challenge.Description</MudText>
+                                                }
+                                                @if (challenge.TargetValue is not null || !string.IsNullOrWhiteSpace(challenge.Unit))
+                                                {
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatChallengeTarget(challenge)</MudText>
+                                                }
+                                            </div>
+                                        }
+                                    </MudStack>
+                                }
+                            </section>
+
+                            <section>
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px;">
                                     <MudText Typo="Typo.subtitle2">@L["TrainingPlans"]</MudText>
                                     @if (trainingPlanPublications.Count > 2)
                                     {
@@ -365,6 +412,7 @@
     private bool _isCoursePickerOpen;
     private bool _showAllDates;
     private bool _showAllEvents;
+    private bool _showAllChallenges;
     private bool _showAllTrainingPlans;
     private CoursesSection _activeSection = CoursesSection.Courses;
 
@@ -559,6 +607,19 @@
         return _showAllEvents ? events : events.Take(2);
     }
 
+    private static IEnumerable<CourseChallengeDocument> GetCourseChallenges(CourseDocument course)
+    {
+        return course.Challenges
+            .Where(challenge => challenge.IsPublished && challenge.EndsAt.Date >= DateTime.Today)
+            .OrderBy(challenge => challenge.StartsAt)
+            .ThenBy(challenge => challenge.Title);
+    }
+
+    private IEnumerable<CourseChallengeDocument> GetVisibleChallenges(IReadOnlyList<CourseChallengeDocument> challenges)
+    {
+        return _showAllChallenges ? challenges : challenges.Take(2);
+    }
+
     private IEnumerable<CourseTrainingPlanPublicationDocument> GetVisibleTrainingPlans(
         IReadOnlyList<CourseTrainingPlanPublicationDocument> publications)
     {
@@ -615,6 +676,7 @@
     {
         _showAllDates = false;
         _showAllEvents = false;
+        _showAllChallenges = false;
         _showAllTrainingPlans = false;
     }
 
@@ -648,6 +710,33 @@
     private string FormatEventDate(CourseEventDocument courseEvent)
     {
         return string.Format(L["EventDate"], courseEvent.StartsAt, courseEvent.EndsAt);
+    }
+
+    private string FormatChallengeType(string? challengeType)
+    {
+        if (string.Equals(challengeType, CourseChallengeTypes.Attendance, StringComparison.OrdinalIgnoreCase))
+            return L["ChallengeType_Attendance"];
+
+        if (string.Equals(challengeType, CourseChallengeTypes.Distance, StringComparison.OrdinalIgnoreCase))
+            return L["ChallengeType_Distance"];
+
+        return L["ChallengeType_General"];
+    }
+
+    private string FormatChallengePeriod(CourseChallengeDocument challenge)
+    {
+        return string.Format(L["ChallengePeriod"], challenge.StartsAt, challenge.EndsAt);
+    }
+
+    private string FormatChallengeTarget(CourseChallengeDocument challenge)
+    {
+        if (challenge.TargetValue is null)
+            return challenge.Unit;
+
+        if (string.IsNullOrWhiteSpace(challenge.Unit))
+            return string.Format(L["ChallengeTargetValue"], challenge.TargetValue);
+
+        return string.Format(L["ChallengeTargetWithUnit"], challenge.TargetValue, challenge.Unit);
     }
 
     private string FormatUpcomingDate(CourseDateDocument? date)

--- a/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/CourseManagement.razor
@@ -433,6 +433,92 @@
                                             </MudStack>
                                         </MudStack>
                                     </MudTabPanel>
+
+                                    <MudTabPanel Text="@L["Challenges"]">
+                                        <MudStack Spacing="2" Class="pt-2">
+                                            @if (course.Challenges.Count == 0)
+                                            {
+                                                <MudText Typo="Typo.body2" Color="Color.Secondary">@L["NoChallenges"]</MudText>
+                                            }
+                                            else
+                                            {
+                                                @foreach (var challenge in course.Challenges.OrderBy(challenge => challenge.StartsAt))
+                                                {
+                                                    <MudPaper Elevation="0" Class="pa-2" Style="border:1px solid var(--mud-palette-lines-default);">
+                                                        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+                                                            <MudStack Spacing="0" Style="min-width:0;">
+                                                                <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:6px; flex-wrap:wrap;">
+                                                                    <MudText Typo="Typo.body2">@challenge.Title</MudText>
+                                                                    <MudChip T="string"
+                                                                             Size="Size.Small"
+                                                                             Color="@GetChallengeTypeColor(challenge.ChallengeType)"
+                                                                             Variant="Variant.Outlined">
+                                                                        @FormatChallengeType(challenge.ChallengeType)
+                                                                    </MudChip>
+                                                                </MudStack>
+                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatChallengePeriod(challenge)</MudText>
+                                                                @if (!string.IsNullOrWhiteSpace(challenge.Description))
+                                                                {
+                                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@challenge.Description</MudText>
+                                                                }
+                                                                @if (challenge.TargetValue is not null || !string.IsNullOrWhiteSpace(challenge.Unit))
+                                                                {
+                                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@FormatChallengeTarget(challenge)</MudText>
+                                                                }
+                                                            </MudStack>
+                                                            <MudTooltip Text="@L["Delete"]">
+                                                                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                                               Color="Color.Default"
+                                                                               OnClick="@(() => RemoveChallengeAsync(course, challenge))"
+                                                                               aria-label="@L["Delete"]" />
+                                                            </MudTooltip>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                }
+                                            }
+
+                                            <MudDivider Class="my-2" />
+                                            <MudGrid Spacing="2">
+                                                <MudItem xs="12" md="6">
+                                                    <MudTextField Label="@L["ChallengeTitle"]" @bind-Value="_challengeTitle" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudSelect T="string"
+                                                               Label="@L["ChallengeType"]"
+                                                               @bind-Value="_challengeType"
+                                                               Variant="Variant.Outlined">
+                                                        <MudSelectItem T="string" Value="@CourseChallengeTypes.General">@L["ChallengeType_General"]</MudSelectItem>
+                                                        <MudSelectItem T="string" Value="@CourseChallengeTypes.Attendance">@L["ChallengeType_Attendance"]</MudSelectItem>
+                                                        <MudSelectItem T="string" Value="@CourseChallengeTypes.Distance">@L["ChallengeType_Distance"]</MudSelectItem>
+                                                    </MudSelect>
+                                                </MudItem>
+                                                <MudItem xs="12">
+                                                    <MudTextField Label="@L["Description"]" @bind-Value="_challengeDescription" Variant="Variant.Outlined" Lines="2" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudDatePicker Label="@L["Start"]" Date="_challengeStartDate" DateChanged="@(date => _challengeStartDate = date)" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudDatePicker Label="@L["End"]" Date="_challengeEndDate" DateChanged="@(date => _challengeEndDate = date)" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudNumericField T="decimal?" Label="@L["ChallengeTarget"]" @bind-Value="_challengeTargetValue" Variant="Variant.Outlined" Min="0" />
+                                                </MudItem>
+                                                <MudItem xs="12" md="6">
+                                                    <MudTextField Label="@L["ChallengeUnit"]" @bind-Value="_challengeUnit" Variant="Variant.Outlined" />
+                                                </MudItem>
+                                            </MudGrid>
+                                            <MudStack Row="true" Justify="Justify.FlexEnd">
+                                                <MudTooltip Text="@L["AddChallenge"]">
+                                                    <MudIconButton Color="Color.Primary"
+                                                                   Variant="Variant.Filled"
+                                                                   Icon="@Icons.Material.Filled.Flag"
+                                                                   OnClick="@(() => CreateChallengeAsync(course))"
+                                                                   aria-label="@L["AddChallenge"]" />
+                                                </MudTooltip>
+                                            </MudStack>
+                                        </MudStack>
+                                    </MudTabPanel>
                                 </MudTabs>
                             </MudStack>
                         }
@@ -479,6 +565,14 @@
     private string _eventEndTime = "19:30";
     private int? _eventCapacity;
     private DateTime? _eventRegistrationDeadline;
+
+    private string _challengeTitle = string.Empty;
+    private string _challengeDescription = string.Empty;
+    private string _challengeType = CourseChallengeTypes.General;
+    private DateTime? _challengeStartDate = DateTime.Today;
+    private DateTime? _challengeEndDate = DateTime.Today.AddDays(14);
+    private decimal? _challengeTargetValue;
+    private string _challengeUnit = string.Empty;
 
     private CourseDocument? SelectedCourse =>
         _courses.FirstOrDefault(course => course.Id == _selectedCourseId)
@@ -567,6 +661,7 @@
         _selectedCourseId = courseId;
         _selectedTrainerToAddId = null;
         _selectedTrainingPlanId = null;
+        ResetChallengeForm();
         _eventParticipants.Clear();
         _openParticipantLists.Clear();
         return LoadSelectedCourseEventsAsync();
@@ -854,6 +949,53 @@
         }
     }
 
+    private async Task CreateChallengeAsync(CourseDocument course)
+    {
+        try
+        {
+            await CourseService.CreateChallengeAsync(
+                course.Id,
+                new CourseChallengeCreateRequest
+                {
+                    Title = _challengeTitle,
+                    Description = _challengeDescription,
+                    ChallengeType = _challengeType,
+                    StartsAt = _challengeStartDate ?? DateTime.Today,
+                    EndsAt = _challengeEndDate ?? DateTime.Today,
+                    TargetValue = _challengeTargetValue,
+                    Unit = _challengeUnit,
+                    IsPublished = true
+                },
+                _userId ?? string.Empty);
+
+            Snackbar.Add(L["AddChallengeSuccess"], Severity.Success);
+            ResetChallengeForm();
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task RemoveChallengeAsync(CourseDocument course, CourseChallengeDocument challenge)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", string.Format(L["RemoveChallengeConfirm"], challenge.Title));
+        if (!confirmed)
+            return;
+
+        try
+        {
+            await CourseService.RemoveChallengeAsync(course.Id, challenge.Id, _userId ?? string.Empty);
+            Snackbar.Add(L["RemoveChallengeSuccess"], Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
     private void ResetCreateForm()
     {
         _courseName = string.Empty;
@@ -884,6 +1026,17 @@
         _eventEndTime = "19:30";
         _eventCapacity = null;
         _eventRegistrationDeadline = null;
+    }
+
+    private void ResetChallengeForm()
+    {
+        _challengeTitle = string.Empty;
+        _challengeDescription = string.Empty;
+        _challengeType = CourseChallengeTypes.General;
+        _challengeStartDate = DateTime.Today;
+        _challengeEndDate = DateTime.Today.AddDays(14);
+        _challengeTargetValue = null;
+        _challengeUnit = string.Empty;
     }
 
     private bool IsCreator(CourseDocument course)
@@ -918,6 +1071,44 @@
         return string.Equals(eventType, CourseEventTypes.RunningAnalysis, StringComparison.OrdinalIgnoreCase)
             ? Color.Primary
             : Color.Default;
+    }
+
+    private string FormatChallengeType(string? challengeType)
+    {
+        if (string.Equals(challengeType, CourseChallengeTypes.Attendance, StringComparison.OrdinalIgnoreCase))
+            return L["ChallengeType_Attendance"];
+
+        if (string.Equals(challengeType, CourseChallengeTypes.Distance, StringComparison.OrdinalIgnoreCase))
+            return L["ChallengeType_Distance"];
+
+        return L["ChallengeType_General"];
+    }
+
+    private Color GetChallengeTypeColor(string? challengeType)
+    {
+        if (string.Equals(challengeType, CourseChallengeTypes.Attendance, StringComparison.OrdinalIgnoreCase))
+            return Color.Success;
+
+        if (string.Equals(challengeType, CourseChallengeTypes.Distance, StringComparison.OrdinalIgnoreCase))
+            return Color.Info;
+
+        return Color.Default;
+    }
+
+    private string FormatChallengePeriod(CourseChallengeDocument challenge)
+    {
+        return string.Format(L["ChallengePeriod"], challenge.StartsAt, challenge.EndsAt);
+    }
+
+    private string FormatChallengeTarget(CourseChallengeDocument challenge)
+    {
+        if (challenge.TargetValue is null)
+            return challenge.Unit;
+
+        if (string.IsNullOrWhiteSpace(challenge.Unit))
+            return string.Format(L["ChallengeTargetValue"], challenge.TargetValue);
+
+        return string.Format(L["ChallengeTargetWithUnit"], challenge.TargetValue, challenge.Unit);
     }
 
     private static bool IsRunningAnalysisEvent(CourseEventDocument courseEvent)

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.de.resx
@@ -21,6 +21,7 @@
   <data name="Joined" xml:space="preserve"><value>Beigetreten</value></data>
   <data name="Dates" xml:space="preserve"><value>Termine</value></data>
   <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="Challenges" xml:space="preserve"><value>Challenges</value></data>
   <data name="TrainingPlans" xml:space="preserve"><value>Trainingspläne</value></data>
   <data name="ShowAll" xml:space="preserve"><value>Alle</value></data>
   <data name="ShowLess" xml:space="preserve"><value>Weniger</value></data>
@@ -33,6 +34,10 @@
   <data name="OpenAnalysisFolder" xml:space="preserve"><value>Analyseordner öffnen</value></data>
   <data name="CancelRegistration" xml:space="preserve"><value>Abmelden</value></data>
   <data name="Register" xml:space="preserve"><value>Anmelden</value></data>
+  <data name="NoChallenges" xml:space="preserve"><value>Keine aktiven Challenges.</value></data>
+  <data name="ChallengeType_General" xml:space="preserve"><value>Allgemein</value></data>
+  <data name="ChallengeType_Attendance" xml:space="preserve"><value>Teilnahme</value></data>
+  <data name="ChallengeType_Distance" xml:space="preserve"><value>Distanz</value></data>
   <data name="NoTrainingPlans" xml:space="preserve"><value>Noch keine Trainingspläne veröffentlicht.</value></data>
   <data name="LoadError" xml:space="preserve"><value>Die Kurse konnten nicht aus Cosmos DB geladen werden.</value></data>
   <data name="JoinSuccess" xml:space="preserve"><value>Du bist dem Kurs beigetreten.</value></data>
@@ -44,4 +49,7 @@
   <data name="ShortPeriod" xml:space="preserve"><value>{0:dd.MM.} bis {1:dd.MM.}</value></data>
   <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} bis {1:HH:mm} Uhr</value></data>
   <data name="EventDate" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} bis {1:HH:mm} Uhr</value></data>
+  <data name="ChallengePeriod" xml:space="preserve"><value>{0:dd.MM.yyyy} bis {1:dd.MM.yyyy}</value></data>
+  <data name="ChallengeTargetValue" xml:space="preserve"><value>Ziel: {0:0.##}</value></data>
+  <data name="ChallengeTargetWithUnit" xml:space="preserve"><value>Ziel: {0:0.##} {1}</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/MyCourses.resx
@@ -21,6 +21,7 @@
   <data name="Joined" xml:space="preserve"><value>Joined</value></data>
   <data name="Dates" xml:space="preserve"><value>Dates</value></data>
   <data name="Events" xml:space="preserve"><value>Events</value></data>
+  <data name="Challenges" xml:space="preserve"><value>Challenges</value></data>
   <data name="TrainingPlans" xml:space="preserve"><value>Training plans</value></data>
   <data name="ShowAll" xml:space="preserve"><value>All</value></data>
   <data name="ShowLess" xml:space="preserve"><value>Less</value></data>
@@ -28,6 +29,10 @@
   <data name="NoEvents" xml:space="preserve"><value>No events are currently listed.</value></data>
   <data name="CancelRegistration" xml:space="preserve"><value>Cancel</value></data>
   <data name="Register" xml:space="preserve"><value>Register</value></data>
+  <data name="NoChallenges" xml:space="preserve"><value>No active challenges.</value></data>
+  <data name="ChallengeType_General" xml:space="preserve"><value>General</value></data>
+  <data name="ChallengeType_Attendance" xml:space="preserve"><value>Attendance</value></data>
+  <data name="ChallengeType_Distance" xml:space="preserve"><value>Distance</value></data>
   <data name="NoTrainingPlans" xml:space="preserve"><value>No training plans published yet.</value></data>
   <data name="LoadError" xml:space="preserve"><value>The courses could not be loaded from Cosmos DB.</value></data>
   <data name="JoinSuccess" xml:space="preserve"><value>You joined the course.</value></data>
@@ -39,4 +44,7 @@
   <data name="ShortPeriod" xml:space="preserve"><value>{0:MM/dd} to {1:MM/dd}</value></data>
   <data name="TimeRange" xml:space="preserve"><value>{0:HH:mm} to {1:HH:mm}</value></data>
   <data name="EventDate" xml:space="preserve"><value>{0:MM/dd/yyyy HH:mm} to {1:HH:mm}</value></data>
+  <data name="ChallengePeriod" xml:space="preserve"><value>{0:MM/dd/yyyy} to {1:MM/dd/yyyy}</value></data>
+  <data name="ChallengeTargetValue" xml:space="preserve"><value>Target: {0:0.##}</value></data>
+  <data name="ChallengeTargetWithUnit" xml:space="preserve"><value>Target: {0:0.##} {1}</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.de.resx
@@ -46,6 +46,16 @@
   <data name="NoPublishedPlan" xml:space="preserve"><value>Noch kein Plan veröffentlicht.</value></data>
   <data name="TrainingPlan" xml:space="preserve"><value>Trainingsplan</value></data>
   <data name="AddPlan" xml:space="preserve"><value>Plan hinzufuegen</value></data>
+  <data name="Challenges" xml:space="preserve"><value>Challenges</value></data>
+  <data name="NoChallenges" xml:space="preserve"><value>Noch keine Challenges.</value></data>
+  <data name="ChallengeTitle" xml:space="preserve"><value>Challenge-Titel</value></data>
+  <data name="ChallengeType" xml:space="preserve"><value>Challenge-Typ</value></data>
+  <data name="ChallengeType_General" xml:space="preserve"><value>Allgemein</value></data>
+  <data name="ChallengeType_Attendance" xml:space="preserve"><value>Teilnahme</value></data>
+  <data name="ChallengeType_Distance" xml:space="preserve"><value>Distanz</value></data>
+  <data name="ChallengeTarget" xml:space="preserve"><value>Ziel</value></data>
+  <data name="ChallengeUnit" xml:space="preserve"><value>Einheit</value></data>
+  <data name="AddChallenge" xml:space="preserve"><value>Challenge hinzufuegen</value></data>
   <data name="Participants" xml:space="preserve"><value>Teilnehmende</value></data>
   <data name="ParticipantsCount" xml:space="preserve"><value>Teilnehmende ({0})</value></data>
   <data name="CreateCourseSuccess" xml:space="preserve"><value>Kurs wurde erstellt.</value></data>
@@ -65,8 +75,14 @@
   <data name="PublishPlanSuccess" xml:space="preserve"><value>Trainingsplan wurde hinzugefuegt.</value></data>
   <data name="RemovePlanConfirm" xml:space="preserve"><value>Trainingsplan "{0}" entfernen?</value></data>
   <data name="RemovePlanSuccess" xml:space="preserve"><value>Trainingsplan wurde entfernt.</value></data>
+  <data name="AddChallengeSuccess" xml:space="preserve"><value>Challenge wurde hinzugefuegt.</value></data>
+  <data name="RemoveChallengeConfirm" xml:space="preserve"><value>Challenge "{0}" entfernen?</value></data>
+  <data name="RemoveChallengeSuccess" xml:space="preserve"><value>Challenge wurde entfernt.</value></data>
   <data name="Period" xml:space="preserve"><value>{0:dd.MM.yyyy} bis {1:dd.MM.yyyy}</value></data>
   <data name="DateRange" xml:space="preserve"><value>{0:dd.MM.yyyy HH:mm} bis {1:HH:mm} Uhr</value></data>
+  <data name="ChallengePeriod" xml:space="preserve"><value>{0:dd.MM.yyyy} bis {1:dd.MM.yyyy}</value></data>
+  <data name="ChallengeTargetValue" xml:space="preserve"><value>Ziel: {0:0.##}</value></data>
+  <data name="ChallengeTargetWithUnit" xml:space="preserve"><value>Ziel: {0:0.##} {1}</value></data>
   <data name="ValidationDateRequired" xml:space="preserve"><value>Bitte ein Datum auswählen.</value></data>
   <data name="ValidationTimeFormat" xml:space="preserve"><value>Bitte eine Uhrzeit im Format HH:mm eingeben.</value></data>
   <data name="TrainerNotResolved" xml:space="preserve"><value>Trainer:in konnte nicht ermittelt werden.</value></data>

--- a/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.resx
+++ b/PaceLetics.Web/Resources/Pages/Trainers/CourseManagement.resx
@@ -46,6 +46,16 @@
   <data name="NoPublishedPlan" xml:space="preserve"><value>No plan published yet.</value></data>
   <data name="TrainingPlan" xml:space="preserve"><value>Training plan</value></data>
   <data name="AddPlan" xml:space="preserve"><value>Add plan</value></data>
+  <data name="Challenges" xml:space="preserve"><value>Challenges</value></data>
+  <data name="NoChallenges" xml:space="preserve"><value>No challenges yet.</value></data>
+  <data name="ChallengeTitle" xml:space="preserve"><value>Challenge title</value></data>
+  <data name="ChallengeType" xml:space="preserve"><value>Challenge type</value></data>
+  <data name="ChallengeType_General" xml:space="preserve"><value>General</value></data>
+  <data name="ChallengeType_Attendance" xml:space="preserve"><value>Attendance</value></data>
+  <data name="ChallengeType_Distance" xml:space="preserve"><value>Distance</value></data>
+  <data name="ChallengeTarget" xml:space="preserve"><value>Target</value></data>
+  <data name="ChallengeUnit" xml:space="preserve"><value>Unit</value></data>
+  <data name="AddChallenge" xml:space="preserve"><value>Add challenge</value></data>
   <data name="Participants" xml:space="preserve"><value>Participants</value></data>
   <data name="ParticipantsCount" xml:space="preserve"><value>Participants ({0})</value></data>
   <data name="CreateCourseSuccess" xml:space="preserve"><value>Course was created.</value></data>
@@ -65,8 +75,14 @@
   <data name="PublishPlanSuccess" xml:space="preserve"><value>Training plan was added.</value></data>
   <data name="RemovePlanConfirm" xml:space="preserve"><value>Remove training plan "{0}"?</value></data>
   <data name="RemovePlanSuccess" xml:space="preserve"><value>Training plan was removed.</value></data>
+  <data name="AddChallengeSuccess" xml:space="preserve"><value>Challenge was added.</value></data>
+  <data name="RemoveChallengeConfirm" xml:space="preserve"><value>Remove challenge "{0}"?</value></data>
+  <data name="RemoveChallengeSuccess" xml:space="preserve"><value>Challenge was removed.</value></data>
   <data name="Period" xml:space="preserve"><value>{0:MM/dd/yyyy} to {1:MM/dd/yyyy}</value></data>
   <data name="DateRange" xml:space="preserve"><value>{0:MM/dd/yyyy HH:mm} to {1:HH:mm}</value></data>
+  <data name="ChallengePeriod" xml:space="preserve"><value>{0:MM/dd/yyyy} to {1:MM/dd/yyyy}</value></data>
+  <data name="ChallengeTargetValue" xml:space="preserve"><value>Target: {0:0.##}</value></data>
+  <data name="ChallengeTargetWithUnit" xml:space="preserve"><value>Target: {0:0.##} {1}</value></data>
   <data name="ValidationDateRequired" xml:space="preserve"><value>Please select a date.</value></data>
   <data name="ValidationTimeFormat" xml:space="preserve"><value>Please enter a time in HH:mm format.</value></data>
   <data name="TrainerNotResolved" xml:space="preserve"><value>The coach could not be resolved.</value></data>

--- a/PaceLetics.Web/Services/Courses/CourseDocuments.cs
+++ b/PaceLetics.Web/Services/Courses/CourseDocuments.cs
@@ -29,6 +29,13 @@ public static class CourseEventTypes
     public const string RunningAnalysis = "runningAnalysis";
 }
 
+public static class CourseChallengeTypes
+{
+    public const string General = "general";
+    public const string Attendance = "attendance";
+    public const string Distance = "distance";
+}
+
 public enum CourseLevel
 {
     Level0 = 0,
@@ -86,6 +93,8 @@ public sealed class CourseDocument : IQueryItem
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public string Level { get; set; } = string.Empty;
+    public string OrganizationId { get; set; } = string.Empty;
+    public string TeamId { get; set; } = string.Empty;
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
     public string CreatedByTrainerUserId { get; set; } = string.Empty;
@@ -94,6 +103,7 @@ public sealed class CourseDocument : IQueryItem
     public List<CourseDateDocument> Dates { get; set; } = new();
     public List<CourseTrainerDocument> Trainers { get; set; } = new();
     public List<CourseTrainingPlanPublicationDocument> TrainingPlanPublications { get; set; } = new();
+    public List<CourseChallengeDocument> Challenges { get; set; } = new();
 }
 
 public sealed class CourseCreateRequest
@@ -101,8 +111,22 @@ public sealed class CourseCreateRequest
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public CourseLevel Level { get; set; } = CourseLevel.Level1;
+    public string OrganizationId { get; set; } = string.Empty;
+    public string TeamId { get; set; } = string.Empty;
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
+    public bool IsPublished { get; set; } = true;
+}
+
+public sealed class CourseChallengeCreateRequest
+{
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string ChallengeType { get; set; } = CourseChallengeTypes.General;
+    public DateTime StartsAt { get; set; }
+    public DateTime EndsAt { get; set; }
+    public decimal? TargetValue { get; set; }
+    public string Unit { get; set; } = string.Empty;
     public bool IsPublished { get; set; } = true;
 }
 
@@ -161,6 +185,21 @@ public sealed class CourseTrainingPlanPublicationDocument
 
         return Target.NormalizeCopy();
     }
+}
+
+public sealed class CourseChallengeDocument
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string ChallengeType { get; set; } = CourseChallengeTypes.General;
+    public DateTime StartsAt { get; set; }
+    public DateTime EndsAt { get; set; }
+    public decimal? TargetValue { get; set; }
+    public string Unit { get; set; } = string.Empty;
+    public string CreatedByUserId { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public bool IsPublished { get; set; } = true;
 }
 
 public sealed class CourseEnrollmentDocument : IQueryItem

--- a/PaceLetics.Web/Services/Courses/CourseSeedData.cs
+++ b/PaceLetics.Web/Services/Courses/CourseSeedData.cs
@@ -107,6 +107,7 @@ public static class CourseSeedData
             CourseId = id,
             Slug = id,
             Name = name,
+            TeamId = id,
             Level = level,
             Description = description,
             StartDate = startDate,

--- a/PaceLetics.Web/Services/Courses/CourseService.cs
+++ b/PaceLetics.Web/Services/Courses/CourseService.cs
@@ -105,6 +105,8 @@ public sealed class CourseService : ICourseService
             Name = request.Name.Trim(),
             Description = request.Description?.Trim() ?? string.Empty,
             Level = CourseLevelFormatting.Format(request.Level),
+            OrganizationId = request.OrganizationId?.Trim() ?? string.Empty,
+            TeamId = string.IsNullOrWhiteSpace(request.TeamId) ? courseId : request.TeamId.Trim(),
             StartDate = request.StartDate.Date,
             EndDate = request.EndDate.Date,
             CreatedByTrainerUserId = creatorTrainerUserId,
@@ -349,6 +351,82 @@ public sealed class CourseService : ICourseService
         await _repository.UpsertCourseAsync(course);
     }
 
+    public async Task<CourseChallengeDocument> CreateChallengeAsync(
+        string courseId,
+        CourseChallengeCreateRequest request,
+        string requestingTrainerUserId)
+    {
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        if (string.IsNullOrWhiteSpace(request.Title))
+            throw new InvalidOperationException(Text("ChallengeTitleRequired", "A challenge needs a title."));
+
+        if (request.EndsAt.Date < request.StartsAt.Date)
+            throw new InvalidOperationException(Text("ChallengeEndBeforeStart", "The challenge end date cannot be before the start date."));
+
+        if (request.TargetValue is < 0)
+            throw new InvalidOperationException(Text("ChallengeTargetPositive", "The challenge target cannot be negative."));
+
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "The course was not found."));
+
+        RequireEventManagement(course, requestingTrainerUserId);
+        course.Challenges ??= new List<CourseChallengeDocument>();
+
+        var challenge = new CourseChallengeDocument
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Title = request.Title.Trim(),
+            Description = request.Description?.Trim() ?? string.Empty,
+            ChallengeType = NormalizeChallengeType(request.ChallengeType),
+            StartsAt = request.StartsAt.Date,
+            EndsAt = request.EndsAt.Date,
+            TargetValue = request.TargetValue,
+            Unit = request.Unit?.Trim() ?? string.Empty,
+            CreatedByUserId = requestingTrainerUserId,
+            CreatedAt = DateTime.UtcNow,
+            IsPublished = request.IsPublished
+        };
+
+        course.Challenges.Add(challenge);
+        course.Challenges = course.Challenges
+            .OrderBy(existing => existing.StartsAt)
+            .ThenBy(existing => existing.Title)
+            .ToList();
+
+        await _repository.UpsertCourseAsync(course);
+        return challenge;
+    }
+
+    public async Task RemoveChallengeAsync(string courseId, string challengeId, string requestingTrainerUserId)
+    {
+        var course = await _repository.GetCourseAsync(courseId)
+            ?? throw new InvalidOperationException(Text("CourseNotFound", "The course was not found."));
+
+        RequireEventManagement(course, requestingTrainerUserId);
+        course.Challenges ??= new List<CourseChallengeDocument>();
+
+        var removed = course.Challenges.RemoveAll(challenge => challenge.Id == challengeId);
+        if (removed == 0)
+            throw new InvalidOperationException(Text("ChallengeNotFound", "The challenge was not found."));
+
+        await _repository.UpsertCourseAsync(course);
+    }
+
+    public async Task<IReadOnlyList<CourseChallengeDocument>> GetChallengesForAthleteAsync(string athleteUserId)
+    {
+        var today = DateTime.UtcNow.Date;
+        var joinedCourses = await GetJoinedCoursesAsync(athleteUserId);
+
+        return joinedCourses
+            .SelectMany(course => course.Challenges ?? Enumerable.Empty<CourseChallengeDocument>())
+            .Where(challenge => challenge.IsPublished && challenge.EndsAt.Date >= today)
+            .OrderBy(challenge => challenge.StartsAt)
+            .ThenBy(challenge => challenge.Title)
+            .ToList();
+    }
+
     public Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId)
     {
         return _repository.GetEventsAsync(courseId);
@@ -562,6 +640,17 @@ public sealed class CourseService : ICourseService
         return string.IsNullOrWhiteSpace(displayName)
             ? fallbackUserId
             : displayName.Trim();
+    }
+
+    private static string NormalizeChallengeType(string? challengeType)
+    {
+        if (string.Equals(challengeType, CourseChallengeTypes.Attendance, StringComparison.OrdinalIgnoreCase))
+            return CourseChallengeTypes.Attendance;
+
+        if (string.Equals(challengeType, CourseChallengeTypes.Distance, StringComparison.OrdinalIgnoreCase))
+            return CourseChallengeTypes.Distance;
+
+        return CourseChallengeTypes.General;
     }
 
     private void RequireTrainerManagement(CourseDocument course, string requestingTrainerUserId)

--- a/PaceLetics.Web/Services/Courses/ICourseService.cs
+++ b/PaceLetics.Web/Services/Courses/ICourseService.cs
@@ -39,6 +39,15 @@ public interface ICourseService
 
     Task RemoveTrainingPlanPublicationAsync(string courseId, string trainingPlanId, string requestingTrainerUserId);
 
+    Task<CourseChallengeDocument> CreateChallengeAsync(
+        string courseId,
+        CourseChallengeCreateRequest request,
+        string requestingTrainerUserId);
+
+    Task RemoveChallengeAsync(string courseId, string challengeId, string requestingTrainerUserId);
+
+    Task<IReadOnlyList<CourseChallengeDocument>> GetChallengesForAthleteAsync(string athleteUserId);
+
     Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId);
 
     Task<CourseEventDocument> CreateEventAsync(


### PR DESCRIPTION
## Summary
- add organization/team anchors and embedded course challenges
- add trainer challenge management and athlete challenge visibility in course details
- cover challenge creation, removal, permissions, and athlete filtering with service tests

## Tests
- dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore -p:BaseOutputPath=$env:TEMP\paceletics-codex-test-bin"