### PR TITLE
Persist workout catalog in Cosmos

### DIFF
--- a/PaceLetics.Tests/WorkoutCatalogManagementServiceTests.cs
+++ b/PaceLetics.Tests/WorkoutCatalogManagementServiceTests.cs
@@ -10,7 +10,7 @@ public sealed class WorkoutCatalogManagementServiceTests
     [Fact]
     public async Task UpsertExerciseAsync_PersistsExerciseAndUpdatesLiveCatalog()
     {
-        var (service, repository) = CreateService();
+        var (service, store) = CreateService();
 
         await service.UpsertExerciseAsync(
             new ExerciseDefinition
@@ -33,8 +33,7 @@ public sealed class WorkoutCatalogManagementServiceTests
 
         Assert.Contains(service.Catalog.Exercises, exercise => exercise.Id == "skip-drill");
 
-        var reloaded = repository.Load();
-        var persisted = Assert.Single(reloaded.Exercises, exercise => exercise.Id == "skip-drill");
+        var persisted = Assert.Single(store.StoredCatalog!.Exercises, exercise => exercise.Id == "skip-drill");
         Assert.Equal("trainer-1", persisted.OwnerUserId);
         Assert.NotNull(persisted.CreatedAt);
         Assert.NotNull(persisted.UpdatedAt);
@@ -43,7 +42,7 @@ public sealed class WorkoutCatalogManagementServiceTests
     [Fact]
     public async Task UpsertWorkoutAsync_PersistsWorkoutForExistingExercises()
     {
-        var (service, repository) = CreateService();
+        var (service, store) = CreateService();
 
         await service.UpsertWorkoutAsync(
             new WorkoutDefinition
@@ -66,17 +65,42 @@ public sealed class WorkoutCatalogManagementServiceTests
 
         Assert.Contains(service.Catalog.Workouts, workout => workout.Id == "foundation-two");
 
-        var reloaded = repository.Load();
-        var persisted = Assert.Single(reloaded.Workouts, workout => workout.Id == "foundation-two");
+        var persisted = Assert.Single(store.StoredCatalog!.Workouts, workout => workout.Id == "foundation-two");
         Assert.Equal("trainer-2", persisted.OwnerUserId);
         Assert.Equal(new[] { "glute-bridge" }, persisted.Exercises);
     }
 
     [Fact]
+    public async Task EnsureLoadedAsync_AppliesPersistedCatalog()
+    {
+        var persistedCatalog = CreateCatalog();
+        persistedCatalog.Exercises.Add(
+            new ExerciseDefinition
+            {
+                Id = "ankle-hop",
+                Name = "Ankle Hop",
+                Description = "Elastic foot drill",
+                Execution = new List<string> { "Hop lightly" },
+                Duration = 20,
+                Level = Level.Easy,
+                Tags = new List<string> { "elasticity" },
+                Source = "PaceLetics",
+                OwnerUserId = "trainer-3"
+            });
+        var (service, store) = CreateService(persistedCatalog);
+
+        await service.EnsureLoadedAsync();
+
+        Assert.Equal(1, store.LoadCount);
+        Assert.Contains(service.Catalog.Exercises, exercise => exercise.Id == "ankle-hop");
+    }
+
+    [Fact]
     public async Task UpsertWorkoutAsync_DoesNotMutateLiveCatalogWhenValidationFails()
     {
-        var (service, _) = CreateService();
+        var (service, store) = CreateService();
         var beforeCount = service.Catalog.Workouts.Count;
+        var beforeSaveCount = store.SaveCount;
 
         await Assert.ThrowsAsync<WorkoutCatalogValidationException>(() =>
             service.UpsertWorkoutAsync(
@@ -92,19 +116,22 @@ public sealed class WorkoutCatalogManagementServiceTests
                 "trainer-1"));
 
         Assert.Equal(beforeCount, service.Catalog.Workouts.Count);
+        Assert.Equal(beforeSaveCount, store.SaveCount);
         Assert.DoesNotContain(service.Catalog.Workouts, workout => workout.Id == "invalid-workout");
     }
 
-    private static (WorkoutCatalogManagementService Service, JsonWorkoutCatalogRepository Repository) CreateService()
+    private static (WorkoutCatalogManagementService Service, InMemoryWorkoutCatalogStore Store) CreateService(
+        WorkoutCatalogDocument? storedCatalog = null)
     {
         var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json");
         var repository = new JsonWorkoutCatalogRepository(path);
         var catalog = CreateCatalog();
         repository.Save(catalog);
         var loadedCatalog = repository.Load();
-        var service = new WorkoutCatalogManagementService(repository, loadedCatalog);
+        var store = new InMemoryWorkoutCatalogStore(storedCatalog ?? loadedCatalog);
+        var service = new WorkoutCatalogManagementService(store, repository, loadedCatalog);
 
-        return (service, repository);
+        return (service, store);
     }
 
     private static WorkoutCatalogDocument CreateCatalog()
@@ -153,5 +180,95 @@ public sealed class WorkoutCatalogManagementServiceTests
                 }
             }
         };
+    }
+
+    private static WorkoutCatalogDocument CloneCatalog(WorkoutCatalogDocument source)
+    {
+        return new WorkoutCatalogDocument
+        {
+            SchemaVersion = source.SchemaVersion,
+            Exercises = source.Exercises.Select(CloneExercise).ToList(),
+            Workouts = source.Workouts.Select(CloneWorkout).ToList()
+        };
+    }
+
+    private static ExerciseDefinition CloneExercise(ExerciseDefinition source)
+    {
+        return new ExerciseDefinition
+        {
+            Id = source.Id,
+            Name = source.Name,
+            Description = source.Description,
+            Execution = source.Execution.ToList(),
+            Duration = source.Duration,
+            ImageFile = source.ImageFile,
+            Level = source.Level,
+            SwitchLeftRight = source.SwitchLeftRight,
+            SwitchTime = source.SwitchTime,
+            Tags = source.Tags.ToList(),
+            ReadMore = source.ReadMore.Select(CloneReference).ToList(),
+            Source = source.Source,
+            OwnerUserId = source.OwnerUserId,
+            CreatedAt = source.CreatedAt,
+            UpdatedAt = source.UpdatedAt
+        };
+    }
+
+    private static WorkoutDefinition CloneWorkout(WorkoutDefinition source)
+    {
+        return new WorkoutDefinition
+        {
+            Id = source.Id,
+            Name = source.Name,
+            Description = source.Description,
+            Level = source.Level,
+            PreparationTime = source.PreparationTime,
+            RestTime = source.RestTime,
+            SwitchTime = source.SwitchTime,
+            Exercises = source.Exercises.ToList(),
+            Tags = source.Tags.ToList(),
+            ReadMore = source.ReadMore.Select(CloneReference).ToList(),
+            Source = source.Source,
+            OwnerUserId = source.OwnerUserId,
+            CreatedAt = source.CreatedAt,
+            UpdatedAt = source.UpdatedAt
+        };
+    }
+
+    private static ContentReference CloneReference(ContentReference source)
+    {
+        return new ContentReference
+        {
+            Title = source.Title,
+            Url = source.Url,
+            Description = source.Description,
+            SourceType = source.SourceType
+        };
+    }
+
+    private sealed class InMemoryWorkoutCatalogStore : IWorkoutCatalogStore
+    {
+        public InMemoryWorkoutCatalogStore(WorkoutCatalogDocument? storedCatalog)
+        {
+            StoredCatalog = storedCatalog is null ? null : CloneCatalog(storedCatalog);
+        }
+
+        public WorkoutCatalogDocument? StoredCatalog { get; private set; }
+        public int LoadCount { get; private set; }
+        public int SaveCount { get; private set; }
+
+        public Task<WorkoutCatalogDocument> LoadOrSeedAsync(WorkoutCatalogDocument seedCatalog)
+        {
+            LoadCount++;
+            StoredCatalog ??= CloneCatalog(seedCatalog);
+            return Task.FromResult(CloneCatalog(StoredCatalog));
+        }
+
+        public Task SaveAsync(WorkoutCatalogDocument catalog)
+        {
+            SaveCount++;
+            StoredCatalog = CloneCatalog(catalog);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/PaceLetics.TrainingModule.CodeBase/Workouts/Repositories/IWorkoutCatalogRepository.cs
+++ b/PaceLetics.TrainingModule.CodeBase/Workouts/Repositories/IWorkoutCatalogRepository.cs
@@ -7,4 +7,9 @@ namespace PaceLetics.TrainingModule.CodeBase.Workouts.Repositories
         WorkoutCatalogDocument Load();
         void Save(WorkoutCatalogDocument document);
     }
+
+    public interface IWorkoutCatalogValidator
+    {
+        void NormalizeAndValidate(WorkoutCatalogDocument document);
+    }
 }

--- a/PaceLetics.TrainingModule.CodeBase/Workouts/Repositories/JsonWorkoutCatalogRepository.cs
+++ b/PaceLetics.TrainingModule.CodeBase/Workouts/Repositories/JsonWorkoutCatalogRepository.cs
@@ -5,7 +5,7 @@ using PaceLetics.TrainingModule.CodeBase.Workouts.Models;
 
 namespace PaceLetics.TrainingModule.CodeBase.Workouts.Repositories
 {
-    public sealed class JsonWorkoutCatalogRepository : IWorkoutCatalogRepository
+    public sealed class JsonWorkoutCatalogRepository : IWorkoutCatalogRepository, IWorkoutCatalogValidator
     {
         private static readonly JsonSerializerOptions Options = new()
         {
@@ -37,8 +37,7 @@ namespace PaceLetics.TrainingModule.CodeBase.Workouts.Repositories
             var document = JsonSerializer.Deserialize<WorkoutCatalogDocument>(json, Options)
                 ?? throw new InvalidDataException($"Workout catalog '{_filePath}' is empty or invalid.");
 
-            Normalize(document);
-            Validate(document);
+            NormalizeAndValidate(document);
             return document;
         }
 
@@ -46,8 +45,7 @@ namespace PaceLetics.TrainingModule.CodeBase.Workouts.Repositories
         {
             ArgumentNullException.ThrowIfNull(document);
 
-            Normalize(document);
-            Validate(document);
+            NormalizeAndValidate(document);
 
             var directory = Path.GetDirectoryName(_filePath);
             if (!string.IsNullOrWhiteSpace(directory))
@@ -55,6 +53,14 @@ namespace PaceLetics.TrainingModule.CodeBase.Workouts.Repositories
 
             var json = JsonSerializer.Serialize(document, Options);
             File.WriteAllText(_filePath, json);
+        }
+
+        public void NormalizeAndValidate(WorkoutCatalogDocument document)
+        {
+            ArgumentNullException.ThrowIfNull(document);
+
+            Normalize(document);
+            Validate(document);
         }
 
         private static void Normalize(WorkoutCatalogDocument document)

--- a/PaceLetics.Web/Pages/Trainers/WorkoutCatalogManagement.razor
+++ b/PaceLetics.Web/Pages/Trainers/WorkoutCatalogManagement.razor
@@ -637,6 +637,19 @@
 
     protected override async Task OnInitializedAsync()
     {
+        try
+        {
+            await CatalogService.EnsureLoadedAsync();
+        }
+        catch (WorkoutCatalogValidationException ex)
+        {
+            Snackbar.Add(string.Join(" ", ex.Errors.Take(3)), Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         _trainerUserId = authState.User.FindFirstValue(ClaimTypes.NameIdentifier);
         EnsureSelection();

--- a/PaceLetics.Web/Program.cs
+++ b/PaceLetics.Web/Program.cs
@@ -76,7 +76,9 @@ var webRootPath = !string.IsNullOrWhiteSpace(builder.Environment.WebRootPath)
     ? builder.Environment.WebRootPath
     : Path.Combine(builder.Environment.ContentRootPath, "wwwroot");
 var workoutCatalogPath = Path.Combine(webRootPath, "data", "workouts", "catalog.de.json");
-builder.Services.AddSingleton<IWorkoutCatalogRepository>(new JsonWorkoutCatalogRepository(workoutCatalogPath));
+builder.Services.AddSingleton(new JsonWorkoutCatalogRepository(workoutCatalogPath));
+builder.Services.AddSingleton<IWorkoutCatalogRepository>(x => x.GetRequiredService<JsonWorkoutCatalogRepository>());
+builder.Services.AddSingleton<IWorkoutCatalogValidator>(x => x.GetRequiredService<JsonWorkoutCatalogRepository>());
 builder.Services.AddSingleton<WorkoutCatalogDocument>(x => x.GetRequiredService<IWorkoutCatalogRepository>().Load());
 builder.Services.AddSingleton<IExerciseCatalog>(x => new ExerciseCatalog(x.GetRequiredService<WorkoutCatalogDocument>().Exercises));
 builder.Services.AddSingleton<IExerciseFactory, ExerciseFactory>();
@@ -88,7 +90,9 @@ builder.Services.AddScoped<IWorkoutService, WorkoutService>();
 builder.Services.AddScoped<WorkoutAreaViewModel>();
 builder.Services.AddScoped<SelectDifficultyViewModel>();
 builder.Services.AddScoped<WorkoutRoomViewModel>();
+builder.Services.AddSingleton<IWorkoutCatalogStore, CosmosWorkoutCatalogStore>();
 builder.Services.AddSingleton<WorkoutCatalogManagementService>();
+builder.Services.AddHostedService<WorkoutCatalogStartupLoader>();
 builder.Services.AddSingleton<AthleteModelFactory>();
 builder.Services.AddSingleton(builder.Configuration.GetAthleteDataOptions());
 builder.Services.AddTransient<IDataAccess>(x => new DataAccess(nonSqlConnectionString));

--- a/PaceLetics.Web/Services/Workouts/CosmosWorkoutCatalogStore.cs
+++ b/PaceLetics.Web/Services/Workouts/CosmosWorkoutCatalogStore.cs
@@ -1,0 +1,70 @@
+using AthleteDataAccessLibrary;
+using AthleteDataAccessLibrary.Contracts;
+using PaceLetics.TrainingModule.CodeBase.Workouts.Models;
+
+namespace PaceLetics.Web.Services.Workouts;
+
+public sealed class CosmosWorkoutCatalogStore : IWorkoutCatalogStore
+{
+    private const string Locale = "de";
+
+    private readonly IDataAccess _db;
+    private readonly AthleteDataOptions _options;
+
+    public CosmosWorkoutCatalogStore(IDataAccess db, AthleteDataOptions options)
+    {
+        _db = db;
+        _options = options;
+        _options.Validate();
+    }
+
+    public async Task<WorkoutCatalogDocument> LoadOrSeedAsync(WorkoutCatalogDocument seedCatalog)
+    {
+        ArgumentNullException.ThrowIfNull(seedCatalog);
+
+        var document = await LoadDocumentAsync();
+        if (document is not null)
+        {
+            document.Normalize(Locale);
+            return document.Catalog;
+        }
+
+        var now = DateTime.UtcNow;
+        document = WorkoutCatalogStoreDocument.Create(Locale, seedCatalog, now);
+        await SaveDocumentAsync(document);
+        return document.Catalog;
+    }
+
+    public async Task SaveAsync(WorkoutCatalogDocument catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+
+        var now = DateTime.UtcNow;
+        var existing = await LoadDocumentAsync();
+        var document = WorkoutCatalogStoreDocument.Create(Locale, catalog, now);
+        document.CreatedAt = existing?.CreatedAt ?? now;
+        document.UpdatedAt = now;
+
+        await SaveDocumentAsync(document);
+    }
+
+    private Task<WorkoutCatalogStoreDocument?> LoadDocumentAsync()
+    {
+        return _db.LoadItem<WorkoutCatalogStoreDocument>(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            WorkoutCatalogStoreDocumentIds.Catalog(Locale),
+            WorkoutCatalogStoreDocumentIds.Partition(Locale));
+    }
+
+    private Task SaveDocumentAsync(WorkoutCatalogStoreDocument document)
+    {
+        document.Normalize(Locale);
+
+        return _db.UpsertItem(
+            _options.DatabaseName,
+            _options.CourseContainerName,
+            document,
+            document.CourseId);
+    }
+}

--- a/PaceLetics.Web/Services/Workouts/IWorkoutCatalogStore.cs
+++ b/PaceLetics.Web/Services/Workouts/IWorkoutCatalogStore.cs
@@ -1,0 +1,9 @@
+using PaceLetics.TrainingModule.CodeBase.Workouts.Models;
+
+namespace PaceLetics.Web.Services.Workouts;
+
+public interface IWorkoutCatalogStore
+{
+    Task<WorkoutCatalogDocument> LoadOrSeedAsync(WorkoutCatalogDocument seedCatalog);
+    Task SaveAsync(WorkoutCatalogDocument catalog);
+}

--- a/PaceLetics.Web/Services/Workouts/WorkoutCatalogManagementService.cs
+++ b/PaceLetics.Web/Services/Workouts/WorkoutCatalogManagementService.cs
@@ -7,25 +7,50 @@ namespace PaceLetics.Web.Services.Workouts;
 
 public sealed class WorkoutCatalogManagementService
 {
-    private readonly IWorkoutCatalogRepository _repository;
+    private readonly IWorkoutCatalogStore _store;
+    private readonly IWorkoutCatalogValidator _validator;
     private readonly WorkoutCatalogDocument _catalog;
-    private readonly object _gate = new();
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _isLoaded;
 
     public WorkoutCatalogManagementService(
-        IWorkoutCatalogRepository repository,
+        IWorkoutCatalogStore store,
+        IWorkoutCatalogValidator validator,
         WorkoutCatalogDocument catalog)
     {
-        _repository = repository;
+        _store = store;
+        _validator = validator;
         _catalog = catalog;
     }
 
     public WorkoutCatalogDocument Catalog => _catalog;
 
-    public Task UpsertExerciseAsync(ExerciseDefinition exercise, string? trainerUserId)
+    public async Task EnsureLoadedAsync()
+    {
+        await _gate.WaitAsync();
+        try
+        {
+            if (_isLoaded)
+                return;
+
+            var loadedCatalog = await _store.LoadOrSeedAsync(CloneCatalog(_catalog));
+            _validator.NormalizeAndValidate(loadedCatalog);
+            Apply(loadedCatalog);
+            _isLoaded = true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task UpsertExerciseAsync(ExerciseDefinition exercise, string? trainerUserId)
     {
         ArgumentNullException.ThrowIfNull(exercise);
 
-        lock (_gate)
+        await EnsureLoadedAsync();
+        await _gate.WaitAsync();
+        try
         {
             var candidate = CloneCatalog(_catalog);
             var now = DateTime.UtcNow;
@@ -55,17 +80,21 @@ public sealed class WorkoutCatalogManagementService
                 candidate.Exercises.Add(normalized);
             }
 
-            SaveAndApply(candidate);
+            await SaveAndApplyAsync(candidate);
         }
-
-        return Task.CompletedTask;
+        finally
+        {
+            _gate.Release();
+        }
     }
 
-    public Task UpsertWorkoutAsync(WorkoutDefinition workout, string? trainerUserId)
+    public async Task UpsertWorkoutAsync(WorkoutDefinition workout, string? trainerUserId)
     {
         ArgumentNullException.ThrowIfNull(workout);
 
-        lock (_gate)
+        await EnsureLoadedAsync();
+        await _gate.WaitAsync();
+        try
         {
             var candidate = CloneCatalog(_catalog);
             var now = DateTime.UtcNow;
@@ -93,16 +122,24 @@ public sealed class WorkoutCatalogManagementService
                 candidate.Workouts.Add(normalized);
             }
 
-            SaveAndApply(candidate);
+            await SaveAndApplyAsync(candidate);
         }
-
-        return Task.CompletedTask;
+        finally
+        {
+            _gate.Release();
+        }
     }
 
-    private void SaveAndApply(WorkoutCatalogDocument candidate)
+    private async Task SaveAndApplyAsync(WorkoutCatalogDocument candidate)
     {
-        _repository.Save(candidate);
+        _validator.NormalizeAndValidate(candidate);
+        await _store.SaveAsync(candidate);
+        Apply(candidate);
+        _isLoaded = true;
+    }
 
+    private void Apply(WorkoutCatalogDocument candidate)
+    {
         _catalog.SchemaVersion = candidate.SchemaVersion;
         Replace(_catalog.Exercises, candidate.Exercises);
         Replace(_catalog.Workouts, candidate.Workouts);

--- a/PaceLetics.Web/Services/Workouts/WorkoutCatalogStartupLoader.cs
+++ b/PaceLetics.Web/Services/Workouts/WorkoutCatalogStartupLoader.cs
@@ -1,0 +1,40 @@
+namespace PaceLetics.Web.Services.Workouts;
+
+public sealed class WorkoutCatalogStartupLoader : IHostedService
+{
+    private readonly WorkoutCatalogManagementService _catalogService;
+    private readonly ILogger<WorkoutCatalogStartupLoader> _logger;
+
+    public WorkoutCatalogStartupLoader(
+        WorkoutCatalogManagementService catalogService,
+        ILogger<WorkoutCatalogStartupLoader> logger)
+    {
+        _catalogService = catalogService;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _ = LoadCatalogAsync();
+        return Task.CompletedTask;
+    }
+
+    private async Task LoadCatalogAsync()
+    {
+        try
+        {
+            await _catalogService.EnsureLoadedAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not load the persisted workout catalog. Continuing with the JSON seed catalog.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/PaceLetics.Web/Services/Workouts/WorkoutCatalogStoreDocument.cs
+++ b/PaceLetics.Web/Services/Workouts/WorkoutCatalogStoreDocument.cs
@@ -1,0 +1,60 @@
+using PaceLetics.CoreModule.Infrastructure.Interfaces;
+using PaceLetics.TrainingModule.CodeBase.Workouts.Models;
+
+namespace PaceLetics.Web.Services.Workouts;
+
+public static class WorkoutCatalogStoreDocumentTypes
+{
+    public const string Catalog = "workoutCatalog";
+}
+
+public sealed class WorkoutCatalogStoreDocument : IQueryItem
+{
+    public string Id { get; set; } = WorkoutCatalogStoreDocumentIds.Catalog("de");
+    public string CourseId { get; set; } = WorkoutCatalogStoreDocumentIds.Partition("de");
+    public string DocumentType { get; set; } = WorkoutCatalogStoreDocumentTypes.Catalog;
+    public string Locale { get; set; } = "de";
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    public WorkoutCatalogDocument Catalog { get; set; } = new();
+
+    public void Normalize(string locale)
+    {
+        locale = string.IsNullOrWhiteSpace(locale) ? "de" : locale.Trim().ToLowerInvariant();
+        Id = WorkoutCatalogStoreDocumentIds.Catalog(locale);
+        CourseId = WorkoutCatalogStoreDocumentIds.Partition(locale);
+        DocumentType = WorkoutCatalogStoreDocumentTypes.Catalog;
+        Locale = locale;
+        Catalog ??= new WorkoutCatalogDocument();
+    }
+
+    public static WorkoutCatalogStoreDocument Create(string locale, WorkoutCatalogDocument catalog, DateTime now)
+    {
+        var document = new WorkoutCatalogStoreDocument
+        {
+            Catalog = catalog,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        document.Normalize(locale);
+        return document;
+    }
+}
+
+public static class WorkoutCatalogStoreDocumentIds
+{
+    public static string Catalog(string locale)
+    {
+        return $"workout-catalog:{NormalizeLocale(locale)}";
+    }
+
+    public static string Partition(string locale)
+    {
+        return Catalog(locale);
+    }
+
+    private static string NormalizeLocale(string locale)
+    {
+        return string.IsNullOrWhiteSpace(locale) ? "de" : locale.Trim().ToLowerInvariant();
+    }
+}


### PR DESCRIPTION
## Summary
- store trainer-authored workout catalog updates in Cosmos using a dedicated workout catalog document
- keep the JSON catalog as seed/fallback and reusable validator
- load persisted catalog into the live singleton catalog and keep trainer UI resilient when loading fails

## Verification
- git diff --check
- dotnet test PaceLetics.Tests\PaceLetics.Tests.csproj --no-restore -p:BaseOutputPath="$env:TEMP\paceletics-codex-test-bin\"
- dotnet build PaceLetics.Web\PaceLetics.Web.csproj --no-restore
- local HTTP check: /css/app-theme.css => 200, /Trainers/workout-catalog => 302
