### PR TITLE
Refine Mate sharing UX

### DIFF
--- a/PaceLetics.Web/Pages/Athletes/Mate.razor
+++ b/PaceLetics.Web/Pages/Athletes/Mate.razor
@@ -19,6 +19,11 @@
     else
     {
         <MudStack Spacing="3" Class="mt-4">
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                <MudText Typo="Typo.subtitle2">@L["PrivacyTitle"]</MudText>
+                <MudText Typo="Typo.body2">@L["PrivacyBody"]</MudText>
+            </MudAlert>
+
             <MudPaper Elevation="0" Class="pa-4 pl-panel">
                 <MudGrid Spacing="2">
                     <MudItem xs="4">
@@ -51,7 +56,10 @@
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:8px; flex-wrap:wrap;">
                                     <MudIcon Icon="@Icons.Material.Filled.People" Color="Color.Primary" />
                                     <MudText Typo="Typo.h6">@match.MateSession.AthleteDisplayName</MudText>
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">
+                                    <MudChip T="string" Size="Size.Small" Color="@GetMatchQualityColor(match.Score)" Variant="Variant.Outlined">
+                                        @GetMatchQualityLabel(match.Score)
+                                    </MudChip>
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">
                                         @($"{match.Score}%")
                                     </MudChip>
                                 </MudStack>
@@ -62,6 +70,13 @@
                                     @string.Format(L["MatchOwn"], match.OwnSession.SessionName)
                                 </MudText>
                                 <MudText Typo="Typo.caption" Color="Color.Secondary">@GetMatchDelta(match)</MudText>
+                                <MudStack Row="true" AlignItems="AlignItems.Center" Style="gap:6px; flex-wrap:wrap;">
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">@L["WhyMatch"]</MudText>
+                                    @foreach (var reason in GetMatchReasons(match))
+                                    {
+                                        <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">@reason</MudChip>
+                                    }
+                                </MudStack>
                             </MudStack>
                         </MudPaper>
                     }
@@ -87,35 +102,46 @@
                                         @if (session.IsShared)
                                         {
                                             <MudChip T="string" Size="Size.Small" Color="Color.Success" Variant="Variant.Outlined">
-                                                @L["Shared"]
+                                                @L["SharedForMate"]
+                                            </MudChip>
+                                        }
+                                        else
+                                        {
+                                            <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">
+                                                @L["NotShared"]
                                             </MudChip>
                                         }
                                     </MudStack>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">@GetShareableDetail(session)</MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        @($"{L["Course"]}: {session.CourseName} · {L["Plan"]}: {session.PlanName}")
+                                        @($"{L["Course"]}: {session.CourseName} | {L["Plan"]}: {session.PlanName}")
+                                    </MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        @string.Format(L["SharedVisibility"], GetVisibleShareData(session))
                                     </MudText>
                                 </MudStack>
 
                                 @if (session.IsShared && session.AvailabilityId is not null)
                                 {
-                                    <MudTooltip Text="@L["Remove"]">
+                                    <MudTooltip Text="@L["RemoveTooltip"]">
                                         <MudIconButton Icon="@Icons.Material.Filled.Close"
                                                        Color="Color.Secondary"
                                                        Disabled="@_isSaving"
-                                                       OnClick="@(() => RemoveAsync(session.AvailabilityId))"
+                                                       OnClick="@(() => RemoveAsync(session.AvailabilityId!))"
                                                        aria-label="@L["Remove"]" />
                                     </MudTooltip>
                                 }
                                 else
                                 {
-                                    <MudButton Color="Color.Primary"
-                                               Variant="Variant.Filled"
-                                               Disabled="@_isSaving"
-                                               StartIcon="@Icons.Material.Filled.PersonAdd"
-                                               OnClick="@(() => ShareAsync(session))">
-                                        @L["Share"]
-                                    </MudButton>
+                                    <MudTooltip Text="@L["ShareTooltip"]">
+                                        <MudButton Color="Color.Primary"
+                                                   Variant="Variant.Filled"
+                                                   Disabled="@_isSaving"
+                                                   StartIcon="@Icons.Material.Filled.PersonAdd"
+                                                   OnClick="@(() => ShareAsync(session))">
+                                            @L["ShareCta"]
+                                        </MudButton>
+                                    </MudTooltip>
                                 }
                             </MudStack>
                         </MudPaper>
@@ -205,7 +231,7 @@
     private string GetShareableDetail(MateShareableSession session)
     {
         return string.Join(
-            " · ",
+            " | ",
             new[]
             {
                 FormatDate(session.StartsAt ?? session.SessionDate),
@@ -218,7 +244,7 @@
     private string GetAvailabilityDetail(MateAvailabilityDocument availability)
     {
         return string.Join(
-            " · ",
+            " | ",
             new[]
             {
                 FormatDate(availability.StartsAt ?? availability.SessionDate),
@@ -237,7 +263,62 @@
         var days = string.Format(L["DayDelta"], match.DayDelta);
         var distance = string.Format(L["DistanceDelta"], FormatDistance(match.DistanceDeltaMeters));
 
-        return $"{pace} · {days} · {distance}";
+        return $"{pace} | {days} | {distance}";
+    }
+
+    private IReadOnlyList<string> GetMatchReasons(MateMatch match)
+    {
+        return new[]
+        {
+            L["ReasonSameCourse"].Value,
+            GetPaceReason(match),
+            string.Format(L["ReasonDate"], match.DayDelta),
+            string.Format(L["ReasonDistance"], FormatDistance(match.DistanceDeltaMeters))
+        };
+    }
+
+    private string GetPaceReason(MateMatch match)
+    {
+        if (match.PaceDeltaSeconds is null)
+            return L["ReasonSamePaceZone"];
+
+        return match.PaceDeltaSeconds.Value <= 10
+            ? string.Format(L["ReasonPaceVeryClose"], match.PaceDeltaSeconds.Value)
+            : string.Format(L["ReasonPaceClose"], match.PaceDeltaSeconds.Value);
+    }
+
+    private string GetMatchQualityLabel(int score)
+    {
+        if (score >= 90)
+            return L["QualityStrong"].Value;
+
+        return score >= 75
+            ? L["QualityGood"].Value
+            : L["QualityPossible"].Value;
+    }
+
+    private static Color GetMatchQualityColor(int score)
+    {
+        if (score >= 90)
+            return Color.Success;
+
+        return score >= 75
+            ? Color.Primary
+            : Color.Warning;
+    }
+
+    private string GetVisibleShareData(MateShareableSession session)
+    {
+        return string.Join(
+            ", ",
+            new[]
+            {
+                L["VisibleDisplayName"].Value,
+                FormatDate(session.StartsAt ?? session.SessionDate),
+                FormatDistance(session.DistanceMeters),
+                FormatPace(session.PaceSecondsPerKilometer, session.PaceKey),
+                string.IsNullOrWhiteSpace(session.Location) ? string.Empty : session.Location
+            }.Where(part => !string.IsNullOrWhiteSpace(part)));
     }
 
     private static string FormatDate(DateTime date)

--- a/PaceLetics.Web/Resources/Pages/Athletes/Mate.de.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Mate.de.resx
@@ -31,4 +31,23 @@
   <data name="RemoveSuccess" xml:space="preserve"><value>Mate-Freigabe entfernt.</value></data>
   <data name="ShareError" xml:space="preserve"><value>Freigabe fehlgeschlagen</value></data>
   <data name="RemoveError" xml:space="preserve"><value>Entfernen fehlgeschlagen</value></data>
+  <data name="PrivacyTitle" xml:space="preserve"><value>Deine Mate-Freigabe</value></data>
+  <data name="PrivacyBody" xml:space="preserve"><value>Mate zeigt freigegebene Einheiten nur innerhalb des passenden Kurses. Sichtbar werden koennen dein oeffentlicher Name, Einheit, Termin, Ort, Distanz und Pace; es wird nichts in einen Feed oder Social-Kanal gepostet.</value></data>
+  <data name="SharedForMate" xml:space="preserve"><value>Fuer Mate freigegeben</value></data>
+  <data name="NotShared" xml:space="preserve"><value>Nicht freigegeben</value></data>
+  <data name="ShareCta" xml:space="preserve"><value>Fuer Mate freigeben</value></data>
+  <data name="ShareTooltip" xml:space="preserve"><value>Einheit fuer passende Kursteilnehmer:innen sichtbar machen</value></data>
+  <data name="RemoveTooltip" xml:space="preserve"><value>Mate-Freigabe entfernen</value></data>
+  <data name="SharedVisibility" xml:space="preserve"><value>Sichtbar nach Freigabe: {0}</value></data>
+  <data name="WhyMatch" xml:space="preserve"><value>Warum passt das?</value></data>
+  <data name="ReasonSameCourse" xml:space="preserve"><value>Gleicher Kurs</value></data>
+  <data name="ReasonSamePaceZone" xml:space="preserve"><value>Gleicher Pacebereich</value></data>
+  <data name="ReasonPaceVeryClose" xml:space="preserve"><value>Pace fast gleich ({0} s/km)</value></data>
+  <data name="ReasonPaceClose" xml:space="preserve"><value>Pace nah dran ({0} s/km)</value></data>
+  <data name="ReasonDate" xml:space="preserve"><value>{0} Tag(e) Abstand</value></data>
+  <data name="ReasonDistance" xml:space="preserve"><value>{0} Distanzabstand</value></data>
+  <data name="QualityStrong" xml:space="preserve"><value>Sehr passend</value></data>
+  <data name="QualityGood" xml:space="preserve"><value>Passend</value></data>
+  <data name="QualityPossible" xml:space="preserve"><value>Moeglich</value></data>
+  <data name="VisibleDisplayName" xml:space="preserve"><value>oeffentlicher Name</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Mate.en.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Mate.en.resx
@@ -31,4 +31,23 @@
   <data name="RemoveSuccess" xml:space="preserve"><value>Mate sharing removed.</value></data>
   <data name="ShareError" xml:space="preserve"><value>Sharing failed</value></data>
   <data name="RemoveError" xml:space="preserve"><value>Removing failed</value></data>
+  <data name="PrivacyTitle" xml:space="preserve"><value>Your Mate sharing</value></data>
+  <data name="PrivacyBody" xml:space="preserve"><value>Mate shows shared sessions only within the matching course. Your public name, session, date, location, distance, and pace can be visible; nothing is posted to a feed or social channel.</value></data>
+  <data name="SharedForMate" xml:space="preserve"><value>Shared for Mate</value></data>
+  <data name="NotShared" xml:space="preserve"><value>Not shared</value></data>
+  <data name="ShareCta" xml:space="preserve"><value>Share for Mate</value></data>
+  <data name="ShareTooltip" xml:space="preserve"><value>Make this session visible to matching course participants</value></data>
+  <data name="RemoveTooltip" xml:space="preserve"><value>Remove Mate sharing</value></data>
+  <data name="SharedVisibility" xml:space="preserve"><value>Visible after sharing: {0}</value></data>
+  <data name="WhyMatch" xml:space="preserve"><value>Why it fits</value></data>
+  <data name="ReasonSameCourse" xml:space="preserve"><value>Same course</value></data>
+  <data name="ReasonSamePaceZone" xml:space="preserve"><value>Same pace zone</value></data>
+  <data name="ReasonPaceVeryClose" xml:space="preserve"><value>Pace almost equal ({0} s/km)</value></data>
+  <data name="ReasonPaceClose" xml:space="preserve"><value>Pace close ({0} s/km)</value></data>
+  <data name="ReasonDate" xml:space="preserve"><value>{0} day(s) apart</value></data>
+  <data name="ReasonDistance" xml:space="preserve"><value>{0} distance gap</value></data>
+  <data name="QualityStrong" xml:space="preserve"><value>Strong fit</value></data>
+  <data name="QualityGood" xml:space="preserve"><value>Good fit</value></data>
+  <data name="QualityPossible" xml:space="preserve"><value>Possible fit</value></data>
+  <data name="VisibleDisplayName" xml:space="preserve"><value>public name</value></data>
 </root>

--- a/PaceLetics.Web/Resources/Pages/Athletes/Mate.resx
+++ b/PaceLetics.Web/Resources/Pages/Athletes/Mate.resx
@@ -31,4 +31,23 @@
   <data name="RemoveSuccess" xml:space="preserve"><value>Mate sharing removed.</value></data>
   <data name="ShareError" xml:space="preserve"><value>Sharing failed</value></data>
   <data name="RemoveError" xml:space="preserve"><value>Removing failed</value></data>
+  <data name="PrivacyTitle" xml:space="preserve"><value>Your Mate sharing</value></data>
+  <data name="PrivacyBody" xml:space="preserve"><value>Mate shows shared sessions only within the matching course. Your public name, session, date, location, distance, and pace can be visible; nothing is posted to a feed or social channel.</value></data>
+  <data name="SharedForMate" xml:space="preserve"><value>Shared for Mate</value></data>
+  <data name="NotShared" xml:space="preserve"><value>Not shared</value></data>
+  <data name="ShareCta" xml:space="preserve"><value>Share for Mate</value></data>
+  <data name="ShareTooltip" xml:space="preserve"><value>Make this session visible to matching course participants</value></data>
+  <data name="RemoveTooltip" xml:space="preserve"><value>Remove Mate sharing</value></data>
+  <data name="SharedVisibility" xml:space="preserve"><value>Visible after sharing: {0}</value></data>
+  <data name="WhyMatch" xml:space="preserve"><value>Why it fits</value></data>
+  <data name="ReasonSameCourse" xml:space="preserve"><value>Same course</value></data>
+  <data name="ReasonSamePaceZone" xml:space="preserve"><value>Same pace zone</value></data>
+  <data name="ReasonPaceVeryClose" xml:space="preserve"><value>Pace almost equal ({0} s/km)</value></data>
+  <data name="ReasonPaceClose" xml:space="preserve"><value>Pace close ({0} s/km)</value></data>
+  <data name="ReasonDate" xml:space="preserve"><value>{0} day(s) apart</value></data>
+  <data name="ReasonDistance" xml:space="preserve"><value>{0} distance gap</value></data>
+  <data name="QualityStrong" xml:space="preserve"><value>Strong fit</value></data>
+  <data name="QualityGood" xml:space="preserve"><value>Good fit</value></data>
+  <data name="QualityPossible" xml:space="preserve"><value>Possible fit</value></data>
+  <data name="VisibleDisplayName" xml:space="preserve"><value>public name</value></data>
 </root>


### PR DESCRIPTION
## Summary
- add privacy guidance for Mate sharing without introducing social or messaging features
- make share state clearer with Mate-specific shared/not-shared chips and a stronger share CTA
- add match quality labels and localized reason chips explaining why a match fits
- keep matching rules unchanged

## Verification
- git diff --check
- dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore -p:BaseOutputPath="$env:TEMP\paceletics-codex-test-bin\"
- local run on http://localhost:5093; /Athletes/mate and /Academy redirect to login, CSS/assets return 200 OK
