### PR TITLE
Add mate feature foundation

### DIFF
--- a/PaceLetics.Tests/MateServiceTests.cs
+++ b/PaceLetics.Tests/MateServiceTests.cs
@@ -1,0 +1,427 @@
+using AthleteDataAccessLibrary.Contracts;
+using PaceLetics.AthleteModule.CodeBase.Models;
+using PaceLetics.CoreModule.Infrastructure.Constants;
+using PaceLetics.CoreModule.Infrastructure.Models;
+using PaceLetics.TrainingModule.CodeBase.Running.Models;
+using PaceLetics.TrainingPlanModule.CodeBase.Models;
+using PaceLetics.Web.Services;
+using PaceLetics.Web.Services.Courses;
+using PaceLetics.Web.Services.Mates;
+
+namespace PaceLetics.Tests;
+
+public sealed class MateServiceTests
+{
+    [Fact]
+    public async Task ShareSessionAsync_CreatesAvailabilityForVisibleCoursePlan()
+    {
+        var fixture = CreateFixture();
+
+        await fixture.CourseService.JoinCourseAsync("course-1", "athlete-1");
+
+        var availability = await fixture.MateService.ShareSessionAsync(
+            "athlete-1",
+            new MateShareRequest
+            {
+                CourseId = "course-1",
+                PlanId = "plan-1",
+                SessionId = "session-1"
+            });
+
+        Assert.Equal("course-1", availability.CourseId);
+        Assert.Equal("athlete-1", availability.AthleteUserId);
+        Assert.Equal("Pitt", availability.AthleteDisplayName);
+        Assert.Equal(5000, availability.DistanceMeters);
+        Assert.Equal(345, availability.PaceSecondsPerKilometer);
+        Assert.True(availability.IsActive);
+        Assert.Single(await fixture.MateRepository.GetMateAvailabilitiesForAthleteAsync("athlete-1"));
+    }
+
+    [Fact]
+    public async Task GetOverviewAsync_ReturnsMatchesOnlyForOwnSharedSessionsInSameCourse()
+    {
+        var fixture = CreateFixture();
+        await fixture.CourseService.JoinCourseAsync("course-1", "athlete-1");
+        await fixture.CourseService.JoinCourseAsync("course-1", "athlete-2");
+
+        await fixture.MateRepository.UpsertMateAvailabilityAsync(CreateCandidateAvailability(
+            "course-1",
+            "athlete-2",
+            "Pat",
+            350));
+        await fixture.MateRepository.UpsertMateAvailabilityAsync(CreateCandidateAvailability(
+            "course-2",
+            "athlete-3",
+            "Other course",
+            348));
+
+        var beforeShare = await fixture.MateService.GetOverviewAsync("athlete-1");
+        Assert.Empty(beforeShare.Matches);
+
+        await fixture.MateService.ShareSessionAsync(
+            "athlete-1",
+            new MateShareRequest
+            {
+                CourseId = "course-1",
+                PlanId = "plan-1",
+                SessionId = "session-1"
+            });
+
+        var overview = await fixture.MateService.GetOverviewAsync("athlete-1");
+
+        var match = Assert.Single(overview.Matches);
+        Assert.Equal("athlete-2", match.MateSession.AthleteUserId);
+        Assert.Equal("Pat", match.MateSession.AthleteDisplayName);
+        Assert.Equal(5, match.PaceDeltaSeconds);
+    }
+
+    [Fact]
+    public async Task ShareSessionAsync_RequiresJoinedCourse()
+    {
+        var fixture = CreateFixture();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            fixture.MateService.ShareSessionAsync(
+                "athlete-1",
+                new MateShareRequest
+                {
+                    CourseId = "course-1",
+                    PlanId = "plan-1",
+                    SessionId = "session-1"
+                }));
+
+        Assert.Empty(await fixture.MateRepository.GetMateAvailabilitiesForAthleteAsync("athlete-1"));
+    }
+
+    private static Fixture CreateFixture()
+    {
+        var plan = CreatePlan("plan-1", DateTime.Today.AddDays(2));
+        var courseRepository = new InMemoryCourseRepository(CreateCourse("course-1", "plan-1"), CreateCourse("course-2", "plan-1"));
+        var courseService = new CourseService(courseRepository);
+        var mateRepository = new InMemoryMateRepository();
+        var trainingPlanService = new FakeTrainingPlanService(plan);
+        var athleteData = new InMemoryAthleteData(
+            CreateAthlete("athlete-1", "Pitt", 345),
+            CreateAthlete("athlete-2", "Pat", 350));
+        var mateService = new MateService(courseService, mateRepository, trainingPlanService, athleteData);
+
+        return new Fixture(courseService, mateRepository, mateService);
+    }
+
+    private static TrainingPlan CreatePlan(string planId, DateTime date)
+    {
+        var run = new SimpleRunSession(
+            "run-1",
+            "Easy run",
+            date,
+            5000,
+            PaceKeys.Easy);
+        var session = new TrainingSession(
+            "session-1",
+            "5k easy",
+            date,
+            new[] { run },
+            Array.Empty<WorkoutSessionDefinition>(),
+            Array.Empty<TrainingSessionActivity>(),
+            Array.Empty<TrainingSessionActivity>(),
+            TrainingEffect.Empty,
+            new TrainingSessionAppointment(date.AddHours(18), date.AddHours(19), "Track"));
+
+        return new TrainingPlan(planId, "Level 1", new[] { session });
+    }
+
+    private static CourseDocument CreateCourse(string courseId, string planId)
+    {
+        return new CourseDocument
+        {
+            Id = courseId,
+            CourseId = courseId,
+            Name = courseId,
+            Slug = courseId,
+            IsPublished = true,
+            StartDate = DateTime.Today.AddDays(-1),
+            EndDate = DateTime.Today.AddDays(30),
+            CreatedByTrainerUserId = "trainer-1",
+            Trainers =
+            {
+                new CourseTrainerDocument
+                {
+                    TrainerUserId = "trainer-1",
+                    DisplayName = "Coach"
+                }
+            },
+            TrainingPlanPublications =
+            {
+                new CourseTrainingPlanPublicationDocument
+                {
+                    TrainingPlanId = planId,
+                    PublishedAt = DateTime.UtcNow.AddDays(-1)
+                }
+            }
+        };
+    }
+
+    private static AthleteModel CreateAthlete(string userId, string publicUserName, int easyPaceSeconds)
+    {
+        return new AthleteModel
+        {
+            Id = userId,
+            AthleteId = userId,
+            Name = publicUserName,
+            PublicProfile = new PublicProfileModel
+            {
+                PublicUserName = publicUserName,
+                NormalizedPublicUserName = publicUserName.ToUpperInvariant()
+            },
+            PaceModel = new PaceModel
+            {
+                Easy = TimeSpan.FromSeconds(easyPaceSeconds),
+                Marathon = TimeSpan.FromSeconds(easyPaceSeconds - 20),
+                Threshold = TimeSpan.FromSeconds(easyPaceSeconds - 40),
+                Intervall = TimeSpan.FromSeconds(easyPaceSeconds - 55),
+                Repetition = TimeSpan.FromSeconds(easyPaceSeconds - 70)
+            }
+        };
+    }
+
+    private static MateAvailabilityDocument CreateCandidateAvailability(
+        string courseId,
+        string athleteUserId,
+        string displayName,
+        int paceSeconds)
+    {
+        var date = DateTime.Today.AddDays(2);
+        return new MateAvailabilityDocument
+        {
+            Id = MateDocumentIds.Availability(courseId, athleteUserId, "plan-1", "session-1"),
+            CourseId = courseId,
+            DocumentType = MateDocumentTypes.Availability,
+            AthleteUserId = athleteUserId,
+            AthleteDisplayName = displayName,
+            CourseName = courseId,
+            PlanId = "plan-1",
+            PlanName = "Level 1",
+            SessionId = "session-1",
+            SessionName = "5k easy",
+            SessionDate = date,
+            StartsAt = date.AddHours(18),
+            DistanceMeters = 5200,
+            PaceKey = PaceKeys.Easy,
+            PaceSecondsPerKilometer = paceSeconds,
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            UpdatedAt = DateTime.UtcNow.AddHours(-1)
+        };
+    }
+
+    private sealed record Fixture(
+        ICourseService CourseService,
+        InMemoryMateRepository MateRepository,
+        IMateService MateService);
+
+    private sealed class FakeTrainingPlanService : ITrainingPlanService
+    {
+        private readonly IReadOnlyList<TrainingPlan> _plans;
+
+        public FakeTrainingPlanService(params TrainingPlan[] plans)
+        {
+            _plans = plans;
+        }
+
+        public IReadOnlyList<TrainingPlan> LoadTrainingPlans()
+        {
+            return _plans;
+        }
+
+        public Task<IReadOnlyList<TrainingPlan>> LoadTrainingPlansForUserAsync(string? userId)
+        {
+            return Task.FromResult(string.IsNullOrWhiteSpace(userId)
+                ? Array.Empty<TrainingPlan>()
+                : _plans);
+        }
+
+        public IReadOnlyList<RunningSession> LoadLegacySessions()
+        {
+            return Array.Empty<RunningSession>();
+        }
+    }
+
+    private sealed class InMemoryAthleteData : IAthleteData
+    {
+        private readonly List<AthleteModel> _athletes;
+
+        public InMemoryAthleteData(params AthleteModel[] athletes)
+        {
+            _athletes = athletes.ToList();
+        }
+
+        public Task<List<AthleteModel>> GetAthletes()
+        {
+            return Task.FromResult(_athletes.ToList());
+        }
+
+        public Task InsertAthlete(AthleteModel model)
+        {
+            _athletes.Add(model);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAthlete(string guid)
+        {
+            _athletes.RemoveAll(athlete => athlete.Id == guid);
+            return Task.CompletedTask;
+        }
+
+        public Task<AthleteModel?> GetAthlete(string id)
+        {
+            return Task.FromResult(_athletes.FirstOrDefault(athlete => athlete.Id == id || athlete.AthleteId == id));
+        }
+
+        public Task UpdateAthlete(AthleteModel model)
+        {
+            _athletes.RemoveAll(athlete => athlete.Id == model.Id);
+            _athletes.Add(model);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryMateRepository : IMateRepository
+    {
+        private readonly List<MateAvailabilityDocument> _availabilities = new();
+
+        public Task<IReadOnlyList<MateAvailabilityDocument>> GetMateAvailabilitiesForCourseAsync(string courseId)
+        {
+            return Task.FromResult<IReadOnlyList<MateAvailabilityDocument>>(
+                _availabilities.Where(availability => availability.CourseId == courseId).ToList());
+        }
+
+        public Task<IReadOnlyList<MateAvailabilityDocument>> GetMateAvailabilitiesForAthleteAsync(string athleteUserId)
+        {
+            return Task.FromResult<IReadOnlyList<MateAvailabilityDocument>>(
+                _availabilities.Where(availability => availability.AthleteUserId == athleteUserId).ToList());
+        }
+
+        public Task<MateAvailabilityDocument?> GetMateAvailabilityAsync(string courseId, string availabilityId)
+        {
+            return Task.FromResult(_availabilities.FirstOrDefault(availability =>
+                availability.CourseId == courseId && availability.Id == availabilityId));
+        }
+
+        public Task UpsertMateAvailabilityAsync(MateAvailabilityDocument availability)
+        {
+            if (string.IsNullOrWhiteSpace(availability.Id))
+                availability.Id = MateDocumentIds.Availability(
+                    availability.CourseId,
+                    availability.AthleteUserId,
+                    availability.PlanId,
+                    availability.SessionId);
+
+            _availabilities.RemoveAll(existing => existing.Id == availability.Id);
+            _availabilities.Add(availability);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteMateAvailabilityAsync(string courseId, string availabilityId)
+        {
+            _availabilities.RemoveAll(availability =>
+                availability.CourseId == courseId && availability.Id == availabilityId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryCourseRepository : ICourseRepository
+    {
+        private readonly List<CourseDocument> _courses;
+        private readonly List<CourseEnrollmentDocument> _enrollments = new();
+
+        public InMemoryCourseRepository(params CourseDocument[] courses)
+        {
+            _courses = courses.ToList();
+        }
+
+        public Task<IReadOnlyList<CourseDocument>> GetCoursesAsync()
+        {
+            return Task.FromResult<IReadOnlyList<CourseDocument>>(_courses);
+        }
+
+        public Task<CourseDocument?> GetCourseAsync(string courseId)
+        {
+            return Task.FromResult(_courses.FirstOrDefault(course => course.Id == courseId));
+        }
+
+        public Task UpsertCourseAsync(CourseDocument course)
+        {
+            _courses.RemoveAll(existing => existing.Id == course.Id);
+            _courses.Add(course);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteCourseAsync(string courseId)
+        {
+            _courses.RemoveAll(course => course.Id == courseId);
+            _enrollments.RemoveAll(enrollment => enrollment.CourseId == courseId);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForAthleteAsync(string athleteUserId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEnrollmentDocument>>(
+                _enrollments.Where(enrollment => enrollment.AthleteUserId == athleteUserId).ToList());
+        }
+
+        public Task<IReadOnlyList<CourseEnrollmentDocument>> GetEnrollmentsForCourseAsync(string courseId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEnrollmentDocument>>(
+                _enrollments.Where(enrollment => enrollment.CourseId == courseId).ToList());
+        }
+
+        public Task<CourseEnrollmentDocument?> GetEnrollmentAsync(string courseId, string athleteUserId)
+        {
+            return Task.FromResult(_enrollments.FirstOrDefault(enrollment =>
+                enrollment.CourseId == courseId && enrollment.AthleteUserId == athleteUserId));
+        }
+
+        public Task UpsertEnrollmentAsync(CourseEnrollmentDocument enrollment)
+        {
+            _enrollments.RemoveAll(existing =>
+                existing.CourseId == enrollment.CourseId && existing.AthleteUserId == enrollment.AthleteUserId);
+            _enrollments.Add(enrollment);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CourseEventDocument>> GetEventsAsync(string courseId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEventDocument>>(Array.Empty<CourseEventDocument>());
+        }
+
+        public Task<CourseEventDocument?> GetEventAsync(string courseId, string eventId)
+        {
+            return Task.FromResult<CourseEventDocument?>(null);
+        }
+
+        public Task UpsertEventAsync(CourseEventDocument courseEvent)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteEventAsync(string courseId, string eventId)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<CourseEventRegistrationDocument>> GetEventRegistrationsAsync(string courseId, string eventId)
+        {
+            return Task.FromResult<IReadOnlyList<CourseEventRegistrationDocument>>(Array.Empty<CourseEventRegistrationDocument>());
+        }
+
+        public Task<CourseEventRegistrationDocument?> GetEventRegistrationAsync(string courseId, string eventId, string athleteUserId)
+        {
+            return Task.FromResult<CourseEventRegistrationDocument?>(null);
+        }
+
+        public Task UpsertEventRegistrationAsync(CourseEventRegistrationDocument registration)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/PaceLetics.Web/Pages/Athletes/Mate.razor
+++ b/PaceLetics.Web/Pages/Athletes/Mate.razor
@@ -1,0 +1,265 @@
+@page "/Athletes/mate"
+@attribute [Authorize]
+@using System.Security.Claims
+@using PaceLetics.Web.Services.Mates
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IMateService MateService
+@inject ISnackbar Snackbar
+@inject IStringLocalizer<Mate> L
+
+<PageTitle>@L["PageTitle"]</PageTitle>
+
+<MudContainer Class="pl-section-page px-6 pb-8" MaxWidth="MaxWidth.Medium">
+    <PageHeader Title="@L["Title"]" Subtitle="@L["Subtitle"]" />
+
+    @if (_isLoading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="mt-4" />
+    }
+    else
+    {
+        <MudStack Spacing="3" Class="mt-4">
+            <MudPaper Elevation="0" Class="pa-4 pl-panel">
+                <MudGrid Spacing="2">
+                    <MudItem xs="4">
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["MetricSessions"]</MudText>
+                        <MudText Typo="Typo.h6">@_overview.ShareableSessions.Count</MudText>
+                    </MudItem>
+                    <MudItem xs="4">
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["MetricShared"]</MudText>
+                        <MudText Typo="Typo.h6">@_overview.MyAvailabilities.Count</MudText>
+                    </MudItem>
+                    <MudItem xs="4">
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">@L["MetricMatches"]</MudText>
+                        <MudText Typo="Typo.h6">@_overview.Matches.Count</MudText>
+                    </MudItem>
+                </MudGrid>
+            </MudPaper>
+
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">@L["SectionMatches"]</MudText>
+                @if (_overview.Matches.Count == 0)
+                {
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">@L["NoMatches"]</MudAlert>
+                }
+                else
+                {
+                    @foreach (var match in _overview.Matches)
+                    {
+                        <MudPaper Elevation="0" Class="pa-4 pl-course-detail">
+                            <MudStack Spacing="2">
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:8px; flex-wrap:wrap;">
+                                    <MudIcon Icon="@Icons.Material.Filled.People" Color="Color.Primary" />
+                                    <MudText Typo="Typo.h6">@match.MateSession.AthleteDisplayName</MudText>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">
+                                        @($"{match.Score}%")
+                                    </MudChip>
+                                </MudStack>
+
+                                <MudText Typo="Typo.body2">@match.MateSession.SessionName</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@GetAvailabilityDetail(match.MateSession)</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    @string.Format(L["MatchOwn"], match.OwnSession.SessionName)
+                                </MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@GetMatchDelta(match)</MudText>
+                            </MudStack>
+                        </MudPaper>
+                    }
+                }
+            </MudStack>
+
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">@L["SectionShare"]</MudText>
+                @if (_overview.ShareableSessions.Count == 0)
+                {
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">@L["NoSessions"]</MudAlert>
+                }
+                else
+                {
+                    @foreach (var session in _overview.ShareableSessions)
+                    {
+                        <MudPaper Elevation="0" Class="pa-4 pl-course-detail">
+                            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Style="gap:12px; flex-wrap:wrap;">
+                                <MudStack Spacing="1" Style="min-width:0; flex:1 1 260px;">
+                                    <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:8px; flex-wrap:wrap;">
+                                        <MudIcon Icon="@Icons.Material.Filled.DirectionsRun" Color="Color.Primary" Size="Size.Small" />
+                                        <MudText Typo="Typo.h6">@session.SessionName</MudText>
+                                        @if (session.IsShared)
+                                        {
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">
+                                                @L["Shared"]
+                                            </MudChip>
+                                        }
+                                    </MudStack>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@GetShareableDetail(session)</MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        @($"{L["Course"]}: {session.CourseName} · {L["Plan"]}: {session.PlanName}")
+                                    </MudText>
+                                </MudStack>
+
+                                @if (session.IsShared && session.AvailabilityId is not null)
+                                {
+                                    <MudTooltip Text="@L["Remove"]">
+                                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                                       Color="Color.Secondary"
+                                                       Disabled="@_isSaving"
+                                                       OnClick="@(() => RemoveAsync(session.AvailabilityId))"
+                                                       aria-label="@L["Remove"]" />
+                                    </MudTooltip>
+                                }
+                                else
+                                {
+                                    <MudButton Color="Color.Primary"
+                                               Variant="Variant.Filled"
+                                               Disabled="@_isSaving"
+                                               StartIcon="@Icons.Material.Filled.PersonAdd"
+                                               OnClick="@(() => ShareAsync(session))">
+                                        @L["Share"]
+                                    </MudButton>
+                                }
+                            </MudStack>
+                        </MudPaper>
+                    }
+                }
+            </MudStack>
+        </MudStack>
+    }
+</MudContainer>
+
+@code {
+    private MateOverview _overview = new();
+    private string? _userId;
+    private bool _isLoading = true;
+    private bool _isSaving;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        try
+        {
+            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            _userId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            _overview = await MateService.GetOverviewAsync(_userId);
+        }
+        catch
+        {
+            Snackbar.Add(L["LoadError"], Severity.Error);
+            _overview = new MateOverview();
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task ShareAsync(MateShareableSession session)
+    {
+        _isSaving = true;
+        try
+        {
+            await MateService.ShareSessionAsync(
+                _userId,
+                new MateShareRequest
+                {
+                    CourseId = session.CourseId,
+                    PlanId = session.PlanId,
+                    SessionId = session.SessionId
+                });
+            Snackbar.Add(L["ShareSuccess"], Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"{L["ShareError"]}: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task RemoveAsync(string availabilityId)
+    {
+        _isSaving = true;
+        try
+        {
+            await MateService.RemoveAvailabilityAsync(_userId, availabilityId);
+            Snackbar.Add(L["RemoveSuccess"], Severity.Success);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"{L["RemoveError"]}: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private string GetShareableDetail(MateShareableSession session)
+    {
+        return string.Join(
+            " · ",
+            new[]
+            {
+                FormatDate(session.StartsAt ?? session.SessionDate),
+                FormatDistance(session.DistanceMeters),
+                FormatPace(session.PaceSecondsPerKilometer, session.PaceKey),
+                string.IsNullOrWhiteSpace(session.Location) ? string.Empty : $"{L["Location"]}: {session.Location}"
+            }.Where(part => !string.IsNullOrWhiteSpace(part)));
+    }
+
+    private string GetAvailabilityDetail(MateAvailabilityDocument availability)
+    {
+        return string.Join(
+            " · ",
+            new[]
+            {
+                FormatDate(availability.StartsAt ?? availability.SessionDate),
+                availability.CourseName,
+                FormatDistance(availability.DistanceMeters),
+                FormatPace(availability.PaceSecondsPerKilometer, availability.PaceKey),
+                string.IsNullOrWhiteSpace(availability.Location) ? string.Empty : $"{L["Location"]}: {availability.Location}"
+            }.Where(part => !string.IsNullOrWhiteSpace(part)));
+    }
+
+    private string GetMatchDelta(MateMatch match)
+    {
+        var pace = match.PaceDeltaSeconds is null
+            ? L["SamePaceZone"].Value
+            : string.Format(L["PaceDelta"], match.PaceDeltaSeconds);
+        var days = string.Format(L["DayDelta"], match.DayDelta);
+        var distance = string.Format(L["DistanceDelta"], FormatDistance(match.DistanceDeltaMeters));
+
+        return $"{pace} · {days} · {distance}";
+    }
+
+    private static string FormatDate(DateTime date)
+    {
+        return date.TimeOfDay == TimeSpan.Zero
+            ? date.ToString("dd.MM.yyyy")
+            : date.ToString("dd.MM.yyyy HH:mm");
+    }
+
+    private static string FormatDistance(int meters)
+    {
+        return meters >= 1000
+            ? $"{meters / 1000.0:0.#} km"
+            : $"{meters} m";
+    }
+
+    private string FormatPace(int? secondsPerKilometer, string paceKey)
+    {
+        if (secondsPerKilometer is null or <= 0)
+            return string.IsNullOrWhiteSpace(paceKey) ? L["NoPace"] : paceKey;
+
+        var pace = TimeSpan.FromSeconds(secondsPerKilometer.Value);
+        return $"{pace:mm\\:ss}/km";
+    }
+}

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -26,6 +26,7 @@ using PaceLetics.Web.Services.DashboardMessages;
 using PaceLetics.Web.Services.Academy;
 using PaceLetics.CoreModule.Infrastructure.Services;
 using PaceLetics.Web.Services.Courses;
+using PaceLetics.Web.Services.Mates;
 using PaceLetics.Web.Services.RunningAnalysis;
 using PaceLetics.Web.Services.Theming;
 using PaceLetics.Web.Services.Loading;
@@ -113,7 +114,9 @@ builder.Services.Configure<TrainerVerificationOptions>(options =>
     }
 });
 builder.Services.AddTransient<IEmailSender, SmtpEmailSender>();
-builder.Services.AddScoped<ICourseRepository, CosmosCourseRepository>();
+builder.Services.AddScoped<CosmosCourseRepository>();
+builder.Services.AddScoped<ICourseRepository>(x => x.GetRequiredService<CosmosCourseRepository>());
+builder.Services.AddScoped<IMateRepository>(x => x.GetRequiredService<CosmosCourseRepository>());
 builder.Services.Configure<GoogleDriveRunningAnalysisOptions>(options =>
 {
     builder.Configuration.GetSection(GoogleDriveRunningAnalysisOptions.LegacySectionName).Bind(options);
@@ -137,6 +140,7 @@ builder.Services.AddScoped<ICourseRunningAnalysisRegistrationAdapter, CourseRunn
 builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddScoped<ITrainingPlanService, TrainingPlanService>();
 builder.Services.AddScoped<IAcademyService, AcademyService>();
+builder.Services.AddScoped<IMateService, MateService>();
 builder.Services.AddScoped<ThemePreferenceService>();
 builder.Services.AddScoped<LoadingStateService>();
 builder.Services.AddSingleton<DashboardMessageFeedOptions>();

--- a/PaceLetics.Web/Resources/Pages/Athletes/Mate.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Mate.de.resx
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Mate</value></data>
+  <data name="Title" xml:space="preserve"><value>Mate</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Finde passende Trainingspartner:innen fuer freigegebene Laufeinheiten.</value></data>
+  <data name="MetricSessions" xml:space="preserve"><value>Einheiten</value></data>
+  <data name="MetricShared" xml:space="preserve"><value>Freigegeben</value></data>
+  <data name="MetricMatches" xml:space="preserve"><value>Matches</value></data>
+  <data name="SectionMatches" xml:space="preserve"><value>Matches</value></data>
+  <data name="SectionShare" xml:space="preserve"><value>Laufeinheiten</value></data>
+  <data name="NoMatches" xml:space="preserve"><value>Noch keine Mate-Matches.</value></data>
+  <data name="NoSessions" xml:space="preserve"><value>Keine kommenden Laufeinheiten verfuegbar.</value></data>
+  <data name="Shared" xml:space="preserve"><value>Freigegeben</value></data>
+  <data name="Share" xml:space="preserve"><value>Freigeben</value></data>
+  <data name="Remove" xml:space="preserve"><value>Entfernen</value></data>
+  <data name="Course" xml:space="preserve"><value>Kurs</value></data>
+  <data name="Plan" xml:space="preserve"><value>Plan</value></data>
+  <data name="Location" xml:space="preserve"><value>Ort</value></data>
+  <data name="MatchOwn" xml:space="preserve"><value>Passt zu deiner Einheit: {0}</value></data>
+  <data name="SamePaceZone" xml:space="preserve"><value>Gleicher Pacebereich</value></data>
+  <data name="PaceDelta" xml:space="preserve"><value>{0} s/km Unterschied</value></data>
+  <data name="DayDelta" xml:space="preserve"><value>{0} Tag(e)</value></data>
+  <data name="DistanceDelta" xml:space="preserve"><value>{0} Distanzunterschied</value></data>
+  <data name="NoPace" xml:space="preserve"><value>Keine Pace</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Mate-Daten konnten nicht geladen werden.</value></data>
+  <data name="ShareSuccess" xml:space="preserve"><value>Einheit fuer Mate freigegeben.</value></data>
+  <data name="RemoveSuccess" xml:space="preserve"><value>Mate-Freigabe entfernt.</value></data>
+  <data name="ShareError" xml:space="preserve"><value>Freigabe fehlgeschlagen</value></data>
+  <data name="RemoveError" xml:space="preserve"><value>Entfernen fehlgeschlagen</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Mate.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Mate.en.resx
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Mate</value></data>
+  <data name="Title" xml:space="preserve"><value>Mate</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Find matching training partners for released running sessions.</value></data>
+  <data name="MetricSessions" xml:space="preserve"><value>Sessions</value></data>
+  <data name="MetricShared" xml:space="preserve"><value>Shared</value></data>
+  <data name="MetricMatches" xml:space="preserve"><value>Matches</value></data>
+  <data name="SectionMatches" xml:space="preserve"><value>Matches</value></data>
+  <data name="SectionShare" xml:space="preserve"><value>Running sessions</value></data>
+  <data name="NoMatches" xml:space="preserve"><value>No Mate matches yet.</value></data>
+  <data name="NoSessions" xml:space="preserve"><value>No upcoming running sessions are available.</value></data>
+  <data name="Shared" xml:space="preserve"><value>Shared</value></data>
+  <data name="Share" xml:space="preserve"><value>Share</value></data>
+  <data name="Remove" xml:space="preserve"><value>Remove</value></data>
+  <data name="Course" xml:space="preserve"><value>Course</value></data>
+  <data name="Plan" xml:space="preserve"><value>Plan</value></data>
+  <data name="Location" xml:space="preserve"><value>Location</value></data>
+  <data name="MatchOwn" xml:space="preserve"><value>Matches your session: {0}</value></data>
+  <data name="SamePaceZone" xml:space="preserve"><value>Same pace zone</value></data>
+  <data name="PaceDelta" xml:space="preserve"><value>{0} s/km difference</value></data>
+  <data name="DayDelta" xml:space="preserve"><value>{0} day(s)</value></data>
+  <data name="DistanceDelta" xml:space="preserve"><value>{0} distance difference</value></data>
+  <data name="NoPace" xml:space="preserve"><value>No pace</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Mate data could not be loaded.</value></data>
+  <data name="ShareSuccess" xml:space="preserve"><value>Session shared for Mate.</value></data>
+  <data name="RemoveSuccess" xml:space="preserve"><value>Mate sharing removed.</value></data>
+  <data name="ShareError" xml:space="preserve"><value>Sharing failed</value></data>
+  <data name="RemoveError" xml:space="preserve"><value>Removing failed</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Mate.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Mate.resx
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="PageTitle" xml:space="preserve"><value>Mate</value></data>
+  <data name="Title" xml:space="preserve"><value>Mate</value></data>
+  <data name="Subtitle" xml:space="preserve"><value>Find matching training partners for released running sessions.</value></data>
+  <data name="MetricSessions" xml:space="preserve"><value>Sessions</value></data>
+  <data name="MetricShared" xml:space="preserve"><value>Shared</value></data>
+  <data name="MetricMatches" xml:space="preserve"><value>Matches</value></data>
+  <data name="SectionMatches" xml:space="preserve"><value>Matches</value></data>
+  <data name="SectionShare" xml:space="preserve"><value>Running sessions</value></data>
+  <data name="NoMatches" xml:space="preserve"><value>No Mate matches yet.</value></data>
+  <data name="NoSessions" xml:space="preserve"><value>No upcoming running sessions are available.</value></data>
+  <data name="Shared" xml:space="preserve"><value>Shared</value></data>
+  <data name="Share" xml:space="preserve"><value>Share</value></data>
+  <data name="Remove" xml:space="preserve"><value>Remove</value></data>
+  <data name="Course" xml:space="preserve"><value>Course</value></data>
+  <data name="Plan" xml:space="preserve"><value>Plan</value></data>
+  <data name="Location" xml:space="preserve"><value>Location</value></data>
+  <data name="MatchOwn" xml:space="preserve"><value>Matches your session: {0}</value></data>
+  <data name="SamePaceZone" xml:space="preserve"><value>Same pace zone</value></data>
+  <data name="PaceDelta" xml:space="preserve"><value>{0} s/km difference</value></data>
+  <data name="DayDelta" xml:space="preserve"><value>{0} day(s)</value></data>
+  <data name="DistanceDelta" xml:space="preserve"><value>{0} distance difference</value></data>
+  <data name="NoPace" xml:space="preserve"><value>No pace</value></data>
+  <data name="LoadError" xml:space="preserve"><value>Mate data could not be loaded.</value></data>
+  <data name="ShareSuccess" xml:space="preserve"><value>Session shared for Mate.</value></data>
+  <data name="RemoveSuccess" xml:space="preserve"><value>Mate sharing removed.</value></data>
+  <data name="ShareError" xml:space="preserve"><value>Sharing failed</value></data>
+  <data name="RemoveError" xml:space="preserve"><value>Removing failed</value></data>
+</root>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.de.resx
@@ -34,6 +34,7 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_Academy" xml:space="preserve"><value>Academy</value></data>
+  <data name="Nav_Mate" xml:space="preserve"><value>Mate</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Laufdaten</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pacebereiche</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>Kurse &amp; Plaene</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.en.resx
@@ -34,6 +34,7 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_Academy" xml:space="preserve"><value>Academy</value></data>
+  <data name="Nav_Mate" xml:space="preserve"><value>Mate</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>Courses &amp; Plans</value></data>

--- a/PaceLetics.Web/Resources/Shared/NavMenu.resx
+++ b/PaceLetics.Web/Resources/Shared/NavMenu.resx
@@ -34,6 +34,7 @@
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <data name="Nav_Dashboard" xml:space="preserve"><value>Dashboard</value></data>
   <data name="Nav_Academy" xml:space="preserve"><value>Academy</value></data>
+  <data name="Nav_Mate" xml:space="preserve"><value>Mate</value></data>
   <data name="Nav_RaceData" xml:space="preserve"><value>Race Data</value></data>
   <data name="Nav_PaceZones" xml:space="preserve"><value>Pace Zones</value></data>
   <data name="Nav_Courses" xml:space="preserve"><value>Courses &amp; Plans</value></data>

--- a/PaceLetics.Web/Services/Courses/CosmosCourseRepository.cs
+++ b/PaceLetics.Web/Services/Courses/CosmosCourseRepository.cs
@@ -1,9 +1,10 @@
 using AthleteDataAccessLibrary;
 using AthleteDataAccessLibrary.Contracts;
+using PaceLetics.Web.Services.Mates;
 
 namespace PaceLetics.Web.Services.Courses;
 
-public sealed class CosmosCourseRepository : ICourseRepository
+public sealed class CosmosCourseRepository : ICourseRepository, IMateRepository
 {
     private readonly IDataAccess _db;
     private readonly AthleteDataOptions _options;
@@ -55,10 +56,20 @@ public sealed class CosmosCourseRepository : ICourseRepository
         var registrations = await LoadPartitionItems<CourseEventRegistrationDocument>(
             courseId,
             CourseDocumentTypes.EventRegistration);
+        var mateAvailabilities = await LoadPartitionItems<MateAvailabilityDocument>(
+            courseId,
+            CourseDocumentTypes.MateAvailability);
         var events = await LoadPartitionItems<CourseEventDocument>(courseId, CourseDocumentTypes.Event);
         var enrollments = await LoadPartitionItems<CourseEnrollmentDocument>(
             courseId,
             CourseDocumentTypes.Enrollment);
+
+        foreach (var availability in mateAvailabilities)
+            await _db.DeleteItem<MateAvailabilityDocument>(
+                _options.DatabaseName,
+                _options.CourseContainerName,
+                availability.Id,
+                courseId);
 
         foreach (var registration in registrations)
             await _db.DeleteItem<CourseEventRegistrationDocument>(
@@ -217,6 +228,63 @@ public sealed class CosmosCourseRepository : ICourseRepository
             _options.CourseContainerName,
             registration,
             registration.CourseId);
+    }
+
+    public Task<IReadOnlyList<MateAvailabilityDocument>> GetMateAvailabilitiesForCourseAsync(string courseId)
+    {
+        return LoadPartitionItems<MateAvailabilityDocument>(courseId, CourseDocumentTypes.MateAvailability);
+    }
+
+    public async Task<IReadOnlyList<MateAvailabilityDocument>> GetMateAvailabilitiesForAthleteAsync(string athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return Array.Empty<MateAvailabilityDocument>();
+
+        var availabilities = await _db.LoadData<MateAvailabilityDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            CourseDocumentTypes.MateAvailability);
+
+        return availabilities
+            .Where(availability => availability.AthleteUserId == athleteUserId)
+            .ToList();
+    }
+
+    public Task<MateAvailabilityDocument?> GetMateAvailabilityAsync(string courseId, string availabilityId)
+    {
+        return _db.LoadItem<MateAvailabilityDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            availabilityId,
+            courseId);
+    }
+
+    public Task UpsertMateAvailabilityAsync(MateAvailabilityDocument availability)
+    {
+        availability.DocumentType = CourseDocumentTypes.MateAvailability;
+        if (string.IsNullOrWhiteSpace(availability.Id))
+        {
+            availability.Id = MateDocumentIds.Availability(
+                availability.CourseId,
+                availability.AthleteUserId,
+                availability.PlanId,
+                availability.SessionId);
+        }
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            availability,
+            availability.CourseId);
+    }
+
+    public Task DeleteMateAvailabilityAsync(string courseId, string availabilityId)
+    {
+        return _db.DeleteItem<MateAvailabilityDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            availabilityId,
+            courseId);
     }
 
     private async Task EnsureDefaultCoursesAsync()

--- a/PaceLetics.Web/Services/Courses/CourseDocuments.cs
+++ b/PaceLetics.Web/Services/Courses/CourseDocuments.cs
@@ -9,6 +9,7 @@ public static class CourseDocumentTypes
     public const string Enrollment = "courseEnrollment";
     public const string Event = "courseEvent";
     public const string EventRegistration = "courseEventRegistration";
+    public const string MateAvailability = "mateAvailability";
 }
 
 public static class CourseEnrollmentStatus

--- a/PaceLetics.Web/Services/Mates/IMateRepository.cs
+++ b/PaceLetics.Web/Services/Mates/IMateRepository.cs
@@ -1,0 +1,14 @@
+namespace PaceLetics.Web.Services.Mates;
+
+public interface IMateRepository
+{
+    Task<IReadOnlyList<MateAvailabilityDocument>> GetMateAvailabilitiesForCourseAsync(string courseId);
+
+    Task<IReadOnlyList<MateAvailabilityDocument>> GetMateAvailabilitiesForAthleteAsync(string athleteUserId);
+
+    Task<MateAvailabilityDocument?> GetMateAvailabilityAsync(string courseId, string availabilityId);
+
+    Task UpsertMateAvailabilityAsync(MateAvailabilityDocument availability);
+
+    Task DeleteMateAvailabilityAsync(string courseId, string availabilityId);
+}

--- a/PaceLetics.Web/Services/Mates/IMateService.cs
+++ b/PaceLetics.Web/Services/Mates/IMateService.cs
@@ -1,0 +1,10 @@
+namespace PaceLetics.Web.Services.Mates;
+
+public interface IMateService
+{
+    Task<MateOverview> GetOverviewAsync(string? athleteUserId);
+
+    Task<MateAvailabilityDocument> ShareSessionAsync(string? athleteUserId, MateShareRequest request);
+
+    Task RemoveAvailabilityAsync(string? athleteUserId, string availabilityId);
+}

--- a/PaceLetics.Web/Services/Mates/MateModels.cs
+++ b/PaceLetics.Web/Services/Mates/MateModels.cs
@@ -1,0 +1,76 @@
+using PaceLetics.CoreModule.Infrastructure.Interfaces;
+
+namespace PaceLetics.Web.Services.Mates;
+
+public sealed class MateShareRequest
+{
+    public string CourseId { get; set; } = string.Empty;
+    public string PlanId { get; set; } = string.Empty;
+    public string SessionId { get; set; } = string.Empty;
+    public string Notes { get; set; } = string.Empty;
+}
+
+public sealed class MateAvailabilityDocument : IQueryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string CourseId { get; set; } = string.Empty;
+    public string DocumentType { get; set; } = MateDocumentTypes.Availability;
+    public string AthleteUserId { get; set; } = string.Empty;
+    public string AthleteDisplayName { get; set; } = string.Empty;
+    public string PlanId { get; set; } = string.Empty;
+    public string PlanName { get; set; } = string.Empty;
+    public string SessionId { get; set; } = string.Empty;
+    public string SessionName { get; set; } = string.Empty;
+    public string CourseName { get; set; } = string.Empty;
+    public DateTime SessionDate { get; set; }
+    public DateTime? StartsAt { get; set; }
+    public DateTime? EndsAt { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public int DistanceMeters { get; set; }
+    public string PaceKey { get; set; } = string.Empty;
+    public int? PaceSecondsPerKilometer { get; set; }
+    public string Notes { get; set; } = string.Empty;
+    public bool IsActive { get; set; } = true;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}
+
+public sealed class MateShareableSession
+{
+    public string CourseId { get; init; } = string.Empty;
+    public string CourseName { get; init; } = string.Empty;
+    public string PlanId { get; init; } = string.Empty;
+    public string PlanName { get; init; } = string.Empty;
+    public string SessionId { get; init; } = string.Empty;
+    public string SessionName { get; init; } = string.Empty;
+    public DateTime SessionDate { get; init; }
+    public DateTime? StartsAt { get; init; }
+    public string Location { get; init; } = string.Empty;
+    public int DistanceMeters { get; init; }
+    public string PaceKey { get; init; } = string.Empty;
+    public int? PaceSecondsPerKilometer { get; init; }
+    public bool IsShared { get; init; }
+    public string? AvailabilityId { get; init; }
+}
+
+public sealed class MateMatch
+{
+    public MateAvailabilityDocument OwnSession { get; init; } = new();
+    public MateAvailabilityDocument MateSession { get; init; } = new();
+    public int Score { get; init; }
+    public int? PaceDeltaSeconds { get; init; }
+    public int DayDelta { get; init; }
+    public int DistanceDeltaMeters { get; init; }
+}
+
+public sealed class MateOverview
+{
+    public IReadOnlyList<MateShareableSession> ShareableSessions { get; init; } = Array.Empty<MateShareableSession>();
+    public IReadOnlyList<MateAvailabilityDocument> MyAvailabilities { get; init; } = Array.Empty<MateAvailabilityDocument>();
+    public IReadOnlyList<MateMatch> Matches { get; init; } = Array.Empty<MateMatch>();
+}
+
+public static class MateDocumentTypes
+{
+    public const string Availability = "mateAvailability";
+}

--- a/PaceLetics.Web/Services/Mates/MateService.cs
+++ b/PaceLetics.Web/Services/Mates/MateService.cs
@@ -1,0 +1,435 @@
+using AthleteDataAccessLibrary.Contracts;
+using PaceLetics.AthleteModule.CodeBase.Models;
+using PaceLetics.CoreModule.Infrastructure.Constants;
+using PaceLetics.CoreModule.Infrastructure.Models;
+using PaceLetics.TrainingModule.CodeBase.Running.Models;
+using PaceLetics.TrainingPlanModule.CodeBase.Models;
+using PaceLetics.Web.Services.Courses;
+
+namespace PaceLetics.Web.Services.Mates;
+
+public sealed class MateService : IMateService
+{
+    private const int MaxDateDeltaDays = 7;
+    private const int MaxPaceDeltaSeconds = 25;
+    private const double MaxDistanceDeltaRatio = 0.35;
+
+    private static readonly SegmentType[] MatchSegmentTypes =
+    {
+        SegmentType.Dauerlauf,
+        SegmentType.Intervall
+    };
+
+    private readonly ICourseService _courseService;
+    private readonly IMateRepository _mateRepository;
+    private readonly ITrainingPlanService _trainingPlanService;
+    private readonly IAthleteData _athleteData;
+
+    public MateService(
+        ICourseService courseService,
+        IMateRepository mateRepository,
+        ITrainingPlanService trainingPlanService,
+        IAthleteData athleteData)
+    {
+        _courseService = courseService;
+        _mateRepository = mateRepository;
+        _trainingPlanService = trainingPlanService;
+        _athleteData = athleteData;
+    }
+
+    public async Task<MateOverview> GetOverviewAsync(string? athleteUserId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            return new MateOverview();
+
+        var userId = athleteUserId.Trim();
+        var joinedCourses = await _courseService.GetJoinedCoursesAsync(userId);
+        var visiblePlans = await _trainingPlanService.LoadTrainingPlansForUserAsync(userId);
+        var ownAvailabilities = await GetActiveOwnAvailabilitiesAsync(userId);
+        var shareableSessions = BuildShareableSessions(joinedCourses, visiblePlans, ownAvailabilities);
+        var matches = await BuildMatchesAsync(userId, joinedCourses, ownAvailabilities);
+
+        return new MateOverview
+        {
+            ShareableSessions = shareableSessions,
+            MyAvailabilities = ownAvailabilities,
+            Matches = matches
+        };
+    }
+
+    public async Task<MateAvailabilityDocument> ShareSessionAsync(string? athleteUserId, MateShareRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId))
+            throw new InvalidOperationException("Mate sharing requires a signed-in athlete.");
+
+        if (request is null)
+            throw new ArgumentNullException(nameof(request));
+
+        var userId = athleteUserId.Trim();
+        var courseId = request.CourseId?.Trim() ?? string.Empty;
+        var planId = request.PlanId?.Trim() ?? string.Empty;
+        var sessionId = request.SessionId?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(courseId) || string.IsNullOrWhiteSpace(planId) || string.IsNullOrWhiteSpace(sessionId))
+            throw new InvalidOperationException("Course, plan, and session are required for Mate sharing.");
+
+        var joinedCourses = await _courseService.GetJoinedCoursesAsync(userId);
+        var course = joinedCourses.FirstOrDefault(course => string.Equals(course.Id, courseId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException("The selected course is not available for this athlete.");
+
+        if (!GetVisiblePlanIds(course).Contains(planId))
+            throw new InvalidOperationException("The selected training plan is not visible in this course.");
+
+        var plans = await _trainingPlanService.LoadTrainingPlansForUserAsync(userId);
+        var plan = plans.FirstOrDefault(plan => string.Equals(plan.Id, planId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException("The selected training plan is not available for this athlete.");
+        var session = plan.Sessions.FirstOrDefault(session => string.Equals(session.Id, sessionId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException("The selected training session was not found.");
+
+        if (session.PrimaryRun is null)
+            throw new InvalidOperationException("Only running sessions can be shared with Mate.");
+
+        var athlete = await _athleteData.GetAthlete(userId);
+        var availabilityId = MateDocumentIds.Availability(course.Id, userId, plan.Id, session.Id);
+        var existing = await _mateRepository.GetMateAvailabilityAsync(course.Id, availabilityId);
+        var now = DateTime.UtcNow;
+        var availability = CreateAvailability(
+            course,
+            plan,
+            session,
+            athlete,
+            userId,
+            request.Notes,
+            existing?.CreatedAt ?? now);
+
+        availability.Id = availabilityId;
+        availability.UpdatedAt = now;
+        availability.IsActive = true;
+
+        await _mateRepository.UpsertMateAvailabilityAsync(availability);
+        return availability;
+    }
+
+    public async Task RemoveAvailabilityAsync(string? athleteUserId, string availabilityId)
+    {
+        if (string.IsNullOrWhiteSpace(athleteUserId) || string.IsNullOrWhiteSpace(availabilityId))
+            return;
+
+        var ownAvailabilities = await _mateRepository.GetMateAvailabilitiesForAthleteAsync(athleteUserId.Trim());
+        var availability = ownAvailabilities.FirstOrDefault(availability =>
+            string.Equals(availability.Id, availabilityId, StringComparison.OrdinalIgnoreCase));
+
+        if (availability is null)
+            return;
+
+        await _mateRepository.DeleteMateAvailabilityAsync(availability.CourseId, availability.Id);
+    }
+
+    private async Task<IReadOnlyList<MateAvailabilityDocument>> GetActiveOwnAvailabilitiesAsync(string athleteUserId)
+    {
+        return (await _mateRepository.GetMateAvailabilitiesForAthleteAsync(athleteUserId))
+            .Where(IsActiveAndCurrent)
+            .OrderBy(availability => GetEffectiveStart(availability))
+            .ThenBy(availability => availability.SessionName)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<MateMatch>> BuildMatchesAsync(
+        string athleteUserId,
+        IReadOnlyList<CourseDocument> joinedCourses,
+        IReadOnlyList<MateAvailabilityDocument> ownAvailabilities)
+    {
+        if (ownAvailabilities.Count == 0 || joinedCourses.Count == 0)
+            return Array.Empty<MateMatch>();
+
+        var candidates = new List<MateAvailabilityDocument>();
+        foreach (var course in joinedCourses)
+        {
+            candidates.AddRange(await _mateRepository.GetMateAvailabilitiesForCourseAsync(course.Id));
+        }
+
+        return ownAvailabilities
+            .SelectMany(own => candidates
+                .Where(candidate => IsCandidate(athleteUserId, own, candidate))
+                .Select(candidate => CreateMatch(own, candidate)))
+            .Where(match => match is not null)
+            .Select(match => match!)
+            .OrderByDescending(match => match.Score)
+            .ThenBy(match => match.DayDelta)
+            .ThenBy(match => match.PaceDeltaSeconds ?? int.MaxValue)
+            .ThenBy(match => match.MateSession.AthleteDisplayName)
+            .Take(20)
+            .ToList();
+    }
+
+    private static IReadOnlyList<MateShareableSession> BuildShareableSessions(
+        IReadOnlyList<CourseDocument> joinedCourses,
+        IReadOnlyList<TrainingPlan> visiblePlans,
+        IReadOnlyList<MateAvailabilityDocument> ownAvailabilities)
+    {
+        var plansById = visiblePlans.ToDictionary(plan => plan.Id, StringComparer.OrdinalIgnoreCase);
+        var activeAvailabilityByKey = ownAvailabilities
+            .GroupBy(availability => ShareKey(availability.CourseId, availability.PlanId, availability.SessionId), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+        var sessions = new List<MateShareableSession>();
+
+        foreach (var course in joinedCourses)
+        {
+            foreach (var planId in GetVisiblePlanIds(course))
+            {
+                if (!plansById.TryGetValue(planId, out var plan))
+                    continue;
+
+                foreach (var session in plan.Sessions.Where(session => session.PrimaryRun is not null && session.Date.Date >= DateTime.Today))
+                {
+                    var snapshot = BuildRunSnapshot(session.PrimaryRun!, null);
+                    var key = ShareKey(course.Id, plan.Id, session.Id);
+                    activeAvailabilityByKey.TryGetValue(key, out var availability);
+
+                    sessions.Add(new MateShareableSession
+                    {
+                        CourseId = course.Id,
+                        CourseName = course.Name,
+                        PlanId = plan.Id,
+                        PlanName = plan.Name,
+                        SessionId = session.Id,
+                        SessionName = session.Name,
+                        SessionDate = session.Date,
+                        StartsAt = session.Appointment.StartsAt,
+                        Location = session.Appointment.Location,
+                        DistanceMeters = snapshot.DistanceMeters,
+                        PaceKey = snapshot.PaceKey,
+                        PaceSecondsPerKilometer = snapshot.PaceSecondsPerKilometer,
+                        IsShared = availability is not null,
+                        AvailabilityId = availability?.Id
+                    });
+                }
+            }
+        }
+
+        return sessions
+            .GroupBy(session => ShareKey(session.CourseId, session.PlanId, session.SessionId), StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .OrderBy(session => session.StartsAt ?? session.SessionDate)
+            .ThenBy(session => session.CourseName)
+            .ThenBy(session => session.SessionName)
+            .ToList();
+    }
+
+    private static MateAvailabilityDocument CreateAvailability(
+        CourseDocument course,
+        TrainingPlan plan,
+        TrainingSession session,
+        AthleteModel? athlete,
+        string athleteUserId,
+        string? notes,
+        DateTime createdAt)
+    {
+        var snapshot = BuildRunSnapshot(session.PrimaryRun!, athlete?.PaceModel);
+
+        return new MateAvailabilityDocument
+        {
+            CourseId = course.Id,
+            DocumentType = MateDocumentTypes.Availability,
+            AthleteUserId = athleteUserId,
+            AthleteDisplayName = ResolveDisplayName(athlete, athleteUserId),
+            PlanId = plan.Id,
+            PlanName = plan.Name,
+            SessionId = session.Id,
+            SessionName = session.Name,
+            CourseName = course.Name,
+            SessionDate = session.Date,
+            StartsAt = session.Appointment.StartsAt,
+            EndsAt = session.Appointment.EndsAt,
+            Location = session.Appointment.Location,
+            DistanceMeters = snapshot.DistanceMeters,
+            PaceKey = snapshot.PaceKey,
+            PaceSecondsPerKilometer = snapshot.PaceSecondsPerKilometer,
+            Notes = notes?.Trim() ?? string.Empty,
+            CreatedAt = createdAt
+        };
+    }
+
+    private static MateMatch? CreateMatch(MateAvailabilityDocument own, MateAvailabilityDocument candidate)
+    {
+        var dayDelta = Math.Abs((GetEffectiveStart(candidate).Date - GetEffectiveStart(own).Date).Days);
+        if (dayDelta > MaxDateDeltaDays)
+            return null;
+
+        var distanceDelta = Math.Abs(candidate.DistanceMeters - own.DistanceMeters);
+        var distanceRatio = own.DistanceMeters <= 0 || candidate.DistanceMeters <= 0
+            ? 0
+            : distanceDelta / (double)Math.Max(own.DistanceMeters, candidate.DistanceMeters);
+        if (distanceRatio > MaxDistanceDeltaRatio)
+            return null;
+
+        int? paceDelta = null;
+        var paceMatches = false;
+        if (own.PaceSecondsPerKilometer is not null && candidate.PaceSecondsPerKilometer is not null)
+        {
+            paceDelta = Math.Abs(own.PaceSecondsPerKilometer.Value - candidate.PaceSecondsPerKilometer.Value);
+            paceMatches = paceDelta <= MaxPaceDeltaSeconds;
+        }
+        else if (!string.IsNullOrWhiteSpace(own.PaceKey) && !string.IsNullOrWhiteSpace(candidate.PaceKey))
+        {
+            paceMatches = string.Equals(own.PaceKey, candidate.PaceKey, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (!paceMatches)
+            return null;
+
+        var paceScore = paceDelta is null ? 35 : Math.Max(0, 50 - paceDelta.Value);
+        var dateScore = Math.Max(0, 25 - (dayDelta * 3));
+        var distanceScore = Math.Max(0, 25 - (int)Math.Round(distanceRatio * 70));
+
+        return new MateMatch
+        {
+            OwnSession = own,
+            MateSession = candidate,
+            PaceDeltaSeconds = paceDelta,
+            DayDelta = dayDelta,
+            DistanceDeltaMeters = distanceDelta,
+            Score = paceScore + dateScore + distanceScore
+        };
+    }
+
+    private static bool IsCandidate(string athleteUserId, MateAvailabilityDocument own, MateAvailabilityDocument candidate)
+    {
+        return IsActiveAndCurrent(candidate)
+            && !string.Equals(candidate.AthleteUserId, athleteUserId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(candidate.CourseId, own.CourseId, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(candidate.Id, own.Id, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static RunSnapshot BuildRunSnapshot(RunningSession run, PaceModel? paceModel)
+    {
+        var relevantSegments = run.Sequence
+            .Where(segment => MatchSegmentTypes.Contains(segment.Type))
+            .ToList();
+
+        if (relevantSegments.Count == 0)
+            relevantSegments = run.Sequence.ToList();
+
+        var paceKey = relevantSegments
+            .Where(segment => !string.IsNullOrWhiteSpace(segment.PaceKey))
+            .OrderByDescending(segment => segment.Distance)
+            .Select(segment => segment.PaceKey!)
+            .FirstOrDefault() ?? string.Empty;
+
+        return new RunSnapshot(
+            run.TotalDistance,
+            paceKey,
+            ResolveWeightedPaceSeconds(run, paceModel));
+    }
+
+    private static int? ResolveWeightedPaceSeconds(RunningSession run, PaceModel? paceModel)
+    {
+        if (!HasUsablePaceModel(paceModel))
+            return null;
+
+        try
+        {
+            var resolved = RunningSessionResolver.Resolve(run, paceModel!);
+            var segments = resolved.Segments
+                .Where(segment => MatchSegmentTypes.Contains(segment.Segment.Type))
+                .Where(segment => segment.Pace is not null && segment.Pace.Value > TimeSpan.Zero && segment.Segment.Distance > 0)
+                .ToList();
+
+            if (segments.Count == 0)
+                return null;
+
+            var distance = segments.Sum(segment => segment.Segment.Distance);
+            if (distance <= 0)
+                return null;
+
+            var weightedSeconds = segments.Sum(segment =>
+                segment.Segment.Distance * segment.Pace!.Value.TotalSeconds) / distance;
+            return (int)Math.Round(weightedSeconds);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool HasUsablePaceModel(PaceModel? paceModel)
+    {
+        return paceModel is not null
+            && (paceModel.Easy > TimeSpan.Zero
+                || paceModel.Marathon > TimeSpan.Zero
+                || paceModel.Threshold > TimeSpan.Zero
+                || paceModel.Intervall > TimeSpan.Zero
+                || paceModel.Repetition > TimeSpan.Zero);
+    }
+
+    private static IReadOnlySet<string> GetVisiblePlanIds(CourseDocument course)
+    {
+        var now = DateTime.UtcNow;
+        return course.TrainingPlanPublications
+            .Where(publication => publication.IsVisibleInCourse(course.Id, now))
+            .Select(publication => publication.TrainingPlanId)
+            .Where(planId => !string.IsNullOrWhiteSpace(planId))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool IsActiveAndCurrent(MateAvailabilityDocument availability)
+    {
+        return availability.IsActive && GetEffectiveStart(availability).Date >= DateTime.Today;
+    }
+
+    private static DateTime GetEffectiveStart(MateAvailabilityDocument availability)
+    {
+        return availability.StartsAt ?? availability.SessionDate;
+    }
+
+    private static string ResolveDisplayName(AthleteModel? athlete, string athleteUserId)
+    {
+        var publicUserName = athlete?.PublicProfile?.PublicUserName;
+        if (!string.IsNullOrWhiteSpace(publicUserName)
+            && !publicUserName.Equals("NA", StringComparison.OrdinalIgnoreCase)
+            && !publicUserName.Contains('@'))
+        {
+            return publicUserName.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(athlete?.Name)
+            && !athlete.Name.Equals("NA", StringComparison.OrdinalIgnoreCase)
+            && !athlete.Name.Contains('@'))
+        {
+            return athlete.Name.Trim();
+        }
+
+        return athleteUserId;
+    }
+
+    private static string ShareKey(string courseId, string planId, string sessionId)
+    {
+        return $"{courseId}|{planId}|{sessionId}";
+    }
+
+    private sealed record RunSnapshot(
+        int DistanceMeters,
+        string PaceKey,
+        int? PaceSecondsPerKilometer);
+}
+
+public static class MateDocumentIds
+{
+    public static string Availability(string courseId, string athleteUserId, string planId, string sessionId)
+    {
+        return string.Join(
+            ":",
+            "mate-availability",
+            Normalize(courseId),
+            Normalize(athleteUserId),
+            Normalize(planId),
+            Normalize(sessionId));
+    }
+
+    private static string Normalize(string value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? "na"
+            : value.Trim().Replace(":", "-", StringComparison.Ordinal);
+    }
+}

--- a/PaceLetics.Web/Shared/BottomNavBar.razor
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor
@@ -27,6 +27,19 @@
         </span>
     </NavLink>
 
+    <NavLink href="/Athletes/mate"
+             class="pl-bottom-nav__item"
+             ActiveClass="pl-bottom-nav__item--active"
+             Match="NavLinkMatch.Prefix"
+             title="@L["Nav_Mate"]">
+        <span class="pl-bottom-nav__content">
+            <span class="pl-bottom-nav__icon" aria-hidden="true">
+                <MudIcon Icon="@Icons.Material.Filled.People" Size="Size.Medium" />
+            </span>
+            <span class="pl-bottom-nav__label">@L["Nav_Mate"]</span>
+        </span>
+    </NavLink>
+
     <NavLink href="/Athletes/racepaces"
              class="pl-bottom-nav__item"
              ActiveClass="pl-bottom-nav__item--active"

--- a/PaceLetics.Web/Shared/BottomNavBar.razor.css
+++ b/PaceLetics.Web/Shared/BottomNavBar.razor.css
@@ -9,7 +9,7 @@
     box-sizing: border-box;
     display: flex;
     justify-content: center;
-    gap: 0.15rem;
+    gap: 0.08rem;
     height: calc(4.65rem + var(--pl-bottom-nav-safe-area));
     padding: 0.45rem 0.35rem calc(0.45rem + var(--pl-bottom-nav-safe-area));
     background: color-mix(in srgb, var(--mud-palette-surface) 94%, black);
@@ -26,9 +26,9 @@
     justify-content: center;
     flex: 1 1 0;
     min-width: 0;
-    max-width: 5rem;
+    max-width: 4.75rem;
     min-height: 3.75rem;
-    padding: 0.35rem 0.18rem;
+    padding: 0.35rem 0.12rem;
     color: var(--mud-palette-text-secondary);
     text-decoration: none;
     border-radius: 999px;
@@ -71,7 +71,7 @@
     display: -webkit-box;
     max-width: 100%;
     overflow: hidden;
-    font-size: 0.68rem;
+    font-size: 0.64rem;
     font-weight: 600;
     line-height: 1.15;
     text-align: center;
@@ -87,7 +87,7 @@
     }
 
     .pl-bottom-nav__label {
-        font-size: 0.62rem;
+        font-size: 0.58rem;
     }
 }
 

--- a/PaceLetics.Web/Shared/NavMenu.razor
+++ b/PaceLetics.Web/Shared/NavMenu.razor
@@ -3,6 +3,7 @@
 <MudNavMenu>
     <MudNavLink Href="/Athletes/dashboard" Match="NavLinkMatch.All">@L["Nav_Dashboard"]</MudNavLink>
     <MudNavLink Href="/Athletes/academy" Match="NavLinkMatch.Prefix">@L["Nav_Academy"]</MudNavLink>
+    <MudNavLink Href="/Athletes/mate" Match="NavLinkMatch.Prefix">@L["Nav_Mate"]</MudNavLink>
     <MudNavLink Href="/Athletes/racepaces" Match="NavLinkMatch.Prefix">@L["Nav_RaceData"]</MudNavLink>
     <MudNavLink Href="/Athletes/courses" Match="NavLinkMatch.Prefix">@L["Nav_Courses"]</MudNavLink>
     <MudNavLink Href="/Athletes/data-analyses" Match="NavLinkMatch.Prefix">@L["Nav_DataAnalyses"]</MudNavLink>


### PR DESCRIPTION
## Summary
- add opt-in Mate availability documents, repository integration, and matching service
- match shared running sessions by same course, nearby date, similar distance, and compatible pace
- add the authenticated athlete Mate page plus desktop and mobile navigation
- keep social/fediverse/community publishing out of scope

## Verification
- dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore -p:BaseOutputPath="$env:TEMP\paceletics-codex-test-bin\"
- git diff --check
- local run on http://localhost:5090; /Athletes/mate redirects to login with ReturnUrl when unauthenticated
