### PR TITLE
Add academy to mobile bottom navigation

### DIFF
--- a/PaceLetics.Web/Shared/BottomNavBar.razor
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor
@@ -14,6 +14,19 @@
         </span>
     </NavLink>
 
+    <NavLink href="/Athletes/academy"
+             class="pl-bottom-nav__item"
+             ActiveClass="pl-bottom-nav__item--active"
+             Match="NavLinkMatch.Prefix"
+             title="@L["Nav_Academy"]">
+        <span class="pl-bottom-nav__content">
+            <span class="pl-bottom-nav__icon" aria-hidden="true">
+                <MudIcon Icon="@Icons.Material.Filled.AutoStories" Size="Size.Medium" />
+            </span>
+            <span class="pl-bottom-nav__label">@L["Nav_Academy"]</span>
+        </span>
+    </NavLink>
+
     <NavLink href="/Athletes/racepaces"
              class="pl-bottom-nav__item"
              ActiveClass="pl-bottom-nav__item--active"

--- a/PaceLetics.Web/Shared/BottomNavBar.razor.css
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor.css
@@ -26,9 +26,9 @@
     justify-content: center;
     flex: 1 1 0;
     min-width: 0;
-    max-width: 5.4rem;
+    max-width: 5rem;
     min-height: 3.75rem;
-    padding: 0.35rem 0.25rem;
+    padding: 0.35rem 0.18rem;
     color: var(--mud-palette-text-secondary);
     text-decoration: none;
     border-radius: 999px;
@@ -54,6 +54,8 @@
     align-items: center;
     justify-content: center;
     gap: 0.1rem;
+    width: 100%;
+    min-width: 0;
 }
 
 .pl-bottom-nav__icon {
@@ -67,7 +69,7 @@
 
 .pl-bottom-nav__label {
     display: -webkit-box;
-    max-width: 4.9rem;
+    max-width: 100%;
     overflow: hidden;
     font-size: 0.68rem;
     font-weight: 600;
@@ -76,6 +78,17 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
     overflow-wrap: anywhere;
+}
+
+@media (max-width: 380px) {
+    .pl-bottom-nav ::deep .pl-bottom-nav__item {
+        padding-right: 0.08rem;
+        padding-left: 0.08rem;
+    }
+
+    .pl-bottom-nav__label {
+        font-size: 0.62rem;
+    }
 }
 
 @media (min-width: 960px) {


### PR DESCRIPTION
## Summary
- add Academy to the mobile bottom navigation directly after Dashboard
- tighten bottom-nav label/item sizing so six entries fit on narrow mobile widths

## Verification
- dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore -p:BaseOutputPath="$env:TEMP\paceletics-codex-test-bin\"
- git diff --check origin/main..HEAD
- http://localhost:5089/Athletes/academy returned HTTP 200

Note: authenticated browser verification is currently blocked locally by the existing Azure SQL firewall/Identity cookie issue; the app build and route are healthy.
